### PR TITLE
fix(deps): bump vite 6.4.1 → 6.4.2 (security patches)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15823,9 +15823,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Bumps vite from 6.4.1 to 6.4.2 (within existing `^6.2.0` range)
- Fixes Dependabot alert #50 (high): arbitrary file read via dev server WebSocket
- Fixes Dependabot alert #51 (medium): path traversal in optimized deps `.map` handling

## Test plan
- [x] `npm run build` passes on vite 6.4.2
- [x] All 792 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)