### PR TITLE
feat(tokens): add amber color and fix Storybook glob

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,9 +3,7 @@ import { dirname, join } from "path";
 /** @type { import('@storybook/react-vite').StorybookConfig } */
 const config = {
   stories: [
-    "../src/components/Alert/**/*.stories.@(js|jsx|ts|tsx)",
-    "../src/components/Icon/**/*.stories.@(js|jsx|ts|tsx)",
-    "../src/components/Accordion/**/*.stories.@(js|jsx|ts|tsx)"
+    "../src/components/**/*.stories.@(js|jsx|ts|tsx)"
   ],
   addons: [
     "@storybook/addon-links",

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -20,6 +20,7 @@
   --color-cga-green: #00AA00;
   --color-cga-blue: #0000AA;
   --color-cga-black: #000000;
+  --color-cga-amber: #FFBF00;
   --color-text-accent: var(--color-cga-yellow);
   --color-text-secondary: var(--color-cga-white);
   --color-text-primary: var(--color-cga-lightgray);

--- a/src/tokens/colors.json
+++ b/src/tokens/colors.json
@@ -16,7 +16,8 @@
       "brightRed": { "value": "#FF5555" },
       "brightMagenta": { "value": "#FF55FF" },
       "yellow": { "value": "#FFFF55" },
-      "white": { "value": "#FFFFFF" }
+      "white": { "value": "#FFFFFF" },
+      "amber": { "value": "#FFBF00" }
     },
     "background": {
       "primary": { "value": "{color.cga.blue.value}" },

--- a/src/tokens/tokens.json
+++ b/src/tokens/tokens.json
@@ -2157,7 +2157,7 @@
       "Numbers/Mode 1",
       "Component Size/Mode 1"
     ]
-  }
+  },
 
   "global/global": {
     "colors": {
@@ -4118,5 +4118,4 @@
       "Numbers/Mode 1"
     ]
   }
->>>>>>> 3b16c7e (Initial setup of design system with Storybook and core components)
 }


### PR DESCRIPTION
## Summary

- Add CGA amber token (`#FFBF00`) for EatThisDie compatibility
- Simplify Storybook config to use single glob pattern instead of manual component paths
- Fix JSON syntax errors in tokens.json (missing comma, merge conflict marker)

## Changes

| File | Change |
|------|--------|
| `src/tokens/colors.json` | +1 amber token |
| `.storybook/main.js` | Replace 3 manual paths with 1 glob |
| `src/styles/tokens.css` | +1 CSS variable |
| `src/tokens/tokens.json` | Fix JSON syntax |

## Testing

- ✅ `npm run build` succeeds
- ✅ `npm run test` - 53 tests pass
- ✅ `npm run build-storybook` - discovers all 8 component stories
- ✅ `grep amber tokens.css` - confirms `--color-cga-amber: #FFBF00`

## Verification

```bash
# Amber token exists
grep amber src/styles/tokens.css
# Output: --color-cga-amber: #FFBF00;

# Storybook finds all stories (8 components)
npm run build-storybook 2>&1 | grep ".stories"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)