### PR TITLE
docs: update README and CLAUDE.md for Header + font upgrade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,8 @@ border-color: rgba(255, 255, 255, 0.1);
 | Loading state | `<Progress>` |
 | Collapsible section | `<Section>` (Accordion) |
 | Navigation path | `<Breadcrumb>` |
+| Site header | `<Header>` |
+| Site footer | `<Footer>` |
 | Timeline marker | `<TimelineNode>` |
 | Multi-zoom timeline | `<TimelineContainer>` |
 | Inline text expansion | `<InlineExpand>` |
@@ -244,6 +246,10 @@ eiDotter uses Untitled UI as a **reference resource**, not a runtime component l
 **Tailwind CSS build (v0.16.1):** Tailwind v3 processes component utility classes via `postcss.config.cjs` + `tailwind.config.cjs`. The compiled `dist/eidotter.css` includes all Tailwind utilities — consumers do NOT need Tailwind installed to use components. Two presets are exported: `tailwind.preset` (base tokens) and `tailwind.preset.enhanced` (adds React Aria state variants + animate plugin).
 
 **Icons (v0.18.0):** Backed by `@untitledui-pro/icons` (4600+ icons, 4 styles: line/solid/duocolor/duotone). The `<Icon>` component wraps UTI Pro icons via an internal mapping — consumers use `<Icon name="Warning" size="S" />` unchanged. Available names: Info, Warning, Error, Done, Check, Close, Chevron Up, Chevron Down, App, Cancel, Fullscreen, Add. The old SVG spritesheet has been removed. Auth token for private registry stored in `~/.npmrc` (never committed); CI uses `UNTITLEDUI_PRO_TOKEN` GitHub secret.
+
+**Header (PR #246):** Sticky site header composing branding link + Nav. Props: `brandName`, `brandHref`, `items`, `variant` (retro/modern), `sticky`, `linkComponent`, `children` (custom branding). Uses `forwardRef`. Retro variant has amber phosphor glow on border-bottom.
+
+**Font (PR #246):** Upgraded from Flexi IBM VGA False v1 to Flexi IBM VGA True v2 — aspect-corrected for 4:3 VGA, redrawn glyphs, extended character set. Typography tokens renamed from `xs/sm/base/lg` to `text-xs` through `display-2xl` to match Figma V.37.
 
 **Chat components** (`src/components/Chat/`): Pure presentational — no AI SDK dependency. Consumers wire up `useChat` or any chat state. Compose inside `<Terminal>` for full DOS window experience.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ import 'eidotter/tokens.css';  // CSS variable definitions
 import 'eidotter/themes/amber-mono.css';
 ```
 
-**Font:** eiDotter uses [Flexi IBM VGA True](https://int10h.org/blog/2018/05/flexi-ibm-vga-scalable-truetype-font/) — a vector remake of the IBM VGA BIOS font (CC BY-SA 4.0). It scales cleanly at any size. The `fonts.css` import loads the bundled TTF via `@font-face`. No fallback fonts are configured so you'll immediately see if the font isn't loading.
+**Font:** eiDotter uses [Flexi IBM VGA True v2](https://int10h.org/blog/2018/05/flexi-ibm-vga-scalable-truetype-font/) — an aspect-corrected vector remake of the IBM VGA BIOS font (CC BY-SA 4.0). The "True" variant matches authentic 4:3 VGA proportions with an extended character set (Greek, Cyrillic, Hebrew, Latin). The `fonts.css` import loads the bundled TTF via `@font-face`. No fallback fonts are configured so you'll immediately see if the font isn't loading.
 
 ### With Tailwind CSS
 
@@ -74,7 +74,7 @@ For React Aria state variants and animations, use the enhanced preset:
 presets: [require('eidotter/tailwind.preset.enhanced')],
 ```
 
-## Available Components (v0.18.0)
+## Available Components (33)
 
 | Component | Description |
 |-----------|-------------|
@@ -92,6 +92,7 @@ presets: [require('eidotter/tailwind.preset.enhanced')],
 | CommandPrompt | Interactive command-line input with blinking cursor |
 | FilterBar | Multi-select toggle group for faceted filtering |
 | Footer | Site footer with legal links (Impressum + Datenschutz) |
+| Header | Sticky site header composing branding + Nav — retro/modern variants |
 | Icon | SVG icons backed by @untitledui/icons |
 | InlineExpand | Inline disclosure widget for expanding text within prose |
 | Input | Text input with DOS styling and error variant |
@@ -112,6 +113,14 @@ presets: [require('eidotter/tailwind.preset.enhanced')],
 | Tokens | Design token reference display (Storybook only) |
 
 ## Component Examples
+
+### Header
+
+```tsx
+<Header brandName="DMNC.TECH" items={navItems} variant="retro">
+  {/* or use children for custom branding */}
+</Header>
+```
 
 ### Terminal
 


### PR DESCRIPTION
## Summary
- Add Header component to README component table and examples section
- Update font description to Flexi IBM VGA True v2 (aspect-corrected, extended charset)
- Update Tailwind typography quick reference to new class names (`text-dos-text-xs` through `text-dos-display-2xl`)
- Add Header to CLAUDE.md component selection table, status section, and document font/token changes

Follow-up to PR #246.

## Test plan
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)