### PR TITLE
feat: single CSS entry point for consumer imports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,5 +332,5 @@ See the workspace-level `CLAUDE.md` for the full project portfolio.
 - **npm publish:** Requires `npm login` first — not pre-authenticated on this machine
 - **Font-size tokens are rem:** All `--typography-font-size-*` tokens use rem (assumes 16px browser default). Hardcoded `font-size: Npx` in component CSS is an anti-pattern — use `var(--typography-font-size-*, fallback)` instead.
 - **62.5% pattern incompatible:** eiDotter assumes `1rem = 16px`. Consumers using `html { font-size: 62.5% }` will see all text at 62.5% of intended size.
-- **Consumer CSS imports:** Consumers must import `eidotter/fonts.css` (Flexi IBM VGA True @font-face), `eidotter/styles` (component CSS), and `eidotter/tokens.css` (CSS variables). Tailwind is NOT required — utilities are pre-compiled in `dist/eidotter.css`.
+- **Consumer CSS imports:** A single `import 'eidotter/styles'` provides everything (fonts, tokens, component CSS, Tailwind utilities). Tailwind is NOT required — utilities are pre-compiled in `dist/eidotter.css`. Granular imports (`eidotter/fonts.css`, `eidotter/tokens.css`) remain available for consumers who override fonts or tokens independently.
 - **Update docs on release:** Always update README.md, CLAUDE.md, and guidelines/README.md when releasing versions or changing consumer setup.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ npm install eidotter
 
 ```tsx
 import { Terminal, Button, Alert } from 'eidotter';
-import 'eidotter/fonts.css';   // Flexi IBM VGA True @font-face (required)
-import 'eidotter/styles';      // Component CSS (includes Tailwind utilities)
-import 'eidotter/tokens.css';  // Design token CSS variables (required)
+import 'eidotter/styles';      // All styles: fonts, tokens, components
 
 function App() {
   return (
@@ -32,15 +30,21 @@ function App() {
 
 ### Basic (no Tailwind needed)
 
-Import the styles, tokens, and font. All component styling is pre-compiled — no build tools required.
+Import the styles. All component styling, fonts, and design tokens are pre-compiled — no build tools required.
 
 ```tsx
-import 'eidotter/fonts.css';   // Flexi IBM VGA True @font-face (required)
-import 'eidotter/styles';      // Component CSS (includes Tailwind utilities)
-import 'eidotter/tokens.css';  // CSS variable definitions
+import 'eidotter/styles';      // Fonts, tokens, components, Tailwind utilities
 
 // Optional: import a theme
 import 'eidotter/themes/amber-mono.css';
+```
+
+Individual imports are still available for granular control:
+
+```tsx
+import 'eidotter/fonts.css';   // Flexi IBM VGA True @font-face
+import 'eidotter/tokens.css';  // CSS variable definitions
+import 'eidotter/styles';      // Component CSS + Tailwind utilities
 ```
 
 **Font:** eiDotter uses [Flexi IBM VGA True v2](https://int10h.org/blog/2018/05/flexi-ibm-vga-scalable-truetype-font/) — an aspect-corrected vector remake of the IBM VGA BIOS font (CC BY-SA 4.0). The "True" variant matches authentic 4:3 VGA proportions with an extended character set (Greek, Cyrillic, Hebrew, Latin). The `fonts.css` import loads the bundled TTF via `@font-face`. No fallback fonts are configured so you'll immediately see if the font isn't loading.

--- a/guidelines/README.md
+++ b/guidelines/README.md
@@ -17,9 +17,7 @@ eidotter provides 33 ready-to-use components with consistent DOS terminal stylin
 
 ```tsx
 import { Button, Card, Input } from 'eidotter';
-import 'eidotter/fonts.css';   // Flexi IBM VGA True @font-face (required)
-import 'eidotter/styles';      // Component CSS (includes Tailwind utilities)
-import 'eidotter/tokens.css';  // CSS variable definitions (required)
+import 'eidotter/styles';      // All styles: fonts, tokens, components, Tailwind utilities
 
 function App() {
   return (
@@ -90,12 +88,18 @@ function App() {
 ### CSS Import (required)
 
 ```tsx
-import 'eidotter/fonts.css';   // Flexi IBM VGA True @font-face (required)
-import 'eidotter/styles';      // Component CSS (includes compiled Tailwind utilities)
-import 'eidotter/tokens.css';  // Design token CSS variables
+import 'eidotter/styles';      // All styles: fonts, tokens, components, Tailwind utilities
 
 // Optional: import a theme
 import 'eidotter/themes/amber-mono.css';
+```
+
+Individual imports are still available if you need granular control (e.g., providing your own font or overriding tokens):
+
+```tsx
+import 'eidotter/fonts.css';   // Flexi IBM VGA True @font-face
+import 'eidotter/tokens.css';  // Design token CSS variables
+import 'eidotter/styles';      // Component CSS + Tailwind utilities
 ```
 
 ### Tailwind Preset (optional)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 // DOS-themed React component library with terminal aesthetics
 
 import './styles/fonts.css';
+import './styles/tokens.css';
 import './styles/tailwind.css';
 
 // Core Components


### PR DESCRIPTION
## Summary

- Bundles `tokens.css` into `dist/eidotter.css` so consumers need only `import 'eidotter/styles'` instead of three separate CSS imports
- Updates README, guidelines, and CLAUDE.md to document the simplified import
- Granular imports (`eidotter/fonts.css`, `eidotter/tokens.css`) remain available for advanced use

## Consumer migration

```diff
- import 'eidotter/fonts.css';
- import 'eidotter/styles';
- import 'eidotter/tokens.css';
+ import 'eidotter/styles';
```

Non-breaking: consumers who still import all three get harmless duplicate declarations.

## Test plan

- [x] `npm run build` — `dist/eidotter.css` contains `:root` token declarations
- [x] `npm run test` — 803 tests passing, 0 failures
- [x] Storybook renders correctly with bundled tokens

Resolves DMNC-679

🤖 Generated with [Claude Code](https://claude.com/claude-code)