### PR TITLE
chore(gitignore): ignore private scratch dirs (ideation/, .superpowers/, .context/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ opencode.jsonc
 
 # Internal/personal files (not for public)
 plans/
+ideation/
+.superpowers/
+.context/
 skill/
 references/
 eidotter archive/


### PR DESCRIPTION
## Summary

Add three paths to `.gitignore` that are used by Claude Code skills for private scratch content:

- `ideation/` — brainstorm docs and open ideation notes
- `.superpowers/` — superpowers skill specs and plans
- `.context/` — session scratch + temp artifacts

## Why

The eidotter repo is **public on GitHub**. Skill-generated content paths listed as "Storybook-safe" in `CLAUDE.md:210` (solutions/, plans/, ideation/, .superpowers/, .devjournal/) are safe from the Storybook build wipe — but that is not the same as safe from public exposure.

`plans/` and `.devjournal/` were already gitignored. `ideation/`, `.superpowers/`, and `.context/` were not — anything written there (including pricing/premium/brand exploration from the 2026-04-24 naming brainstorm) would commit accidentally on next `git add -A`.

Fix is a 3-line addition to the existing "Internal/personal files (not for public)" block.

## Test plan

- [ ] `git check-ignore -v ideation/` reports the gitignore rule
- [ ] `git check-ignore -v .superpowers/` reports the gitignore rule
- [ ] `git check-ignore -v .context/` reports the gitignore rule
- [ ] `git status` in any worktree with content in these paths shows nothing staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)