### PR TITLE
chore: add .claude/launch.json for dmnc-online preview server

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,7 +4,7 @@
     {
       "name": "dmnc-online",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev", "--prefix", "D:/Coding/dmnc-online", "--", "--port", "5175"],
+      "runtimeArgs": ["run", "dev", "--prefix", "../dmnc-online", "--", "--port", "5175"],
       "port": 5175
     }
   ]

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dmnc-online",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev", "--prefix", "D:/Coding/dmnc-online", "--", "--port", "5175"],
+      "port": 5175
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds `.claude/launch.json` configuring the Claude Code preview server to run the dmnc-online Vite dev server on port 5175. Useful when working on eidotter components while previewing their adoption in the dmnc-online linktree site.

## ⚠️ Review caveats

1. **Absolute Windows path**: The file hard-codes `D:/Coding/dmnc-online` — this will not work on macOS or for collaborators whose checkout isn't at the same path. If we commit this to a public repo, we're betting that anyone needing it will edit the path locally.
2. **Personal dev-env exposure**: `eidotter` is public on GitHub. This file reveals local directory structure (`D:/Coding/`). Not a security risk but worth considering.
3. **Alternative**: Gitignore `.claude/launch.json` the way `.claude/settings.local.json` already is, and keep `launch.json` as a personal local-only file.

Recommendation: either merge as-is (accepting the Windows path assumption as documentation of one valid config) OR close this PR and gitignore the file instead. Your call.

## Test plan
- [ ] `.claude/launch.json` exists after checkout
- [ ] Running Claude Code preview from within eidotter starts the dmnc-online dev server on :5175

## Origin
Cherry-picked from stale `claude/affectionate-jemison` branch. Original authored 2026-04-23 by CinimoDY + Claude Sonnet 4.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)