### PR TITLE
chore(tsconfig): exclude src/icons from build compilation

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,5 +7,5 @@
     "outDir": "./dist"
   },
   "include": ["src"],
-  "exclude": ["**/*.test.tsx", "**/*.stories.tsx", "src/stories"]
+  "exclude": ["**/*.test.tsx", "**/*.stories.tsx", "src/stories", "src/icons"]
 }


### PR DESCRIPTION
## Summary
Mirrors the `src/icons` exclusion already present on `feat/tree-shakable-icons` back onto main. Safe no-op today (nothing to exclude); preventive guardrail for when developers pull the icon-WIP branch and switch back with orphan files in their working tree.

## Repro of the issue this prevents
1. Check out `feat/tree-shakable-icons`
2. Run `npm run generate-icons` → populates `src/icons/components/` with 1,172 pixel-art icon .tsx files + `index.ts` re-exporting all of them
3. `git switch main` → the 43 *tracked* icons get removed by git, but the other ~1,129 untracked .tsx files + `index.ts` remain
4. `npm run build` on main crashes in tsc — `index.ts` references component paths that aren't in the tsconfig's include set, or have mismatched exports

This surfaced today: consumers trying to refresh eidotter's `dist/` for v0.20.0 hit this exact error.

## Immediate workaround for users already stuck
```bash
rm -rf src/icons
npm run build
```

## Test plan
- [x] `npm run build` succeeds on main with the exclusion in place
- [x] `npm run build` also succeeds when someone has orphan `src/icons/` files in their working tree (because tsc now ignores them)

## Not in scope
- Deleting icons from anyone's local working tree — that's a user hygiene thing
- Changing `feat/tree-shakable-icons` — it already has this exclusion + its own `tsconfig.icons.json` for compiling icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)