### PR TITLE
test: add CSS variable assertions to font-weight contract tests

### DIFF
--- a/src/styles/tokens.test.ts
+++ b/src/styles/tokens.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 import baseTokens from '../tokens/base.tokens.json';
 import generatedTokens from './tokens.json';
 
@@ -18,6 +20,14 @@ describe('Font-weight token contract', () => {
     'source token fontWeight.%s.$value equals 400',
     (weight) => {
       expect(baseTokens.typography.fontWeight[weight].$value).toBe(400);
+    },
+  );
+
+  it.each(['regular', 'semibold', 'bold'] as const)(
+    'CSS variable --typography-font-weight-%s contains 400',
+    (weight) => {
+      const css = readFileSync(resolve(__dirname, 'tokens.css'), 'utf-8');
+      expect(css).toContain(`--typography-font-weight-${weight}: 400;`);
     },
   );
 });


### PR DESCRIPTION
## Summary

- Add 3 CSS variable assertions to `src/styles/tokens.test.ts`
- Reads `tokens.css` via `fs.readFileSync` and verifies `--typography-font-weight-{regular,semibold,bold}: 400;`
- Closes the gap where JSON tests pass but CSS output could be wrong

## Test plan

- [x] 9 tests pass (6 existing + 3 new)

Closes DMNC-676

🤖 Generated with [Claude Code](https://claude.com/claude-code)