### PR TITLE
docs+story: dos-utilities polish (C1+C2+C3)

### DIFF
--- a/solutions/best-practices/token-name-drift-hand-written-css-2026-04-23.md
+++ b/solutions/best-practices/token-name-drift-hand-written-css-2026-04-23.md
@@ -111,6 +111,7 @@ Treat a token rename as a **rename-refactor with repo-wide blast radius**, not a
 - **Tailwind classes don't reveal this.** `text-dos-text-md` is a Tailwind alias that resolves to a CSS variable reference. Tailwind doesn't know whether the variable is defined — it just emits the reference. So a broken token underlies a working-looking class. This is the Tailwind-preset twin of this problem.
 - **The linter is the only reliable catch.** Visual regression suites can catch visible breaks, but a muted-text color that's "slightly wrong" in an obscure corner will not be flagged by a snapshot diff. A lint step that proves every `var(--*)` resolves to a defined token is the only deterministic guardrail.
 - **ce:review caught this one, but ce:review doesn't run on every PR.** It's an on-demand review, not CI. A missed review means the drift ships.
+- **Contrast limits.** The default-theme resolution `--color-semantic-text-muted` = `#9A5700` on `#020003` has a contrast ratio of ~3.67:1 — passes WCAG AA-Large (3:1, applies at ≥18.66px / 24px unless bold) but fails AA-Normal (4.5:1). The `.dos-caption` (20px) and `.dos-label` (20px) utilities ride the AA-Large threshold. The `.dos-micro` (18px) is right at the boundary. Scope muted-text usage to non-critical supplementary copy (timestamps, counts, footnotes). Do not use muted for primary body text or any copy a user needs to read carefully.
 
 ## When to Apply
 
@@ -151,4 +152,4 @@ Treat a token rename as a **rename-refactor with repo-wide blast radius**, not a
 - PR #246: the typography rename that created the drift window
 - `solutions/workflow-issues/token-staleness-ci-check-2026-04-17.md`: sibling failure mode — generator didn't run at all (distinct from this one, where the generator ran but callsites were stale)
 - `solutions/developer-experience/deprecation-shim-pattern-2026-04-18.md`: the deprecation-alias pattern applied to subpath exports — same idea, different surface; this doc extends it to token-name aliases
-- `solutions/best-practices/v37-component-migration-patterns-2026-04-06.md`: documents the typography token scale before the rename
+- `solutions/best-practices/v37-component-migration-patterns-2026-04-06.md`: V.37 component patterns — token references updated to post-rename names in PR #297

