### PR TITLE
fix(storybook): load Flexi IBM VGA True font in preview iframe

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,15 +1,4 @@
-<!-- Load Flexi IBM VGA True v2 font (self-hosted, CC BY-SA 4.0) -->
-<style>
-  @font-face {
-    font-family: 'Flexi IBM VGA True';
-    font-style: normal;
-    font-weight: 400;
-    font-display: swap;
-    src: url('../src/styles/fonts/Flexi_IBM_VGA_True.ttf') format('truetype');
-  }
-</style>
-
-<!-- Apply official amber-mono theme to document root (tokens loaded via preview.ts) -->
+<!-- Apply official amber-mono theme to document root (tokens and @font-face loaded via preview.ts) -->
 <script>
   document.documentElement.setAttribute('data-theme', 'amber-mono');
 </script>

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import type { Preview } from "@storybook/react-vite";
 import { MINIMAL_VIEWPORTS } from 'storybook/viewport';
 import React from 'react';
+import '../src/styles/fonts.css';                // @font-face for Flexi IBM VGA True (must be first)
 import '../src/styles/tailwind.css';             // Tailwind utilities (must precede tokens)
 import '../src/styles/tokens.css';              // Base design tokens (amber mono default)
 import '../src/styles/accessibility.css';       // Global reduced-motion safety net


### PR DESCRIPTION
## Summary
- Font file was never loading in Storybook — components fell back to system monospace.
- `preview-head.html` had an inline `@font-face` with a relative path (`../src/styles/fonts/...`) that 404'd inside the preview iframe.
- `src/styles/fonts.css` already has the correct `@font-face` but was only imported from `src/index.ts` (library entry), never reached by Storybook's preview.
- Import `fonts.css` from `.storybook/preview.ts` so Vite bundles the `.ttf` and registers `@font-face` in the iframe; remove the broken inline block from `preview-head.html`.

## Test plan
- [ ] `npm run storybook` — open Button/Alert/Header stories and confirm text renders in pixel VGA face (not system monospace)
- [ ] DevTools → Network → Font filter shows `Flexi_IBM_VGA_True.ttf` loading with 200
- [ ] `npm run build-storybook` — static build also loads font correctly
- [ ] After merge, GitHub Pages deploy completes and https://cinimody.github.io/eiDotter/ shows correct font

🤖 Generated with [Claude Code](https://claude.com/claude-code)