### PR TITLE
ci: add token freshness check to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,17 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
+    - name: Check token freshness
+      run: |
+        npm run build-tokens
+        git diff --exit-code -- \
+          src/styles/tokens.css \
+          src/styles/tokens.js \
+          src/styles/tokens.json \
+          src/styles/theme.*.css \
+          tailwind.preset.js \
+          platforms/swiftui/Sources/EiDotterTokens/
+
     - name: Create env file
       run: |
         echo "FIGMA_ACCESS_TOKEN=" >> .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,7 +319,7 @@ See the workspace-level `CLAUDE.md` for the full project portfolio.
 ## Quick Rules
 
 - **text-secondary:** Only use `--color-semantic-text-secondary` / `text-dos-text-secondary` on amber/light backgrounds — it resolves to near-black (#020003)
-- **Generated files:** `tokens.css`, `tokens.js`, `tokens.json`, `tailwind.preset.js`, `theme.*.css` are generated — edit JSON sources in `src/tokens/` instead
+- **Generated files:** `tokens.css`, `tokens.js`, `tokens.json`, `tailwind.preset.js`, `theme.*.css` are generated — edit JSON sources in `src/tokens/` instead. CI enforces freshness: `build.yml` rebuilds tokens and fails if generated files don't match committed output. Run `npm run build-tokens` after editing token JSON sources.
 - **Linear project:** eiDotter issues go in project "eiDotter", team "dmnc"
 - **Storybook viewports:** Custom DOS viewports configured in `.storybook/preview.ts` (phone320, phone375, tablet768, desktop1024, ultrawide)
 - **Button sizes (V.37):** xs=24px, sm=28px, md=32px, lg=40px, xl=44px min-height. Old aliases (small/medium/large) still work. Button/Badge/Tag/Stat/Checkbox text uses `text-dos-text-*` (18–26px) or `text-dos-display-*` (30–78px) utilities — never hardcoded `text-[Npx]`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,7 +319,7 @@ See the workspace-level `CLAUDE.md` for the full project portfolio.
 ## Quick Rules
 
 - **text-secondary:** Only use `--color-semantic-text-secondary` / `text-dos-text-secondary` on amber/light backgrounds — it resolves to near-black (#020003)
-- **Generated files:** `tokens.css`, `tokens.js`, `tokens.json`, `tailwind.preset.js`, `theme.*.css` are generated — edit JSON sources in `src/tokens/` instead. CI enforces freshness: `build.yml` rebuilds tokens and fails if generated files don't match committed output. Run `npm run build-tokens` after editing token JSON sources.
+- **Generated files:** `tokens.css`, `tokens.js`, `tokens.json`, `tailwind.preset.js`, `theme.*.css`, `EiDotterTokens.swift` are generated — edit JSON sources in `src/tokens/` instead. CI enforces freshness: `build.yml` rebuilds tokens and fails if generated files don't match committed output. Run `npm run build-tokens` after editing token JSON sources.
 - **Linear project:** eiDotter issues go in project "eiDotter", team "dmnc"
 - **Storybook viewports:** Custom DOS viewports configured in `.storybook/preview.ts` (phone320, phone375, tablet768, desktop1024, ultrawide)
 - **Button sizes (V.37):** xs=24px, sm=28px, md=32px, lg=40px, xl=44px min-height. Old aliases (small/medium/large) still work. Button/Badge/Tag/Stat/Checkbox text uses `text-dos-text-*` (18–26px) or `text-dos-display-*` (30–78px) utilities — never hardcoded `text-[Npx]`.


### PR DESCRIPTION
## Summary

- Adds a CI step to `build.yml` that rebuilds tokens from JSON sources and fails if generated files don't match committed output
- Enforces the "do not edit tokens.css directly" rule via CI instead of convention
- Documents CI enforcement in CLAUDE.md

## How it works

The new step runs `npm run build-tokens` then `git diff --exit-code` scoped to all 10 generated token files. If any file is stale (forgotten rebuild) or hand-edited, CI fails and prints the diff showing exactly what changed.

## Test plan

- [x] `npm run build-tokens` + `git diff --exit-code` passes locally (tokens are in sync)
- [ ] CI runs the new step on this PR

Resolves DMNC-680

🤖 Generated with [Claude Code](https://claude.com/claude-code)