### PR TITLE
chore: harden the preset-merge surface — tests, doc callouts, CLAUDE.md fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ border-color: rgba(255, 255, 255, 0.1);
 - `solutions/` — Documented solutions and best practices (searchable by YAML frontmatter: module, tags, problem_type)
 - `plans/` — Implementation plans (naming: `YYYY-MM-DD-NNN-<type>-<name>-plan.md`)
 
-**Note:** `docs/DESIGN_PRINCIPLES.md`, `docs/TOKENS.md`, `docs/INTEGRATION.md`, `docs/CROSS_PLATFORM_VARIANTS.md` are overwritten by Storybook builds. Their content lives in component stories and this CLAUDE.md instead.
+**Note:** The **entire `docs/` directory is the Storybook build output** (`package.json` `"build-storybook": "storybook build -o docs"`). Anything written under `docs/` is wiped on every build — this includes `docs/DESIGN_PRINCIPLES.md`, `docs/TOKENS.md`, `docs/INTEGRATION.md`, `docs/CROSS_PLATFORM_VARIANTS.md` (content lives in component stories + this CLAUDE.md instead) AND any other skill-generated content. When a skill wants to write documentation, plans, brainstorms, or solution docs, use these Storybook-safe locations at the repo root: `solutions/<category>/` (compound-engineering solutions), `plans/` (ce:plan / superpowers:writing-plans output — gitignored, local-only), `ideation/` (open ideation notes), `.superpowers/` (superpowers specs and plans), `.devjournal/` (devjournal sessions). Never use `docs/solutions/`, `docs/plans/`, `docs/brainstorms/`, or any other `docs/*` subdir for durable content.
 
 ## Figma Design System
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,15 @@ border-color: rgba(255, 255, 255, 0.1);
 - `solutions/` — Documented solutions and best practices (searchable by YAML frontmatter: module, tags, problem_type)
 - `plans/` — Implementation plans (naming: `YYYY-MM-DD-NNN-<type>-<name>-plan.md`)
 
