### PR TITLE
fix: make component backgrounds transparent by default

### DIFF
--- a/src/components/Accordion/components/Section.tsx
+++ b/src/components/Accordion/components/Section.tsx
@@ -46,7 +46,7 @@ export const Section: React.FC<SectionProps> = ({
   return (
     <div
       className={cn(
-        'w-full border border-dos-border-default bg-dos-bg-primary text-cga-amber font-dos',
+        'w-full border border-dos-border-default text-cga-amber font-dos',
         'eidotter-section',
         isExpanded && 'eidotter-section--expanded',
         isHovered && 'eidotter-section--hover',

--- a/src/components/Alert/components/Alert.test.tsx
+++ b/src/components/Alert/components/Alert.test.tsx
@@ -31,9 +31,9 @@ describe('Alert', () => {
       expect(screen.getByRole('alert')).toBeInTheDocument();
     });
 
-    it('has uniform dark background', () => {
+    it('has transparent background by default', () => {
       render(<Alert color="error" />);
-      expect(getAlert()).toHaveClass('bg-dos-bg-primary');
+      expect(getAlert()).not.toHaveClass('bg-dos-bg-primary');
     });
 
     it('renders featured icon wrapper', () => {
@@ -204,11 +204,11 @@ describe('Alert', () => {
       expect(getAlert()).toHaveAttribute('data-color', 'error');
     });
 
-    it('all color variants have uniform dark background', () => {
+    it('all color variants have transparent background', () => {
       const colors = ['default', 'brand', 'gray', 'error', 'warning', 'success'] as const;
       colors.forEach((color) => {
         const { unmount } = render(<Alert color={color} />);
-        expect(getAlert()).toHaveClass('bg-dos-bg-primary');
+        expect(getAlert()).not.toHaveClass('bg-dos-bg-primary');
         unmount();
       });
     });

--- a/src/components/Alert/components/Alert.tsx
+++ b/src/components/Alert/components/Alert.tsx
@@ -98,7 +98,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(({
       className={cn(
         'relative w-full flex flex-col gap-4 p-4',
         'font-dos text-dos-text-sm',
-        'bg-dos-bg-primary border border-dos-border-default rounded-dos-base',
+        'border border-dos-border-default rounded-dos-base',
         'eidotter-alert',
         `eidotter-alert--${resolvedColor}`,
         resolvedSize === 'floating' && 'max-w-[1216px]',

--- a/src/components/Card/components/Card.tsx
+++ b/src/components/Card/components/Card.tsx
@@ -48,7 +48,7 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(({
       ref={ref}
       className={cn(
         'border-2 border-solid border-dos-border-default',
-        'bg-dos-bg-primary font-dos text-cga-amber',
+        'font-dos text-cga-amber',
         'eidotter-card',
         variantClasses[variant] || variantClasses.default,
         className,

--- a/src/components/Chat/components/ChatContainer.tsx
+++ b/src/components/Chat/components/ChatContainer.tsx
@@ -51,7 +51,7 @@ export const ChatContainer: React.FC<ChatContainerProps & React.HTMLAttributes<H
   return (
     <div
       className={cn(
-        'flex flex-col h-full min-h-0 bg-dos-bg-primary',
+        'flex flex-col h-full min-h-0',
         className,
       )}
       {...props}

--- a/src/components/Chat/components/ChatInput.tsx
+++ b/src/components/Chat/components/ChatInput.tsx
@@ -61,7 +61,7 @@ export const ChatInput: React.FC<ChatInputProps & React.HTMLAttributes<HTMLDivEl
     <div
       className={cn(
         'flex items-start font-dos text-dos-text-md p-2 cursor-text',
-        'bg-dos-bg-primary text-cga-amber',
+        'text-cga-amber',
         'eidotter-chat-input',
         disabled && 'eidotter-chat-input--disabled',
         className,

--- a/src/components/FilterBar/components/FilterBar.css
+++ b/src/components/FilterBar/components/FilterBar.css
@@ -85,7 +85,7 @@
   font-size: var(--typography-font-size-text-xs, 10px);
   line-height: 1;
   border-radius: 2px;
-  background-color: var(--color-semantic-background-primary);
+  background-color: transparent;
   color: var(--color-cga-amber, #ffb000);
   border: 1px solid var(--color-semantic-border-default);
 }

--- a/src/components/Header/components/Header.css
+++ b/src/components/Header/components/Header.css
@@ -14,7 +14,7 @@
 }
 
 .eidotter-header--retro {
-  background-color: var(--color-semantic-background-primary);
+  background-color: transparent;
   box-shadow: 0 1px 0 0 var(--color-cga-amber-glow);
 }
 

--- a/src/components/Input/components/Input.css
+++ b/src/components/Input/components/Input.css
@@ -28,7 +28,7 @@
 .eidotter-input:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-  background: var(--color-semantic-background-primary);
+  background: transparent;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/Input/components/Input.tsx
+++ b/src/components/Input/components/Input.tsx
@@ -58,7 +58,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({
       <AriaInput
         ref={ref}
         className={cn(
-          'w-full bg-dos-bg-primary text-cga-amber font-dos text-base p-2',
+          'w-full bg-transparent text-cga-amber font-dos text-base p-2',
           'border-2 border-dos-border-default outline-none box-border',
           'eidotter-input',
           variantClasses[variant] || variantClasses.default,

--- a/src/components/Notification/components/Notification.test.tsx
+++ b/src/components/Notification/components/Notification.test.tsx
@@ -39,9 +39,9 @@ describe('Notification', () => {
       expect(document.querySelector('.eidotter-notification__icon')).toBeInTheDocument();
     });
 
-    it('has uniform dark background', () => {
+    it('has transparent background by default', () => {
       render(<Notification />);
-      expect(getNotification()).toHaveClass('bg-dos-bg-primary');
+      expect(getNotification()).not.toHaveClass('bg-dos-bg-primary');
     });
   });
 

--- a/src/components/Notification/components/Notification.tsx
+++ b/src/components/Notification/components/Notification.tsx
@@ -81,7 +81,7 @@ export const Notification: React.FC<NotificationProps> = ({
       className={cn(
         'w-full max-w-[400px]',
         'font-dos text-dos-text-sm',
-        'bg-dos-bg-primary border border-dos-border-default rounded-dos-base',
+        'border border-dos-border-default rounded-dos-base',
         'eidotter-notification',
         `eidotter-notification--${type}`,
         isClosing && 'eidotter-notification--closing',

--- a/src/components/TimelineContainer/components/TimelineEntryCard.css
+++ b/src/components/TimelineContainer/components/TimelineEntryCard.css
@@ -5,7 +5,7 @@
   min-width: 0;
   padding: var(--spacing-2, 0.5rem) var(--spacing-3, 1rem);
   border: var(--border-width-thin, 1px) solid var(--color-semantic-border-default);
-  background-color: var(--color-semantic-background-primary);
+  background-color: transparent;
   transition: border-color var(--duration-normal, 200ms) ease-out, box-shadow var(--duration-normal, 200ms) ease-out, transform 0.15s ease;
 }
 


### PR DESCRIPTION
## Summary

- Remove `bg-dos-bg-primary` from 10 components that created black boxes when embedded in consuming sites
- Terminal, CommandPrompt, and Modal keep opaque backgrounds (standalone windows/overlays)
- Input uses `bg-transparent` explicitly so the field inherits its container's background

**Affected components:** Card, Alert, Accordion (Section), Notification, ChatContainer, ChatInput, Input, FilterBar count badge, Header retro variant, TimelineEntryCard

## Breaking change

Components no longer set their own background color. Consumers that relied on the component's opaque background may need to add `bg-dos-bg-primary` to a parent container.

## Test plan

- [x] All 794 tests pass (3 test assertions updated to match new behavior)
- [x] `npm run build` produces dist/eidotter.css
- [ ] Visual check in Storybook — components should inherit parent background

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)