### PR TITLE
chore: migrate muted-text refs from --color-cga-brown to --color-semantic-text-muted

### DIFF
--- a/src/components/Chat/components/ChatHistory.tsx
+++ b/src/components/Chat/components/ChatHistory.tsx
@@ -58,7 +58,7 @@ export const ChatHistory: React.FC<ChatHistoryProps & React.HTMLAttributes<HTMLD
     return (
       <div className={classes} role="log" aria-live="polite" {...props}>
         <div className="flex items-center justify-center h-full min-h-16">
-          <span className="text-cga-brown font-dos text-dos-text-md">Awaiting input...</span>
+          <span className="text-dos-text-muted font-dos text-dos-text-md">Awaiting input...</span>
         </div>
       </div>
     );

--- a/src/components/Chat/components/ChatMessage.css
+++ b/src/components/Chat/components/ChatMessage.css
@@ -9,7 +9,7 @@
 }
 
 .eidotter-chat-message--system {
-  color: var(--color-cga-brown, #aa5500);
+  color: var(--color-semantic-text-muted);
   font-style: italic;
 }
 

--- a/src/components/Footer/components/Footer.tsx
+++ b/src/components/Footer/components/Footer.tsx
@@ -56,7 +56,7 @@ export const Footer: React.FC<FooterProps & React.HTMLAttributes<HTMLElement>> =
         <nav className="flex justify-center items-center flex-wrap gap-2 mb-2" aria-label="Footer links">
           {resolvedLinks.map((link, index) => (
             <React.Fragment key={link.href}>
-              {index > 0 && <span className="text-cga-brown select-none eidotter-footer__dot" aria-hidden="true">·</span>}
+              {index > 0 && <span className="text-dos-text-muted select-none eidotter-footer__dot" aria-hidden="true">·</span>}
               <a
                 className="eidotter-footer__link text-cga-amber no-underline"
                 href={link.href}
@@ -69,7 +69,7 @@ export const Footer: React.FC<FooterProps & React.HTMLAttributes<HTMLElement>> =
         </nav>
       )}
       {copyright && (
-        <p className="text-cga-brown m-0">&copy; {copyright}</p>
+        <p className="text-dos-text-muted m-0">&copy; {copyright}</p>
       )}
     </footer>
   );

--- a/src/components/InlineExpand/components/InlineExpand.css
+++ b/src/components/InlineExpand/components/InlineExpand.css
@@ -115,7 +115,7 @@
   align-items: center;
   gap: var(--spacing-1, 4px);
   font-size: var(--typography-font-size-text-xs, 12px);
-  color: var(--color-cga-brown);
+  color: var(--color-semantic-text-muted);
   text-decoration: none;
   transition: color var(--duration-fast, 100ms) ease-out;
 }
@@ -131,7 +131,7 @@
 }
 
 .eidotter-inline-expand__source-icon {
-  color: var(--color-cga-brown);
+  color: var(--color-semantic-text-muted);
   font-size: var(--typography-font-size-text-xs, 12px);
 }
 

--- a/src/components/Input/components/Input.tsx
+++ b/src/components/Input/components/Input.tsx
@@ -68,7 +68,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({
         {...props}
       />
       {description && !isInvalid && (
-        <AriaText slot="description" className="text-cga-brown font-dos text-xs">
+        <AriaText slot="description" className="text-dos-text-muted font-dos text-xs">
           {description}
         </AriaText>
       )}

--- a/src/components/Progress/components/Progress.css
+++ b/src/components/Progress/components/Progress.css
@@ -72,7 +72,7 @@
 }
 
 .eidotter-progress__empty {
-  color: var(--color-cga-brown);
+  color: var(--color-semantic-text-muted);
 }
 
 .eidotter-progress__transition {


### PR DESCRIPTION
## Summary
Follow-up to #291 — migrates every remaining muted-text reference from `--color-cga-brown` / `text-cga-brown` to the new `--color-semantic-text-muted` / `text-dos-text-muted` semantic introduced in v0.19.4.

Supersedes the earlier stacked #293 (auto-closed when its base branch `feat/ds-handoff-token-adoption` was deleted after #291 squashed into main).

## Scope (7 refs across 6 files)
- `src/components/Progress/components/Progress.css` — `.eidotter-progress__empty`
- `src/components/Chat/components/ChatMessage.css` — `.eidotter-chat-message--system`
- `src/components/InlineExpand/components/InlineExpand.css` — `.eidotter-inline-expand__source-link`, `__source-icon`
- `src/components/Footer/components/Footer.tsx` — separator dot + copyright
- `src/components/Chat/components/ChatHistory.tsx` — "Awaiting input..." empty state
- `src/components/Input/components/Input.tsx` — description slot

Intentionally untouched:
- `ProgressDocs.mdx:129` and `TagDocs.mdx:71` — historical references in documentation prose.
- `tokens.css` / `theme.*.css` — primitive `--color-cga-brown` still exists and remains exported; only its *usage as muted text* is migrated.

## Test plan
- [x] `npm test -- --testPathPatterns="Footer|Input|ChatHistory"` — 55/55 pass
- [ ] Visual check in Storybook — Footer copyright row, Input description slot, ChatHistory empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)