### PR TITLE
fix(tokens): replace hardcoded font-size pixels with V.37 dos tokens

### DIFF
--- a/src/components/Badge/components/Badge.tsx
+++ b/src/components/Badge/components/Badge.tsx
@@ -19,11 +19,11 @@ export interface BadgeProps {
 }
 
 const sizeClasses: Record<string, string> = {
-  sm: 'text-[10px] px-1.5 py-0.5 min-h-[18px] gap-1',
-  md: 'text-[12px] px-2 py-1 min-h-[22px] gap-1.5',
-  lg: 'text-[14px] px-2.5 py-1 min-h-[26px] gap-1.5',
-  small: 'text-[10px] px-1.5 py-0.5 min-h-[18px] gap-1',
-  medium: 'text-[12px] px-2 py-1 min-h-[22px] gap-1.5',
+  sm: 'text-dos-text-xs px-2 py-0.5 min-h-6 gap-1',
+  md: 'text-dos-text-sm px-2.5 py-1 min-h-7 gap-1.5',
+  lg: 'text-dos-text-md px-3 py-1.5 min-h-8 gap-1.5',
+  small: 'text-dos-text-xs px-2 py-0.5 min-h-6 gap-1',
+  medium: 'text-dos-text-sm px-2.5 py-1 min-h-7 gap-1.5',
 };
 
 const variantClasses: Record<string, string> = {

--- a/src/components/Button/components/Button.tsx
+++ b/src/components/Button/components/Button.tsx
@@ -23,14 +23,14 @@ export interface ButtonProps {
 }
 
 const sizeClasses: Record<string, string> = {
-  xs: 'text-[12px] px-2 py-1 min-h-6 gap-1',
-  sm: 'text-[14px] px-2 py-1 min-h-7 gap-1',
-  md: 'text-[14px] px-3 py-2 min-h-8 gap-1.5',
-  lg: 'text-[16px] px-4 py-2.5 min-h-10 gap-1.5',
-  xl: 'text-[16px] px-5 py-3 min-h-11 gap-2',
-  small: 'text-[14px] px-2 py-1 min-h-6 gap-1',
-  medium: 'text-[14px] px-3 py-2 min-h-8 gap-1.5',
-  large: 'text-[16px] px-4 py-2.5 min-h-10 gap-1.5',
+  xs: 'text-dos-text-xs px-2 py-1 min-h-6 gap-1',
+  sm: 'text-dos-text-sm px-2.5 py-1 min-h-7 gap-1',
+  md: 'text-dos-text-md px-3 py-2 min-h-8 gap-1.5',
+  lg: 'text-dos-text-lg px-4 py-2.5 min-h-10 gap-2',
+  xl: 'text-dos-text-xl px-5 py-3 min-h-11 gap-2',
+  small: 'text-dos-text-sm px-2.5 py-1 min-h-7 gap-1',
+  medium: 'text-dos-text-md px-3 py-2 min-h-8 gap-1.5',
+  large: 'text-dos-text-lg px-4 py-2.5 min-h-10 gap-2',
 };
 
 const variantClasses: Record<string, string> = {

--- a/src/components/Checkbox/components/Checkbox.tsx
+++ b/src/components/Checkbox/components/Checkbox.tsx
@@ -60,7 +60,7 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(({
     className={cn(
       'inline-flex items-center gap-2 cursor-pointer select-none group',
       'font-dos',
-      size === 'sm' ? 'text-[14px]' : 'text-[16px]',
+      size === 'sm' ? 'text-dos-text-xs' : 'text-dos-text-sm',
       'eidotter-checkbox',
       disabled && 'opacity-60 cursor-not-allowed',
       className,

--- a/src/components/FilterBar/components/FilterBar.css
+++ b/src/components/FilterBar/components/FilterBar.css
@@ -98,32 +98,39 @@
 
 /* Sizes */
 .eidotter-filter-bar--sm .eidotter-filter-bar__item {
-  font-size: var(--typography-font-size-text-xs, 10px);
-  padding: 2px 6px;
+  font-size: var(--typography-font-size-text-xs, 1.125rem);
+  padding: 2px 8px;
 }
 
 .eidotter-filter-bar--sm .eidotter-filter-bar__count {
-  min-width: 14px;
-  height: 14px;
-  font-size: 9px;
-  padding: 0 3px;
+  min-width: 24px;
+  height: 24px;
+  font-size: var(--typography-font-size-text-xs, 1.125rem);
+  padding: 0 4px;
 }
 
 .eidotter-filter-bar--md .eidotter-filter-bar__item {
-  font-size: var(--typography-font-size-text-xs, 12px);
+  font-size: var(--typography-font-size-text-sm, 1.25rem);
   padding: 6px 12px;
 }
 
+.eidotter-filter-bar--md .eidotter-filter-bar__count {
+  min-width: 26px;
+  height: 26px;
+  font-size: var(--typography-font-size-text-sm, 1.25rem);
+  padding: 0 5px;
+}
+
 .eidotter-filter-bar--lg .eidotter-filter-bar__item {
-  font-size: var(--typography-font-size-text-sm, 14px);
+  font-size: var(--typography-font-size-text-md, 1.375rem);
   padding: 8px 16px;
 }
 
 .eidotter-filter-bar--lg .eidotter-filter-bar__count {
-  min-width: 18px;
-  height: 18px;
-  font-size: var(--typography-font-size-text-xs, 10px);
-  padding: 0 5px;
+  min-width: 28px;
+  height: 28px;
+  font-size: var(--typography-font-size-text-sm, 1.25rem);
+  padding: 0 6px;
 }
 
 /* Focus styles for accessibility */

--- a/src/components/Nav/components/Nav.css
+++ b/src/components/Nav/components/Nav.css
@@ -65,7 +65,7 @@
   border: none;
   padding: var(--spacing-1, 0.25rem);
   cursor: pointer;
-  font-size: 1.5rem;
+  font-size: var(--typography-font-size-text-lg, 1.5rem);
   line-height: 1;
 }
 
@@ -117,7 +117,7 @@
   border: none;
   padding: var(--spacing-1, 0.25rem);
   cursor: pointer;
-  font-size: 1.5rem;
+  font-size: var(--typography-font-size-text-lg, 1.5rem);
   line-height: 1;
 }
 

--- a/src/components/Stat/components/Stat.tsx
+++ b/src/components/Stat/components/Stat.tsx
@@ -21,12 +21,12 @@ export interface StatProps {
 }
 
 const sizeClasses: Record<string, { root: string; label: string; value: string; trend: string }> = {
-  sm:     { root: 'gap-0.5', label: 'text-[10px]', value: 'text-lg',  trend: 'text-[10px]' },
-  md:     { root: 'gap-1',   label: 'text-[10px]', value: 'text-2xl', trend: 'text-[10px]' },
-  lg:     { root: 'gap-1.5', label: 'text-xs',     value: 'text-4xl', trend: 'text-xs' },
-  small:  { root: 'gap-0.5', label: 'text-[10px]', value: 'text-lg',  trend: 'text-[10px]' },
-  medium: { root: 'gap-1',   label: 'text-[10px]', value: 'text-2xl', trend: 'text-[10px]' },
-  large:  { root: 'gap-1.5', label: 'text-xs',     value: 'text-4xl', trend: 'text-xs' },
+  sm:     { root: 'gap-0.5', label: 'text-dos-text-xs', value: 'text-dos-display-xs', trend: 'text-dos-text-xs' },
+  md:     { root: 'gap-1',   label: 'text-dos-text-sm', value: 'text-dos-display-sm', trend: 'text-dos-text-sm' },
+  lg:     { root: 'gap-1.5', label: 'text-dos-text-md', value: 'text-dos-display-md', trend: 'text-dos-text-md' },
+  small:  { root: 'gap-0.5', label: 'text-dos-text-xs', value: 'text-dos-display-xs', trend: 'text-dos-text-xs' },
+  medium: { root: 'gap-1',   label: 'text-dos-text-sm', value: 'text-dos-display-sm', trend: 'text-dos-text-sm' },
+  large:  { root: 'gap-1.5', label: 'text-dos-text-md', value: 'text-dos-display-md', trend: 'text-dos-text-md' },
 };
 
 const trendColorClasses: Record<string, string> = {

--- a/src/components/Tag/components/Tag.tsx
+++ b/src/components/Tag/components/Tag.tsx
@@ -30,11 +30,11 @@ export interface TagProps {
 }
 
 const sizeClasses: Record<string, string> = {
-  sm: 'text-[10px] px-1.5 py-0.5 min-h-[18px] gap-1',
-  md: 'text-[12px] px-2 py-1 min-h-[22px] gap-1.5',
-  lg: 'text-[14px] px-2.5 py-1 min-h-[26px] gap-1.5',
-  small: 'text-[10px] px-1.5 py-0.5 min-h-[18px] gap-1',
-  medium: 'text-[12px] px-2 py-1 min-h-[22px] gap-1.5',
+  sm: 'text-dos-text-xs px-2 py-0.5 min-h-6 gap-1',
+  md: 'text-dos-text-sm px-2.5 py-1 min-h-7 gap-1.5',
+  lg: 'text-dos-text-md px-3 py-1.5 min-h-8 gap-1.5',
+  small: 'text-dos-text-xs px-2 py-0.5 min-h-6 gap-1',
+  medium: 'text-dos-text-sm px-2.5 py-1 min-h-7 gap-1.5',
 };
 
 /**


### PR DESCRIPTION
## Summary

- Seven components violated CLAUDE.md's "no hardcoded `font-size: Npx`" rule, rendering Flexi IBM VGA True at 9–16px — below the font's minimum legible size.
- The bitmap 'A' glyph loses most of its ink mass under ~18px, making it appear "lighter" / smaller than peers like M and H. We measured 34 ink pixels for A at 14px vs 49 for M at the same size — ~30% less visual mass.
- Mapped every hardcoded size to the V.37 dos token scale (`text-xs` 18px → `text-xl` 26px, `display-xs` 30px → `display-2xl` 78px).

## Why the font appeared too small

At 14px Button default, Flexi IBM VGA True renders each uppercase letter in a ~5×9 pixel cell. That's enough for rectangular letters (M, H, N fill the cell) but not for triangular glyphs like A whose apex tapers to a 1-pixel point. Bumping to 18–22px gives A **2.4× more ink pixels** (34 → 82) and reads correctly.

## Changes

**Components (7):**
- **Button**: `xs→text-xs (18)`, `sm→text-sm (20)`, `md→text-md (22)` [default], `lg→text-lg (24)`, `xl→text-xl (26)` — a clean 1-to-1 V.37 mapping
- **Badge / Tag**: `sm→text-xs`, `md→text-sm`, `lg→text-md`; min-heights bumped to `min-h-6/7/8`; padding adjusted to fit new glyph mass
- **Stat**: label/trend → `text-xs/sm/md`; value → `display-xs/sm/md` (30/36/42px) — preserves the original label:value visual hierarchy at the new scale
- **Checkbox**: `sm→text-xs (18)`, `md→text-sm (20)`
- **Nav.css** hamburger: `1.5rem` → `var(--typography-font-size-text-lg, 1.5rem)` (exact 24px match, just token-ized)
- **FilterBar.css**: items use `text-xs/sm/md` tokens directly; the count bubble grew from 14×14 / 9px font to 24–28 × 24–28 / 18–20px font for legibility

**No prop API changes.** Deprecated `small`/`medium`/`large` size aliases remap alongside their `sm`/`md`/`lg` equivalents.

## Before / After (MD default size)

| Element | Before | After | Change |
|---|---|---|---|
| Button MD text | 14px | 22px | +57% |
| Badge MD text | 12px | 20px | +67% |
| Tag MD text | 12px | 20px | +67% |
| Stat label MD | 10px | 20px | +100% |
| Stat value MD | 24px (Tailwind default `text-2xl`) | 36px (`display-sm`) | +50% |
| Checkbox MD text | 16px | 20px | +25% |
| Nav hamburger | 1.5rem (24px) | 1.5rem (24px) | same, now token-referenced |
| FilterBar count | 9px in 14×14 | 18–20px in 24–28 | +100% + container grown |

## Test plan

- [x] `npm run lint` — same 4 pre-existing errors / 4 warnings as `main`, no new errors introduced
- [x] `npm run test` — 792/792 passing
- [x] `npm run build` — `dist/eidotter.css` builds (422.82 kB)
- [x] Visual verification in Storybook for Button, Badge, Tag, Stat, Checkbox, FilterBar — all render with proper DOS bitmap glyph mass at every size
- [ ] Downstream visual check in rizomorf / lifelines / steuerdash once merged — badges will grow physically, tight layouts may need reflow

## Depends on

#250 — this PR uses the `text-dos-text-*` / `text-dos-display-*` Tailwind utilities regenerated from the V.37 tokens in that PR's `tailwind.preset.js`. Merging this PR first would fail because those utility classes don't exist on `main` yet. Base is set to `refactor/single-font-weight` so GitHub tracks the dependency; retarget to `main` once #250 merges.

## Breaking changes for consumers

Consumer apps using `<Badge>`, `<Tag>`, `<Button>`, `<Stat>`, `<Checkbox>`, `<Nav>`, or `<FilterBar>` will see text physically grow 25–100% at the same size prop. Tight layouts (sidebars, dense tables) may overflow. Recommend a coordinated visual audit after merge — no API changes but real layout shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)