--- a/src/components/Tokens/DosUtilities.stories.tsx
+++ b/src/components/Tokens/DosUtilities.stories.tsx
@@ -1,0 +1,188 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../styles/tokens.css';
+import '../../styles/dos-utilities.css';
+
+const meta = {
+  title: 'Design System/DOS Utilities',
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Visual reference for the 12 `.dos-*` classes shipped via the opt-in `eidotter/utilities` subpath (added in v0.19.4). ' +
+          'All classes resolve through the semantic + primitive design tokens, so they track the active theme automatically. ' +
+          'This story exists primarily as a visual regression baseline: a token rename that breaks any utility will show up here before it ships.',
+      },
+    },
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj;
+
+const allClasses = [
+  'dos-hero',
+  'dos-h1',
+  'dos-h2',
+  'dos-h3',
+  'dos-h4',
+  'dos-h5',
+  'dos-body',
+  'dos-body-lg',
+  'dos-caption',
+  'dos-micro',
+  'dos-label',
+  'dos-code',
+] as const;
+
+const SAMPLE_TEXT: Record<(typeof allClasses)[number], React.ReactNode> = {
+  'dos-hero': 'EIDOTTER',
+  'dos-h1': 'H1 — DISPLAY XL',
+  'dos-h2': 'H2 — DISPLAY LG',
+  'dos-h3': 'H3 — DISPLAY MD',
+  'dos-h4': 'H4 — DISPLAY SM',
+  'dos-h5': 'H5 — DISPLAY XS',
+  'dos-body':
+    'Body copy uses `--typography-font-size-text-md` (22px). Scoped for paragraph text in prose and MDX surfaces.',
+  'dos-body-lg':
+    'Body-lg uses `--typography-font-size-text-lg` (24px). Slightly larger for introductory or lead-in paragraphs.',
+  'dos-caption': 'CAPTION · 20PX · UPPERCASE',
+  'dos-micro': 'micro · 18px · muted · timestamps and footnotes',
+  'dos-label': 'LABEL · ACCENT COLOR',
+  'dos-code': 'DIR /W *.EXE',
+};
+
+const CLASS_ELEMENT: Record<(typeof allClasses)[number], 'p' | 'code' | 'span'> = {
+  'dos-hero': 'p',
+  'dos-h1': 'p',
+  'dos-h2': 'p',
+  'dos-h3': 'p',
+  'dos-h4': 'p',
+  'dos-h5': 'p',
+  'dos-body': 'p',
+  'dos-body-lg': 'p',
+  'dos-caption': 'p',
+  'dos-micro': 'p',
+  'dos-label': 'p',
+  'dos-code': 'code',
+};
+
+const UtilityRow: React.FC<{ className: (typeof allClasses)[number] }> = ({
+  className,
+}) => {
+  const Element = CLASS_ELEMENT[className];
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '12rem 1fr',
+        gap: '1rem',
+        alignItems: 'baseline',
+        padding: '0.75rem 0',
+        borderBottom: '1px solid var(--color-semantic-border-default)',
+      }}
+    >
+      <code
+        style={{
+          fontFamily: 'var(--typography-font-family-primary), monospace',
+          color: 'var(--color-semantic-text-muted)',
+          fontSize: 'var(--typography-font-size-text-sm)',
+        }}
+      >
+        .{className}
+      </code>
+      <Element className={className} style={{ margin: 0 }}>
+        {SAMPLE_TEXT[className]}
+      </Element>
+    </div>
+  );
+};
+
+export const AllUtilities: Story = {
+  render: () => (
+    <div
+      className="dos-page"
+      style={{ padding: '2rem', minHeight: '100vh' }}
+    >
+      <p
+        className="dos-label"
+        style={{ marginBottom: '1rem', color: 'var(--color-semantic-text-accent)' }}
+      >
+        EIDOTTER · UTILITIES · AMBER-MONO
+      </p>
+      {allClasses.map((cls) => (
+        <UtilityRow key={cls} className={cls} />
+      ))}
+      <div
+        className="dos-scanlines"
+        style={{
+          marginTop: '2rem',
+          height: '120px',
+          border: '1px solid var(--color-semantic-border-default)',
+          padding: '1rem',
+          color: 'var(--color-semantic-text-primary)',
+        }}
+      >
+        <code style={{ fontFamily: 'var(--typography-font-family-primary), monospace' }}>
+          .dos-scanlines — CRT overlay effect. Expects a dark parent surface.
+        </code>
+      </div>
+    </div>
+  ),
+};
+
+const themes = ['amber-mono', 'cga-amber', 'cga-mode4-p0', 'cga-mode4-p1', 'cga-mode5'] as const;
+
+const ThemeSample: React.FC<{ theme: (typeof themes)[number] }> = ({ theme }) => (
+  <div
+    data-theme={theme}
+    className="dos-page"
+    style={{
+      padding: '1.5rem',
+      border: '1px solid var(--color-semantic-border-default)',
+    }}
+  >
+    <p className="dos-label" style={{ margin: '0 0 1rem 0' }}>
+      {theme.toUpperCase()}
+    </p>
+    <p className="dos-h2" style={{ margin: '0 0 0.5rem 0' }}>
+      HEADING
+    </p>
+    <p className="dos-body" style={{ margin: '0 0 0.5rem 0' }}>
+      Body renders through semantic tokens. A theme switch changes the colour here.
+    </p>
+    <p className="dos-caption" style={{ margin: '0 0 0.5rem 0' }}>
+      CAPTION · MUTED COLOUR
+    </p>
+    <code className="dos-code">DIR /W</code>
+  </div>
+);
+
+export const ThemeGallery: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Same four utility classes rendered under each of the five shipped themes. Useful as a visual regression diff when touching tokens or the utilities sheet.',
+      },
+    },
+  },
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+        gap: '1rem',
+        padding: '2rem',
+        backgroundColor: 'var(--color-semantic-background-primary)',
+        minHeight: '100vh',
+      }}
+    >
+      {themes.map((t) => (
+        <ThemeSample key={t} theme={t} />
+      ))}
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary

Independent content polish from the post-v0.20.0 follow-ups plan. No load-bearing CI changes — ships whenever.

### C1. Contrast caveat
`solutions/best-practices/token-name-drift-hand-written-css-2026-04-23.md` — added a note under "Why This Matters" documenting that `--color-semantic-text-muted` at default theme is #9A5700 on #020003 ≈ 3.67:1. Passes WCAG AA-Large (3:1) but fails AA-Normal (4.5:1). Scope muted copy to non-critical supplementary text (timestamps, counts, footnotes).

### C2. Storybook story for `eidotter/utilities`
New `src/components/Tokens/DosUtilities.stories.tsx` with two stories:
- **All Utilities** — every one of the 12 `.dos-*` classes rendered once against canonical sample text.
- **Theme Gallery** — four representative utilities rendered side-by-side under all 5 themes (amber-mono, cga-amber, cga-mode4-p0, cga-mode4-p1, cga-mode5). Serves as visual regression baseline; any future token rename that breaks a utility shows up here before it ships.

See `.devjournal/sessions/eidotter-2026-04-23/artifacts/` for the canonical screenshots.

### C3. Trivial wording fix
Same doc's Related section — the cross-ref to `v37-component-migration-patterns` no longer says "documents the scale before the rename" (inaccurate after PR #297 updated it); now reflects current state.

## Test plan
- [x] `npm run lint-tokens` — clean (264 files, 175 tokens, 48 preset colors)
- [x] Manual Storybook visual check — all 12 classes render with expected theme-tracking colours (artifacts in devjournal)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)