### PR TITLE
fix(ui): scale featured icons to prevent ring overlap

### DIFF
--- a/src/components/Alert/components/Alert.css
+++ b/src/components/Alert/components/Alert.css
@@ -36,6 +36,11 @@
   align-self: flex-start;
 }
 
+.eidotter-alert__icon .icon__svg {
+  width: 20px !important;
+  height: 20px !important;
+}
+
 .eidotter-alert__icon::before,
 .eidotter-alert__icon::after {
   content: '';

--- a/src/components/Notification/components/Notification.css
+++ b/src/components/Notification/components/Notification.css
@@ -37,6 +37,11 @@
   align-self: flex-start;
 }
 
+.eidotter-notification__icon .icon__svg {
+  width: 20px !important;
+  height: 20px !important;
+}
+
 .eidotter-notification__icon::before,
 .eidotter-notification__icon::after {
   content: '';


### PR DESCRIPTION
## Summary
- Scale featured icon SVGs from 24px to 20px in Alert and Notification components
- The 24px icons had zero clearance inside the 28px inner ring (especially Notification with 2px borders)
- 20px gives 2–3px breathing room on each side

## Test plan
- [x] Alert and Notification tests pass (64/64)
- [ ] Storybook: verify icon sits comfortably inside rings across all color variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)