-**Note:** The **entire `docs/` directory is the Storybook build output** (`package.json` `"build-storybook": "storybook build -o docs"`). Anything written under `docs/` is wiped on every build — this includes `docs/DESIGN_PRINCIPLES.md`, `docs/TOKENS.md`, `docs/INTEGRATION.md`, `docs/CROSS_PLATFORM_VARIANTS.md` (content lives in component stories + this CLAUDE.md instead) AND any other skill-generated content. When a skill wants to write documentation, plans, brainstorms, or solution docs, use these Storybook-safe locations at the repo root: `solutions/<category>/` (compound-engineering solutions), `plans/` (ce:plan / superpowers:writing-plans output — gitignored, local-only), `ideation/` (open ideation notes), `.superpowers/` (superpowers specs and plans), `.devjournal/` (devjournal sessions). Never use `docs/solutions/`, `docs/plans/`, `docs/brainstorms/`, or any other `docs/*` subdir for durable content.
+**Note — `docs/` is Storybook build output.** The entire directory is wiped on every Storybook build (`package.json` `"build-storybook": "storybook build -o docs"`). This includes `docs/DESIGN_PRINCIPLES.md`, `docs/TOKENS.md`, `docs/INTEGRATION.md`, and `docs/CROSS_PLATFORM_VARIANTS.md` (their content lives in component stories + this CLAUDE.md) as well as any skill-generated content. Never write skill output to `docs/solutions/`, `docs/plans/`, `docs/brainstorms/`, or any other `docs/*` subdir.
+
+**Storybook-safe locations for skill-generated content** (all at repo root):
+
+- `solutions/<category>/` — compound-engineering solutions (ce:compound)
+- `plans/` — implementation plans (ce:plan / superpowers:writing-plans); gitignored, local-only
+- `ideation/` — open ideation notes
+- `.superpowers/` — superpowers specs and plans
+- `.devjournal/` — devjournal sessions
 
 ## Figma Design System
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,18 @@ module.exports = {
 </div>
 ```
 
-The preset includes React Aria state variants and animations automatically.
+The preset auto-registers `tailwindcss-react-aria-components` and `tailwindcss-animate` via require-if-available. Consumers who already list either plugin in their own Tailwind config may see duplicate-variant warnings from Tailwind — either rely on the preset's registration alone, or pass those plugins explicitly in your config (they're idempotent, but the duplicate registration is noisy).
+
+#### Migration from 0.19.1 and earlier
+
+In 0.19.2 the two older presets (`eidotter/tailwind.preset` and `eidotter/tailwind.preset.enhanced`) were merged into a single `eidotter/tailwind.preset` that includes all tokens plus the React Aria + animate plugins. The enhanced subpath is now a deprecated alias that logs a one-time `console.warn` on load and will be removed in 0.21.0:
+
+```diff
+- presets: [require('eidotter/tailwind.preset.enhanced')]
++ presets: [require('eidotter/tailwind.preset')]
+```
+
+No behavior change — the merged preset already carries everything the enhanced preset used to add.
 
 ## Available Components (33)
 

--- a/src/styles/package-exports.test.ts
+++ b/src/styles/package-exports.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Snapshot test for `package.json` `exports` keys.
+ *
+ * PR #282 silently removed `./tailwind.preset.enhanced` under a patch version,
+ * which would have thrown `ERR_PACKAGE_PATH_NOT_EXPORTED` for any consumer on
+ * that import. This test pins the full set of published subpaths so any
+ * future removal requires a deliberate snapshot update (and a reviewer who
+ * sees the diff).
+ *
+ * If this test fails on a PR that intentionally changes exports: (a) verify
+ * the change is consumer-safe (shim for removed paths, major bump for
+ * deliberate breaks), (b) update the snapshot.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const pkg = require('../../package.json') as { exports: Record<string, unknown> };
+
+describe('package.json exports snapshot', () => {
+  it('exposes the expected set of subpaths (no silent removals)', () => {
+    const keys = Object.keys(pkg.exports).sort();
+    expect(keys).toMatchInlineSnapshot(`
+[
+  ".",
+  "./fonts.css",
+  "./styles",
+  "./tailwind.preset",
+  "./tailwind.preset.enhanced",
+  "./themes/amber-mono.css",
+  "./themes/cga-amber.css",
+  "./themes/cga-mode4-p0.css",
+  "./themes/cga-mode4-p1.css",
+  "./themes/cga-mode5.css",
+  "./tokens.css",
+]
+`);
+  });
+
+  it('./tailwind.preset.enhanced is still present (deprecated shim, REMOVE-IN-0.21.0)', () => {
+    expect(pkg.exports['./tailwind.preset.enhanced']).toBe('./tailwind.preset.enhanced.cjs');
+  });
+
+  it('./tailwind.preset points at the canonical .cjs', () => {
+    expect(pkg.exports['./tailwind.preset']).toBe('./tailwind.preset.cjs');
+  });
+});

--- a/src/styles/package-exports.test.ts
+++ b/src/styles/package-exports.test.ts
@@ -12,8 +12,15 @@
  * deliberate breaks), (b) update the snapshot.
  */
 
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const pkg = require('../../package.json') as { exports: Record<string, unknown> };
+const pkg = require('../../package.json') as {
+  exports: Record<string, unknown>;
+  files: string[];
+};
+const repoRoot = resolve(__dirname, '../..');
 
 describe('package.json exports snapshot', () => {
   it('exposes the expected set of subpaths (no silent removals)', () => {
@@ -42,4 +49,58 @@ describe('package.json exports snapshot', () => {
   it('./tailwind.preset points at the canonical .cjs', () => {
     expect(pkg.exports['./tailwind.preset']).toBe('./tailwind.preset.cjs');
   });
+});
+
+describe('package.json exports ↔ files ↔ filesystem pairing', () => {
+  /**
+   * The PR #282 regression was caused by `exports` and `files[]` drifting apart
+   * when `tailwind.preset.enhanced.cjs` was deleted. This test verifies three
+   * invariants at once:
+   *   1. Every string-form `exports` target exists on disk.
+   *   2. Every string-form `exports` target is reachable from `files[]` (either
+   *      listed literally or matched by one of its glob patterns).
+   *
+   * Conditional-form exports (`{types, import, require}`) are flattened.
+   */
+  const flattenedTargets: string[] = [];
+  for (const value of Object.values(pkg.exports)) {
+    if (typeof value === 'string') {
+      flattenedTargets.push(value);
+    } else if (value && typeof value === 'object') {
+      for (const inner of Object.values(value as Record<string, unknown>)) {
+        if (typeof inner === 'string') flattenedTargets.push(inner);
+      }
+    }
+  }
+
+  it.each(flattenedTargets.map((t) => [t]))(
+    'exports target "%s" exists on disk',
+    (target) => {
+      expect(existsSync(resolve(repoRoot, target))).toBe(true);
+    },
+  );
+
+  it.each(flattenedTargets.map((t) => [t]))(
+    'exports target "%s" is reachable from package.json files[]',
+    (target) => {
+      const normalized = target.replace(/^\.\//, '');
+      const covered = pkg.files.some((pattern) => {
+        if (pattern === normalized) return true;
+        // Crude glob match: "dir/*" matches "dir/anything" and "dir" covers "dir/anything".
+        if (pattern.endsWith('/*')) {
+          const prefix = pattern.slice(0, -2);
+          return normalized.startsWith(prefix + '/') || normalized === prefix;
+        }
+        if (pattern.includes('*')) {
+          const regex = new RegExp(
+            '^' + pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$',
+          );
+          return regex.test(normalized);
+        }
+        // A directory entry in files[] covers everything under it.
+        return normalized === pattern || normalized.startsWith(pattern + '/');
+      });
+      expect(covered).toBe(true);
+    },
+  );
 });

--- a/src/styles/tailwind-preset-enhanced.test.ts
+++ b/src/styles/tailwind-preset-enhanced.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Shim contract tests for `tailwind.preset.enhanced.cjs`.
+ *
+ * The shim restores the `./tailwind.preset.enhanced` subpath export that
+ * PR #282 accidentally removed. It must:
+ *   1. Re-export the exact same object as `./tailwind.preset.cjs` (identity,
+ *      not deep equality — consumers that memoize by reference depend on this).
+ *   2. Log a `console.warn` exactly once per process, even across
+ *      `require.cache` invalidation (dev servers / HMR / test runners).
+ *
+ * REMOVE-IN-0.21.0 — delete this file when the shim is removed.
+ */
+
+const shimPath = require.resolve('../../tailwind.preset.enhanced.cjs');
+const basePath = require.resolve('../../tailwind.preset.cjs');
+const warnFlag = '__eidotterEnhancedPresetDeprecationWarned' as const;
+
+const globalFlagStore = globalThis as unknown as Record<string, unknown>;
+
+function resetShimState(): void {
+  delete require.cache[shimPath];
+  delete require.cache[basePath];
+  delete globalFlagStore[warnFlag];
+}
+
+describe('tailwind.preset.enhanced.cjs — re-export parity', () => {
+  beforeEach(() => {
+    resetShimState();
+  });
+
+  it('returns the same object identity as ./tailwind.preset.cjs', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const shim = require('../../tailwind.preset.enhanced.cjs');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const base = require('../../tailwind.preset.cjs');
+    expect(shim).toBe(base);
+  });
+});
+
+describe('tailwind.preset.enhanced.cjs — once-per-process deprecation warn', () => {
+  beforeEach(() => {
+    resetShimState();
+  });
+
+  it('fires console.warn exactly once on first require', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../../tailwind.preset.enhanced.cjs');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('deprecated');
+    expect(warnSpy.mock.calls[0][0]).toContain('0.21.0');
+  });
+
+  it('does NOT re-fire when the module is re-required after cache invalidation', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../../tailwind.preset.enhanced.cjs');
+    // Simulate a dev-server HMR cycle: blow the cache and re-require.
+    delete require.cache[shimPath];
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../../tailwind.preset.enhanced.cjs');
+    // The globalThis guard survives require.cache invalidation; warn fires only once.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/styles/tailwind-preset-enhanced.test.ts
+++ b/src/styles/tailwind-preset-enhanced.test.ts
@@ -11,20 +11,25 @@
  * REMOVE-IN-0.21.0 — delete this file when the shim is removed.
  */
 
-const shimPath = require.resolve('../../tailwind.preset.enhanced.cjs');
-const basePath = require.resolve('../../tailwind.preset.cjs');
 const warnFlag = '__eidotterEnhancedPresetDeprecationWarned' as const;
 
 const globalFlagStore = globalThis as unknown as Record<string, unknown>;
 
 function resetShimState(): void {
-  delete require.cache[shimPath];
-  delete require.cache[basePath];
+  // Jest has its own module registry — require.cache deletion alone won't force
+  // re-execution through ts-jest's transformer. jest.resetModules() is the correct
+  // tool; it clears the jest module registry so the next require re-runs the shim.
+  jest.resetModules();
   delete globalFlagStore[warnFlag];
 }
 
 describe('tailwind.preset.enhanced.cjs — re-export parity', () => {
   beforeEach(() => {
+    resetShimState();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
     resetShimState();
   });
 
@@ -35,6 +40,9 @@ describe('tailwind.preset.enhanced.cjs — re-export parity', () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const base = require('../../tailwind.preset.cjs');
     expect(shim).toBe(base);
+    // Deep-equal as well so a future `{ ...require(...) }` refactor still fails
+    // (identity would fail first; toEqual gives a clearer diagnostic on drift).
+    expect(shim).toEqual(base);
   });
 });
 
@@ -43,24 +51,38 @@ describe('tailwind.preset.enhanced.cjs — once-per-process deprecation warn', (
     resetShimState();
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+    resetShimState();
+  });
+
   it('fires console.warn exactly once on first require', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     require('../../tailwind.preset.enhanced.cjs');
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toContain('deprecated');
-    expect(warnSpy.mock.calls[0][0]).toContain('0.21.0');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('deprecated'),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('0.21.0'),
+    );
+    // Lock the migration-target path so a future edit can't silently drop it.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('eidotter/tailwind.preset'),
+    );
   });
 
   it('does NOT re-fire when the module is re-required after cache invalidation', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     require('../../tailwind.preset.enhanced.cjs');
-    // Simulate a dev-server HMR cycle: blow the cache and re-require.
-    delete require.cache[shimPath];
+    // Simulate a dev-server HMR cycle: blow the module registry and re-require.
+    // Note: we do NOT reset the globalThis flag — that's the whole point of this test.
+    jest.resetModules();
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     require('../../tailwind.preset.enhanced.cjs');
-    // The globalThis guard survives require.cache invalidation; warn fires only once.
+    // The globalThis guard survives module cache invalidation; warn fires only once.
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/styles/tailwind-preset.test.ts
+++ b/src/styles/tailwind-preset.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Contract tests for `tailwind.preset.cjs` — the generated Tailwind preset.
+ *
+ * PR #282 consolidated three preset files into one auto-generated .cjs emitted
+ * by Style Dictionary. These assertions pin the output shape so generator
+ * changes don't silently drop tokens or alter the consumer-facing structure.
+ *
+ * If a test here fails, either the generator changed (expected — update the
+ * assertion) or the source tokens moved out from under the preset (unexpected —
+ * investigate why).
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const preset = require('../../tailwind.preset.cjs') as {
+  theme: {
+    extend: {
+      colors: Record<string, string>;
+      fontFamily: Record<string, string[]>;
+      fontSize: Record<string, string>;
+      lineHeight: Record<string, string>;
+      fontWeight: Record<string, string>;
+      spacing: Record<string, string>;
+      borderRadius: Record<string, string>;
+      boxShadow: Record<string, string>;
+    };
+  };
+  plugins: unknown[];
+};
+
+describe('tailwind.preset.cjs — top-level shape', () => {
+  it('exports an object with theme.extend and plugins array', () => {
+    expect(preset).toBeDefined();
+    expect(preset.theme).toBeDefined();
+    expect(preset.theme.extend).toBeDefined();
+    expect(Array.isArray(preset.plugins)).toBe(true);
+  });
+
+  it.each([
+    'colors',
+    'fontFamily',
+    'fontSize',
+    'lineHeight',
+    'fontWeight',
+    'spacing',
+    'borderRadius',
+    'boxShadow',
+  ] as const)('theme.extend.%s is a non-empty object', (key) => {
+    const value = preset.theme.extend[key];
+    expect(typeof value).toBe('object');
+    expect(Object.keys(value as object).length).toBeGreaterThan(0);
+  });
+});
+
+describe('tailwind.preset.cjs — representative token spot-checks', () => {
+  it('colors contains the CGA amber primary', () => {
+    expect(preset.theme.extend.colors['cga-amber']).toBeDefined();
+  });
+
+  it('colors exposes dos-bg-primary as a CSS var reference for theme switching', () => {
+    expect(preset.theme.extend.colors['dos-bg-primary']).toMatch(/var\(--color-semantic-background-primary\)/);
+  });
+
+  it('boxShadow includes the 24 colored glow tokens added in #282', () => {
+    const shadows = preset.theme.extend.boxShadow;
+    const glowKeys = Object.keys(shadows).filter((k) => /^dos-glow[A-Z]/.test(k));
+    // 4 sizes (Xs, Sm, Md, Lg) × 6 colors (Red, Green, Cyan, Magenta, Blue, White) + 4 default amber = 28
+    expect(glowKeys.length).toBeGreaterThanOrEqual(24);
+  });
+
+  it('boxShadow.dos-glowMdRed resolves to the expected CGA red glow', () => {
+    expect(preset.theme.extend.boxShadow['dos-glowMdRed']).toBe('0px 0px 20px 0px #FF555580');
+  });
+
+  it('fontFamily.dos lists Flexi IBM VGA True', () => {
+    expect(preset.theme.extend.fontFamily.dos).toEqual(expect.arrayContaining(['"Flexi IBM VGA True"']));
+  });
+
+  it('fontSize.dos-text-md is 1.375rem (22px)', () => {
+    expect(preset.theme.extend.fontSize['dos-text-md']).toBe('1.375rem');
+  });
+
+  it('fontWeight.dos-regular is "400" (Flexi is single-weight)', () => {
+    expect(preset.theme.extend.fontWeight['dos-regular']).toBe('400');
+  });
+
+  it('borderRadius caps at dos-base (4px) per eidotter style rules', () => {
+    expect(preset.theme.extend.borderRadius['dos-base']).toBe('4px');
+  });
+});

--- a/src/styles/tailwind-preset.test.ts
+++ b/src/styles/tailwind-preset.test.ts
@@ -35,6 +35,14 @@ describe('tailwind.preset.cjs — top-level shape', () => {
     expect(Array.isArray(preset.plugins)).toBe(true);
   });
 
+  it('plugins array is populated (catches silent try/catch fallback to null)', () => {
+    // The generator auto-registers tailwindcss-animate and tailwindcss-react-aria-components
+    // via require-if-available. Both are devDependencies, so both should resolve in this repo.
+    // Array.isArray alone passes even if both silently fell back to null — this assertion
+    // catches the consumer-visible regression where plugins never reach Tailwind.
+    expect(preset.plugins.length).toBeGreaterThanOrEqual(2);
+  });
+
   it.each([
     'colors',
     'fontFamily',

--- a/style-dictionary.config.mjs
+++ b/style-dictionary.config.mjs
@@ -317,7 +317,6 @@ StyleDictionary.registerFormat({
  *     presets: [require('eidotter/tailwind.preset')],
  *   }
  */
-
 `;
 
     const pluginBlock = `

--- a/tailwind.preset.cjs
+++ b/tailwind.preset.cjs
@@ -14,7 +14,6 @@
  *   }
  */
 
-
 let reactAriaPlugin;
 try {
   reactAriaPlugin = require('tailwindcss-react-aria-components');


### PR DESCRIPTION
## Summary

Addresses the autonomous-safe subset of DMNC-712 follow-ups. Adds guardrails against the regression class that caused PR #283, plus small doc improvements from the three ce:review passes.

## Tests (`src/styles/*.test.ts`)

- **`tailwind-preset.test.ts`** — pins the shape of the generated preset (`theme.extend.{colors, fontFamily, fontSize, lineHeight, fontWeight, spacing, borderRadius, boxShadow}` + `plugins` array) and spot-checks representative tokens including `dos-glowMdRed` (one of the 24 new colored glow shadow tokens added in #282).
- **`tailwind-preset-enhanced.test.ts`** — asserts the shim returns the same object identity as `tailwind.preset.cjs`, and that `console.warn` fires exactly once across `require.cache` invalidation — the guarantee the `globalThis` memoization exists to provide.
- **`package-exports.test.ts`** — snapshot of `package.json` `exports` keys. Exists specifically to catch the exact regression class that caused #283 (silent subpath removal).

## Docs

- **`CLAUDE.md:202`** — clarify that the *entire* `docs/` directory is Storybook output, not just the 4 files previously called out. Points skills at Storybook-safe roots (`solutions/`, `plans/`, `ideation/`, `.superpowers/`, `.devjournal/`) so `ce:compound` / `ce:plan` / `superpowers` don't write content that gets wiped on next `storybook build`. This mistake is what caused the P0 in PR #284's review.
- **`README.md`** — migration callout for consumers upgrading from 0.19.1, and a note that the preset auto-registers `tailwindcss-animate` and `tailwindcss-react-aria-components` via require-if-available (consumers who already list either may see duplicate-variant warnings).

## Cosmetic

- **`style-dictionary.config.mjs`** — remove the extra blank line in the generator's header/pluginBlock join. Regenerated `tailwind.preset.cjs` is one line shorter. No behavioral change.

## Test plan

- [x] `npm run test -- --testPathPatterns="tailwind-preset|package-exports|tokens"` — 32/32 pass
- [x] `npm run build-tokens` — generator produces clean output (no double blank line)
- [x] `node -e "require('./tailwind.preset.enhanced.cjs')"` — shim still emits deprecation warn + re-exports base preset

## Held back (not in this PR)

- `font-dos` monospace fallback decision — needs maintainer A/B/C call. Local plan at `plans/2026-04-18-001-decision-font-dos-monospace-fallback-plan.md`.
- Publishing 0.19.2 to npm — awaiting \`gh release create v0.19.2\`. Not urgent; no consumer on the latest yet.
- Generator refactor (extract plugin template, collapse duplicate loops) — P3 polish, deferred.

Resolves the test/doc/CLAUDE.md items in DMNC-712.

🤖 Generated with [Claude Code](https://claude.com/claude-code)