### PR TITLE
fix(fonts): make bold/semibold use same bitmap face (Button inconsistency)

### DIFF
--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,8 +1,15 @@
 /* Flexi IBM VGA True v2 — vector remake of IBM VGA BIOS font, aspect-corrected (CC BY-SA 4.0, VileR/int10h.org) */
+/*
+ * Bitmap/pixel font — single weight only. We declare the range 100 900 so every
+ * `font-weight` request (including bold/semibold on Button, Card, Notification)
+ * resolves to this same face instead of falling back to system monospace.
+ * `font-synthesis: none` prevents browsers from faking bold/italic on top.
+ */
 @font-face {
   font-family: 'Flexi IBM VGA True';
   font-style: normal;
-  font-weight: 400;
+  font-weight: 100 900;
   font-display: swap;
+  font-synthesis: none;
   src: url('./fonts/Flexi_IBM_VGA_True.ttf') format('truetype');
 }


### PR DESCRIPTION
## Summary

Button, Card title, and Notification title looked wrong in a different font than the rest of the library. Root cause:

- **body** sets `font-family: 'Flexi IBM VGA True'` with default weight 400 → most components inherit correctly.
- **Button** uses `font-dos font-dos-bold` → requests weight 700.
- **Card title** uses `font-dos-bold`. **Notification title** uses `font-dos-semibold` (600).
- `fonts.css` declared only one `@font-face` at `font-weight: 400`, so the browser couldn't match 600/700 and fell back to system monospace (or synthesized fake bold).

Flexi IBM VGA True is a single-weight bitmap font — there is no bold variant, and authentic DOS had none either.

**Fix:** declare the `@font-face` with `font-weight: 100 900` so any weight request resolves to the same bitmap face. Add `font-synthesis: none` so browsers don't fake bold on top.

## Test plan
- [ ] `npm run storybook` — Button, Card title, Notification title render in the same pixel VGA face as Alert/Tag/Input
- [ ] DevTools → Computed → `font-family` resolves to `"Flexi IBM VGA True"` on all three
- [ ] No system monospace ("Courier") appears anywhere
- [ ] Consumers (rizomorf, mgnt) that import `eidotter/fonts.css` get the same fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)