### PR TITLE
fix(icons): custom pixel-art X mark for Close icon

### DIFF
--- a/src/components/Icon/components/Icon.tsx
+++ b/src/components/Icon/components/Icon.tsx
@@ -3,7 +3,6 @@ import { InfoBox } from 'pixelarticons/react/InfoBox';
 import { WarningDiamond } from 'pixelarticons/react/WarningDiamond';
 import { SquareAlert } from 'pixelarticons/react/SquareAlert';
 import { Check } from 'pixelarticons/react/Check';
-import { Cancel } from 'pixelarticons/react/Cancel';
 import { ChevronUp } from 'pixelarticons/react/ChevronUp';
 import { ChevronDown } from 'pixelarticons/react/ChevronDown';
 import { WindowFrame } from 'pixelarticons/react/WindowFrame';
@@ -15,14 +14,25 @@ import './Icon.css';
 
 type PixelIcon = FC<React.SVGProps<SVGSVGElement>>;
 
+/**
+ * Custom pixel-art X mark — pixelarticons v2 has no standalone close/X glyph.
+ * Matches pixelarticons' style: 24×24 viewBox, fill-based single path,
+ * currentColor inheritance, 2×2 unit "pixels" on the grid.
+ */
+const PixelX: PixelIcon = (props) => (
+  <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path d="M5 5h2v2H5zM7 7h2v2H7zM9 9h2v2H9zM11 11h2v2h-2zM13 13h2v2h-2zM15 15h2v2h-2zM17 17h2v2h-2zM17 5h2v2h-2zM15 7h2v2h-2zM13 9h2v2h-2zM9 13h2v2H9zM7 15h2v2H7zM5 17h2v2H5z" />
+  </svg>
+);
+
 // 12 public icon names mapping to 11 unique pixelarticons components.
 // Done and Check both map to the Check component intentionally — consumers
 // can use either semantic name for a checkmark glyph.
 //
 // Non-obvious mappings:
-// - 'Close' → pixelarticons Cancel (slashed circle): pixelarticons v2 has no
-//   plain X/Close glyph; the slashed circle is the idiomatic DOS dismissal
-//   symbol in pixelarticons' design language.
+// - 'Close' → custom PixelX component: pixelarticons v2 has no standalone
+//   X/close glyph, so we draw a pixel-art X mark matching their style
+//   (24×24 viewBox, fill-based single path, 2×2 unit pixels).
 // - 'Cancel' → pixelarticons Minus: this name carries Terminal-window semantics
 //   (cancel/minimize control), rendered as a minus glyph matching DOS window
 //   chrome. A future release may rename this to 'Minimize' for clarity.
@@ -33,7 +43,7 @@ const ICON_MAP = {
   'Error':        SquareAlert,
   'Done':         Check,
   'Check':        Check,
-  'Close':        Cancel,         // slashed circle — pixelarticons has no X glyph
+  'Close':        PixelX,         // custom pixel-art X mark (pixelarticons has no X glyph)
   'Chevron Up':   ChevronUp,
   'Chevron Down': ChevronDown,
   'App':          WindowFrame,


### PR DESCRIPTION
## Summary

Replaces the pixelarticons `Cancel` (slashed circle) mapping for `<Icon name="Close" />` with a custom pixel-art X mark that matches pixelarticons' visual style.

pixelarticons v2 has no standalone X/close glyph. The Cancel component renders a "prohibited" symbol, not a "dismiss" action — flagged in the PR #257 review as a semantic mismatch.

## The PixelX component

~15 lines of code. Matches pixelarticons conventions:
- 24×24 viewBox
- Fill-based single `<path>` element
- `currentColor` inheritance
- 2×2 unit "pixels" on the grid
- `{...props}` spread for width/height/className passthrough

Two crossing diagonals spanning (5,5) to (19,19), 13 rect segments.

## Test plan

- [x] 18/18 Icon tests pass
- [x] Build clean (1390 modules, dist/index.es.js 386.01 kB)
- [x] Visually verified in Storybook Icon Grid — renders cleanly at L (56px) and S (24px)
- [x] Removed unused `Cancel` import (was only used by Close mapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)