### PR TITLE
fix(header,command-prompt): transparent bg so components inherit page background (DMNC-608)

### DIFF
--- a/src/components/CommandPrompt/components/CommandPrompt.css
+++ b/src/components/CommandPrompt/components/CommandPrompt.css
@@ -3,7 +3,7 @@
   align-items: center;
   font-family: var(--typography-font-family-primary);
   font-size: var(--typography-font-size-text-md);
-  background: var(--color-semantic-background-primary);
+  background: transparent;
   color: var(--color-semantic-text-accent);
   padding: var(--spacing-2);
   max-width: 100%;

--- a/src/components/Header/components/Header.tsx
+++ b/src/components/Header/components/Header.tsx
@@ -53,7 +53,7 @@ export const Header = forwardRef<HTMLElement, HeaderProps>(({
         'flex items-center justify-between px-4 py-3 font-dos',
         'eidotter-header',
         variantClasses[variant],
-        sticky && 'sticky top-0 z-50',
+        sticky && 'sticky top-0 z-50 bg-dos-bg-primary',
         className,
       )}
       {...rest}


### PR DESCRIPTION
## Summary
- `CommandPrompt.css` — change `background` from `var(--color-semantic-background-primary)` to `transparent` so the `>` prompt inherits the page background instead of forcing the eidotter black
- `Header.tsx` — add `bg-dos-bg-primary` only when `sticky={true}` so sticky headers still cover scrolling content behind them, but non-sticky headers are transparent and inherit the host page's background

Header.css already has `.eidotter-header--retro { background-color: transparent }` on main, so that part of the original flamboyant-chatterjee branch is already shipped — this PR just ships the remaining CommandPrompt and conditional-sticky pieces.

Fixes the black-rectangle issue flagged in DMNC-608 where consumer sites with non-eidotter backgrounds saw an opaque block where the header or CommandPrompt rendered.

## Test plan
- [ ] `npm test` passes (Header + CommandPrompt test suites)
- [ ] Storybook Header + CommandPrompt stories render transparent on a colored host page background
- [ ] Sticky header still covers content scrolling behind it

## Origin
Cherry-picked from stale `claude/flamboyant-chatterjee` branch onto fresh branch off current main. Original authored 2026-04-23 by CinimoDY + Claude Sonnet 4.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)