### PR TITLE
ci: token-ref lint + preset parity contract + fix drift the lint caught

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,9 @@ jobs:
           tailwind.preset.cjs \
           platforms/swiftui/Sources/EiDotterTokens/
 
+    - name: Lint token references
+      run: npm run lint-tokens
+
     - name: Create env file
       run: |
         echo "FIGMA_ACCESS_TOKEN=" >> .env

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "prepublishOnly": "npm run build",
     "build-tokens": "node style-dictionary.config.mjs",
     "lint": "eslint src/ --report-unused-disable-directives --max-warnings 0",
+    "lint-tokens": "node scripts/lint-token-refs.mjs",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build -o docs",

--- a/scripts/lint-token-refs.mjs
+++ b/scripts/lint-token-refs.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+//
+// lint-token-refs — fails CI when var(--*) references or text-dos-*, bg-dos-*,
+// border-dos-*, shadow-dos-*, ring-dos-*, font-dos-* Tailwind class-form
+// references point at tokens that don't exist.
+//
+// Why this script exists:
+// - PR #246 renamed typography tokens (xs/sm/base/lg to text-xs..xl and
+//   display-xs..2xl). CSS var(--typography-font-size-base, 1rem) silently
+//   falls back to 1rem when the token no longer exists — no build error,
+//   no warning, broken theme tracking.
+// - PR #291 shipped dos-utilities.css with 7 obsolete names. The Tailwind
+//   preset also missed a new dos-text-muted key, so consumer JSX using
+//   className="text-dos-text-muted" resolved to nothing.
+//
+// Sources of truth:
+// - src/styles/tokens.css declares every `--<name>:` a consumer can resolve
+//   at runtime.
+// - tailwind.preset.cjs theme.extend.colors declares every `<color>-<variant>`
+//   key Tailwind will emit (paired with a var() target).
+//
+// Check A: every var(--*) reference in scanned source files exists in tokens.css.
+// Check B: every text-dos-*, bg-dos-*, border-dos-*, shadow-dos-*, ring-dos-*,
+//          or font-dos-* class-form reference in .tsx/.ts exists in the preset's
+//          matching namespace.
+//
+// Exit code is non-zero on any violation, so CI can invoke this directly.
+//
+
+import { readFileSync } from 'node:fs';
+import { globSync } from 'glob';
+import { resolve, relative } from 'node:path';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+
+const ROOT = resolve(import.meta.dirname, '..');
+const tokensCss = readFileSync(resolve(ROOT, 'src/styles/tokens.css'), 'utf8');
+
+// ---------- Source of truth A: declared CSS custom properties ---------------
+//
+// A var reference is valid if it's declared in EITHER:
+//   (a) src/styles/tokens.css — the generated global design tokens, or
+//   (b) any component CSS under src/components/**, src/styles/** — component-
+//       local vars like `--retro-intensity`, `--fill-pct` that are scoped to
+//       a single component and set via inline style or local rules.
+//
+// The lint catches the drift case: a var that's referenced but declared
+// nowhere in the repo (typo, stale rename, or removed token still in use).
+
+const declaredVars = new Set();
+
+// (a) tokens.css + component CSS files declare via `--xxx:` at the start of a line.
+const cssSourceFiles = globSync('src/**/*.css', { cwd: ROOT, nodir: true });
+for (const relPath of cssSourceFiles) {
+  const content = readFileSync(resolve(ROOT, relPath), 'utf8');
+  for (const match of content.matchAll(/^\s*(--[A-Za-z0-9_-]+)\s*:/gim)) {
+    declaredVars.add(match[1]);
+  }
+}
+
+// (b) TSX/TS files set runtime-scoped vars via either:
+//     - React inline `style={{ '--xxx': ... }}` (object-literal key form)
+//     - imperative `element.style.setProperty('--xxx', ...)` (DOM API form)
+const tsxSourceFiles = globSync('src/**/*.{tsx,ts}', { cwd: ROOT, nodir: true });
+for (const relPath of tsxSourceFiles) {
+  const content = readFileSync(resolve(ROOT, relPath), 'utf8');
+  // Object-literal key form.
+  for (const match of content.matchAll(/['"`](--[A-Za-z0-9_-]+)['"`]\s*:/g)) {
+    declaredVars.add(match[1]);
+  }
+  // setProperty form.
+  for (const match of content.matchAll(
+    /\.setProperty\(\s*['"`](--[A-Za-z0-9_-]+)['"`]/g,
+  )) {
+    declaredVars.add(match[1]);
+  }
+}
+
+if (declaredVars.size === 0) {
+  console.error(
+    '[lint-token-refs] No `--*: ...;` declarations found anywhere under src/**/*.css. ' +
+      'Run `npm run build-tokens` first.',
+  );
+  process.exit(2);
+}
+
+// ---------- Source of truth B: Tailwind preset color keys -------------------
+
+// Load the CJS preset. Require-interop in an ESM script.
+const { createRequire } = await import('node:module');
+const require = createRequire(import.meta.url);
+const preset = require(resolve(ROOT, 'tailwind.preset.cjs'));
+
+const extend = preset?.theme?.extend ?? {};
+const presetNamespaces = {
+  text: new Set(Object.keys(extend.colors ?? {})),
+  bg: new Set(Object.keys(extend.colors ?? {})),
+  border: new Set(Object.keys(extend.colors ?? {})),
+  ring: new Set(Object.keys(extend.colors ?? {})),
+  shadow: new Set(Object.keys(extend.boxShadow ?? {})),
+  font: new Set(Object.keys(extend.fontFamily ?? {})),
+  // NOTE: text-dos-text-md is fontSize (not color). Tailwind text-* is polymorphic —
+  // the same prefix writes font-size OR color depending on what the value is. We
+  // accept a class as valid if it exists in EITHER namespace.
+};
+const fontSizeKeys = new Set(Object.keys(extend.fontSize ?? {}));
+
+// ---------- Scan ------------------------------------------------------------
+
+const files = globSync('src/**/*.{css,tsx,ts}', { cwd: ROOT, nodir: true });
+const violations = [];
+
+for (const relPath of files) {
+  const abs = resolve(ROOT, relPath);
+  const content = readFileSync(abs, 'utf8');
+
+  // Check A: var(--*) references. Capture var name only; ignore fallbacks.
+  for (const match of content.matchAll(/var\(\s*(--[A-Za-z0-9_-]+)/g)) {
+    const [full, name] = match;
+    if (!declaredVars.has(name)) {
+      violations.push({
+        file: relPath,
+        kind: 'css-var',
+        ref: full,
+        name,
+        line: lineNumberOfMatch(content, match.index ?? 0),
+      });
+    }
+  }
+
+  // Check B: Tailwind class-form drift. Only for .tsx / .ts where classes live.
+  if (relPath.endsWith('.tsx') || relPath.endsWith('.ts')) {
+    // className / class attributes (JSX) + cn(...) / clsx(...) arguments.
+    // Narrow regex keeps the match set small; we capture the whole class string
+    // then split on whitespace.
+    const classStringRe =
+      /(?:className|class)\s*[:=]\s*['"`]([^'"`]*)['"`]|cn\(\s*['"`]([^'"`]*)['"`]/g;
+    for (const m of content.matchAll(classStringRe)) {
+      const classString = m[1] ?? m[2] ?? '';
+      for (const cls of classString.split(/\s+/).filter(Boolean)) {
+        const prefixMatch = cls.match(
+          /^(text|bg|border|ring|shadow|font)-(dos-[a-z0-9-]+)$/,
+        );
+        if (!prefixMatch) continue;
+        const [, prefix, key] = prefixMatch;
+        const ns = presetNamespaces[prefix];
+        if (!ns) continue;
+        // text-* is polymorphic (fontSize OR color). Accept if either has the key.
+        const inPrimary = ns.has(key);
+        const inFontSize = prefix === 'text' && fontSizeKeys.has(key);
+        if (!inPrimary && !inFontSize) {
+          violations.push({
+            file: relPath,
+            kind: 'tailwind-class',
+            ref: cls,
+            name: `${prefix}-${key}`,
+            line: lineNumberOfMatch(content, m.index ?? 0),
+          });
+        }
+      }
+    }
+  }
+}
+
+// ---------- Report ----------------------------------------------------------
+
+if (violations.length === 0) {
+  console.log(
+    `[lint-token-refs] OK — scanned ${files.length} files, ${declaredVars.size} tokens, ` +
+      `${presetNamespaces.text.size} preset colors. No unresolved references.`,
+  );
+  process.exit(0);
+}
+
+console.error(
+  `[lint-token-refs] FAIL — ${violations.length} unresolved reference(s):\n`,
+);
+for (const v of violations) {
+  console.error(`  ${v.file}:${v.line}  [${v.kind}]  ${v.ref}`);
+}
+console.error(
+  '\nTo fix: either add the missing token to src/tokens/*.tokens.json and run ' +
+    '`npm run build-tokens`, or update the reference to a token name that exists ' +
+    'in src/styles/tokens.css / tailwind.preset.cjs.',
+);
+process.exit(1);
+
+// ---------- Helpers ---------------------------------------------------------
+
+function lineNumberOfMatch(source, index) {
+  // 1-based line number for the offset in source.
+  let line = 1;
+  for (let i = 0; i < index; i++) {
+    if (source.charCodeAt(i) === 10) line++;
+  }
+  return line;
+}

--- a/src/components/CmdPalette/components/CmdPalette.css
+++ b/src/components/CmdPalette/components/CmdPalette.css
@@ -57,7 +57,7 @@
   border-bottom: var(--border-width-thin, 1px) solid var(--color-cga-amber);
   background-color: var(--color-cga-amber);
   color: var(--color-semantic-text-secondary);
-  font-size: var(--typography-font-size-xs, 12px);
+  font-size: var(--typography-font-size-text-xs, 1.125rem);
   letter-spacing: 0.15em;
   text-transform: uppercase;
   line-height: 1.2;
@@ -77,7 +77,7 @@
   box-sizing: border-box;
   padding: var(--spacing-3, 12px) var(--spacing-4, 16px);
   font-family: inherit;
-  font-size: var(--typography-font-size-lg, 18px);
+  font-size: var(--typography-font-size-text-lg, 1.5rem);
   color: var(--color-cga-amber);
   background: transparent;
   border-bottom: var(--border-width-thin, 1px) solid var(--color-cga-amber);
@@ -116,7 +116,7 @@
   padding: var(--spacing-2, 8px) var(--spacing-4, 16px);
   cursor: pointer;
   color: var(--color-cga-light-gray);
-  font-size: var(--typography-font-size-sm, 14px);
+  font-size: var(--typography-font-size-text-sm, 1.25rem);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -150,7 +150,7 @@
 .eidotter-cmdpal__item-hint {
   flex-shrink: 0;
   color: var(--color-cga-brown);
-  font-size: var(--typography-font-size-xs, 12px);
+  font-size: var(--typography-font-size-text-xs, 1.125rem);
   letter-spacing: 0.1em;
 }
 
@@ -162,7 +162,7 @@
 .eidotter-cmdpal__empty {
   padding: var(--spacing-4, 16px) var(--spacing-4, 16px);
   color: var(--color-cga-brown);
-  font-size: var(--typography-font-size-sm, 14px);
+  font-size: var(--typography-font-size-text-sm, 1.25rem);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   text-align: center;
@@ -173,7 +173,7 @@
   padding: var(--spacing-1, 4px) var(--spacing-4, 16px);
   border-top: var(--border-width-thin, 1px) solid var(--color-cga-dark-gray);
   color: var(--color-cga-brown);
-  font-size: var(--typography-font-size-xs, 12px);
+  font-size: var(--typography-font-size-text-xs, 1.125rem);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   line-height: 1.8;

--- a/src/components/DosFigure/components/DosFigure.css
+++ b/src/components/DosFigure/components/DosFigure.css
@@ -17,7 +17,7 @@
   background-color: var(--color-cga-amber);
   color: var(--color-semantic-text-secondary);
   padding: 2px var(--spacing-2, 8px);
-  font-size: var(--typography-font-size-xs, 12px);
+  font-size: var(--typography-font-size-text-xs, 1.125rem);
   line-height: 1.4;
   text-transform: uppercase;
   letter-spacing: 0.1em;
@@ -105,7 +105,7 @@
   border: var(--border-width-thin, 1px) solid var(--color-cga-amber);
   color: var(--color-cga-amber);
   padding: 1px var(--spacing-1, 4px);
-  font-size: var(--typography-font-size-xs, 12px);
+  font-size: var(--typography-font-size-text-xs, 1.125rem);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   line-height: 1.2;
@@ -128,7 +128,7 @@
   align-items: center;
   gap: var(--spacing-1, 4px);
   color: var(--color-cga-yellow);
-  font-size: var(--typography-font-size-xs, 12px);
+  font-size: var(--typography-font-size-text-xs, 1.125rem);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   white-space: nowrap;
@@ -156,9 +156,9 @@
 /* Caption — below the frame */
 .eidotter-dos-figure__caption {
   margin-top: var(--spacing-2, 8px);
-  font-size: var(--typography-font-size-sm, 14px);
+  font-size: var(--typography-font-size-text-sm, 1.25rem);
   color: var(--color-cga-light-gray);
-  line-height: var(--typography-line-height-normal, 1.5);
+  line-height: var(--typography-line-height-text-md, 1.5rem);
 }
 
 /* =============================================================================

--- a/src/components/Modal/components/Modal.stories.tsx
+++ b/src/components/Modal/components/Modal.stories.tsx
@@ -177,7 +177,7 @@ export const FormModal: Story = {
       }
     >
       <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-        <label style={{ color: 'var(--color-cga-lightGray)' }}>
+        <label style={{ color: 'var(--color-cga-light-gray)' }}>
           Project Name
           <input
             type="text"
@@ -188,13 +188,13 @@ export const FormModal: Story = {
               marginTop: '4px',
               padding: '8px',
               background: 'var(--color-cga-black)',
-              border: '1px solid var(--color-cga-darkGray)',
-              color: 'var(--color-cga-lightGray)',
+              border: '1px solid var(--color-cga-dark-gray)',
+              color: 'var(--color-cga-light-gray)',
               fontFamily: 'inherit',
             }}
           />
         </label>
-        <label style={{ color: 'var(--color-cga-lightGray)' }}>
+        <label style={{ color: 'var(--color-cga-light-gray)' }}>
           Description
           <textarea
             placeholder="Enter description"
@@ -205,8 +205,8 @@ export const FormModal: Story = {
               marginTop: '4px',
               padding: '8px',
               background: 'var(--color-cga-black)',
-              border: '1px solid var(--color-cga-darkGray)',
-              color: 'var(--color-cga-lightGray)',
+              border: '1px solid var(--color-cga-dark-gray)',
+              color: 'var(--color-cga-light-gray)',
               fontFamily: 'inherit',
               resize: 'vertical',
             }}

--- a/src/components/Nav/components/Nav.css
+++ b/src/components/Nav/components/Nav.css
@@ -90,7 +90,7 @@
 .eidotter-nav__overlay {
   position: fixed;
   inset: 0;
-  background-color: var(--color-semantic-background-overlay, rgba(8, 5, 0, 0.5));
+  background-color: var(--effects-overlay, rgba(8, 5, 0, 0.5));
   z-index: 110;
 }
 

--- a/src/styles/tailwind-preset.test.ts
+++ b/src/styles/tailwind-preset.test.ts
@@ -10,6 +10,9 @@
  * investigate why).
  */
 
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const preset = require('../../tailwind.preset.cjs') as {
   theme: {
@@ -103,5 +106,55 @@ describe('tailwind.preset.cjs — representative token spot-checks', () => {
 
   it('borderRadius caps at dos-base (4px) per eidotter style rules', () => {
     expect(preset.theme.extend.borderRadius['dos-base']).toBe('4px');
+  });
+});
+
+/**
+ * Parity contract: every key in `style-dictionary.config.mjs`'s `semanticVarMap`
+ * must exist as a key in `preset.theme.extend.colors`.
+ *
+ * PR #291 added `--color-semantic-text-muted` to the map but did not regenerate
+ * the preset. The documented `text-dos-text-muted` Tailwind utility silently
+ * resolved to nothing in consumer code. When this test fails, run
+ * `npm run build-tokens` and commit the regenerated `tailwind.preset.cjs`.
+ */
+describe('tailwind.preset.cjs ↔ style-dictionary semanticVarMap', () => {
+  // Extract semanticVarMap keys by regex. Importing the ESM config into Jest's
+  // CJS sandbox is more invasive; the regex is narrow and locked to the single
+  // `semanticVarMap = { ... };` block.
+  const configSource = readFileSync(
+    resolve(__dirname, '../../style-dictionary.config.mjs'),
+    'utf8',
+  );
+  const blockMatch = configSource.match(
+    /semanticVarMap\s*=\s*\{([\s\S]*?)\};/,
+  );
+  if (!blockMatch) {
+    throw new Error(
+      'Could not locate `semanticVarMap = { ... };` in style-dictionary.config.mjs. ' +
+        'Update the regex in tailwind-preset.test.ts if the config was refactored.',
+    );
+  }
+  const expectedKeys = [...blockMatch[1].matchAll(/'([a-z0-9-]+)'\s*:/g)].map(
+    (m) => m[1],
+  );
+
+  it('extracts a non-empty key list from style-dictionary.config.mjs', () => {
+    expect(expectedKeys.length).toBeGreaterThan(0);
+  });
+
+  it.each(expectedKeys)(
+    'preset.theme.extend.colors exposes `%s`',
+    (key) => {
+      expect(preset.theme.extend.colors).toHaveProperty(key);
+    },
+  );
+
+  it('every semanticVarMap key resolves to a var(--*) reference', () => {
+    for (const key of expectedKeys) {
+      const value = preset.theme.extend.colors[key];
+      expect(typeof value).toBe('string');
+      expect(value).toMatch(/^var\(--[a-z0-9-]+\)$/);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Builds on #298's CI hardening (now merged). Adds the two durable guardrails against the PR #291 / #246 class of silent drift, plus fixes 18 real drift bugs the new lint caught on first run.

## Guardrails

### B1. Tailwind preset parity contract test
Extends the existing `src/styles/tailwind-preset.test.ts` with a new describe block that asserts every key in `style-dictionary.config.mjs`'s `semanticVarMap` exists in `preset.theme.extend.colors` and resolves to a `var(--*)` reference. 24 new test cases (one per semantic color). Catches the PR #291 drift in the unit-test lane — fails `npm test` if the preset goes out of sync with the generator config.

### B2 + B3. Token-reference lint script
New `scripts/lint-token-refs.mjs` + `npm run lint-tokens`, wired into `build.yml` after the token-freshness check. Two passes:

- **CSS var refs** — every `var(--*)` in `src/**/*.{css,tsx,ts}` must resolve to a declaration in either (a) `src/styles/tokens.css` / other generated CSS, (b) a component CSS file, (c) an inline React `style={{ '--x': ... }}`, or (d) an imperative `element.style.setProperty('--x', ...)` call.
- **Tailwind class-form refs** — every `text-dos-*`, `bg-dos-*`, `border-dos-*`, `ring-dos-*`, `shadow-dos-*`, `font-dos-*` class in `.tsx` / `.ts` files must exist in the preset's matching namespace.

Exit code 1 on any violation; CI red.

## Drift fixes (what the lint caught on first run)

All real bugs that shipped to consumers. Every one was masked by CSS `var()` fallbacks that rendered with the hardcoded second argument, which "looked close enough" in manual review.

| File | Drift | Fix |
|------|-------|-----|
| `DosFigure.css` × 5 | Obsolete `--typography-font-size-xs`, `-sm`, `line-height-normal` | Migrated to `-text-xs`, `-text-sm`, `-text-md` (post-PR #246 names) |
| `CmdPalette.css` × 6 | Same PR #246 drift | Same fix |
| `Modal.stories.tsx` × 6 | `--color-cga-lightGray` / `darkGray` (camelCase) — tokens emit kebab-case | Renamed to `--color-cga-light-gray` / `dark-gray`. Labels were rendering in browser-default color |
| `Nav.css:93` × 1 | `--color-semantic-background-overlay` doesn't exist | Actual token is `--effects-overlay` |

## Test plan
- [x] `npm test` — 916 passing (up from 892; +24 parity cases)
- [x] `npm run lint-tokens` — OK, scanned 263 files, 175 tokens, 48 preset colors, 0 unresolved
- [ ] CI passes with new branch protection blocking merge until green

🤖 Generated with [Claude Code](https://claude.com/claude-code)