### PR TITLE
chore: clean up dead plan file references

### DIFF
--- a/.claude/skills/figma-audit/SKILL.md
+++ b/.claude/skills/figma-audit/SKILL.md
@@ -88,6 +88,6 @@ For each gap found, recommend:
 - **Keep eidotter**: The React version has something V.37 doesn't (e.g., phosphor effects)
 - **Merge**: Take best of both
 
-### Step 6: Update audit doc
+### Step 6: Record findings
 
-Append findings to `plans/2026-04-04-001-feat-component-audit-v37.md` in the component's row.
+Document audit findings in the PR description or commit message. For recurring audits, add to `solutions/` as a best-practice doc.

--- a/.claude/skills/migrate-component/SKILL.md
+++ b/.claude/skills/migrate-component/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: migrate-component
 description: Migrate an eidotter component to React Aria + Tailwind-first following the V.37 pattern established by Button (PR #200)
+status: archival
 ---
 
 # Migrate Component to V.37
+
+> **Status: Archival** — All 17 audited components were migrated to V.37 as of v0.19.1 (April 2026). This skill is retained as a reference for future component additions.
 
 Migrate an eidotter component from BEM CSS to React Aria + Tailwind-first styling.
 
@@ -15,7 +18,6 @@ Migrate an eidotter component from BEM CSS to React Aria + Tailwind-first stylin
 
 - React Aria deps installed (`react-aria-components`, `react-aria`, `react-stately`)
 - `src/utils/cn.ts` exists (Tailwind class merge utility)
-- Component audit completed: `plans/2026-04-04-001-feat-component-audit-v37.md`
 
 ## Workflow
 

--- a/todos/001-ready-p1-url-sanitization-utility.md
+++ b/todos/001-ready-p1-url-sanitization-utility.md
@@ -44,5 +44,4 @@ Create `src/utils/isSafeUrl.ts` with its own test file. Export from `src/utils/i
 
 ## Resources
 
-- Plan: `plans/2026-03-08-feat-inline-expand-sources-update-plan.md`
 - Breadcrumb component: `src/components/Breadcrumb/components/Breadcrumb.tsx:92`


### PR DESCRIPTION
## Summary

- Mark `migrate-component` skill as archival (V.37 migration complete as of v0.19.1)
- Remove dead plan file references from 3 files that pointed to files that never existed on disk
- Update `figma-audit` Step 6 to direct findings to `solutions/` instead of a non-existent plan

## Test plan

- [x] No runtime code changed — skill files and todo only

Closes DMNC-677

🤖 Generated with [Claude Code](https://claude.com/claude-code)