### PR TITLE
feat(timeline): add renderEntry prop for pluggable content types

### DIFF
--- a/src/components/TimelineContainer/components/TimelineContainer.stories.tsx
+++ b/src/components/TimelineContainer/components/TimelineContainer.stories.tsx
@@ -234,7 +234,7 @@ export const CustomRenderEntry: Story = {
         <div
           style={{
             border: '2px solid var(--color-cga-amber)',
-            borderRadius: 'var(--radius-dos-base)',
+            borderRadius: 'var(--border-radius-base)',
             padding: 'var(--spacing-3)',
             marginBottom: 'var(--spacing-2)',
             background: 'var(--color-semantic-background-secondary)',

--- a/src/components/TimelineContainer/components/TimelineContainer.stories.tsx
+++ b/src/components/TimelineContainer/components/TimelineContainer.stories.tsx
@@ -216,3 +216,53 @@ const ControlledExample = () => {
 export const Controlled: Story = {
   render: () => <ControlledExample />,
 };
+
+/**
+ * `renderEntry` lets consumers swap the default `TimelineEntryCard` for any
+ * custom node — useful for blog posts, photos, or domain-specific layouts.
+ *
+ * The render context exposes `defaultRender()` so you can opt in per-entry:
+ * customise some entries while letting the rest fall through to the default
+ * card. Selection and expansion state are passed through unchanged.
+ */
+export const CustomRenderEntry: Story = {
+  args: {
+    entries: sampleEntries,
+    defaultZoomLevel: 'month',
+    renderEntry: (entry, ctx) =>
+      entry.type === 'milestone' ? (
+        <div
+          style={{
+            border: '2px solid var(--color-cga-amber)',
+            borderRadius: 'var(--radius-dos-base)',
+            padding: 'var(--spacing-3)',
+            marginBottom: 'var(--spacing-2)',
+            background: 'var(--color-semantic-background-secondary)',
+            boxShadow: ctx.isSelected ? 'var(--shadow-glow-md)' : 'none',
+          }}
+        >
+          <div
+            style={{
+              fontSize: 'var(--typography-font-size-text-xs)',
+              color: 'var(--color-cga-amber-dim)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.1em',
+              marginBottom: 'var(--spacing-1)',
+            }}
+          >
+            ★ MILESTONE
+          </div>
+          <div
+            style={{
+              fontSize: 'var(--typography-font-size-text-md)',
+              color: 'var(--color-cga-amber)',
+            }}
+          >
+            {entry.title}
+          </div>
+        </div>
+      ) : (
+        ctx.defaultRender()
+      ),
+  },
+};

--- a/src/components/TimelineContainer/components/TimelineContainer.test.tsx
+++ b/src/components/TimelineContainer/components/TimelineContainer.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { TimelineContainer } from './TimelineContainer';
-import type { TimelineEntry } from './types';
+import type { TimelineEntry, TimelineRenderEntry } from './types';
 
 const sampleEntries: TimelineEntry[] = [
   {
@@ -334,6 +334,129 @@ describe('TimelineContainer', () => {
 
       // Interactive mode shows zoom controls
       expect(screen.getByText('MONTH')).toBeInTheDocument();
+    });
+  });
+
+  describe('renderEntry prop', () => {
+    it('replaces the default card with a custom node', () => {
+      render(
+        <TimelineContainer
+          entries={sampleEntries}
+          defaultZoomLevel="month"
+          renderEntry={(entry) => (
+            <article data-testid={`custom-${entry.id}`}>{entry.title.toUpperCase()}</article>
+          )}
+        />
+      );
+
+      expect(screen.getByTestId('custom-1')).toBeInTheDocument();
+      expect(screen.getByText('ENTRY ONE')).toBeInTheDocument();
+      // Default trigger shouldn't render when overridden.
+      expect(screen.queryByRole('button', { name: /Entry One/ })).not.toBeInTheDocument();
+    });
+
+    it('passes selection and expansion state in context', () => {
+      const renderEntry = jest.fn<ReturnType<TimelineRenderEntry>, Parameters<TimelineRenderEntry>>((_entry, ctx) => (
+        <div data-selected={ctx.isSelected} data-expanded={ctx.isExpanded}>
+          marker
+        </div>
+      ));
+
+      render(
+        <TimelineContainer
+          entries={sampleEntries}
+          defaultZoomLevel="month"
+          selectedEntryId="2"
+          renderEntry={renderEntry}
+        />
+      );
+
+      const calls = renderEntry.mock.calls;
+      const selectedCall = calls.find(([entry]) => entry.id === '2');
+      const otherCall = calls.find(([entry]) => entry.id === '1');
+
+      expect(selectedCall?.[1]).toMatchObject({ isSelected: true, isExpanded: true });
+      expect(otherCall?.[1]).toMatchObject({ isSelected: false, isExpanded: false });
+    });
+
+    it('defaultRender returns the built-in card so consumers can opt-in per entry', () => {
+      render(
+        <TimelineContainer
+          entries={sampleEntries}
+          defaultZoomLevel="month"
+          renderEntry={(entry, ctx) =>
+            entry.type === 'milestone'
+              ? <div data-testid={`special-${entry.id}`}>Milestone: {entry.title}</div>
+              : ctx.defaultRender()
+          }
+        />
+      );
+
+      // Custom rendering for the milestone
+      expect(screen.getByTestId('special-2')).toBeInTheDocument();
+      // Default card for other entries — preserves the built-in trigger button
+      expect(screen.getByRole('button', { name: /Entry One/ })).toBeInTheDocument();
+    });
+
+    it('applies in hour view (always-expanded)', () => {
+      const renderEntry = jest.fn<ReturnType<TimelineRenderEntry>, Parameters<TimelineRenderEntry>>(() => <div>hour-custom</div>);
+
+      render(
+        <TimelineContainer
+          entries={sampleEntries}
+          defaultZoomLevel="hour"
+          renderEntry={renderEntry}
+        />
+      );
+
+      expect(renderEntry).toHaveBeenCalled();
+      // Hour view is always expanded
+      expect(renderEntry.mock.calls[0][1].isExpanded).toBe(true);
+    });
+
+    it('applies in day view', () => {
+      const renderEntry = jest.fn<ReturnType<TimelineRenderEntry>, Parameters<TimelineRenderEntry>>(() => <div>day-custom</div>);
+
+      render(
+        <TimelineContainer
+          entries={sampleEntries}
+          defaultZoomLevel="day"
+          renderEntry={renderEntry}
+        />
+      );
+
+      expect(renderEntry).toHaveBeenCalled();
+    });
+
+    it('applies in static mode and treats every entry as expanded', () => {
+      const renderEntry = jest.fn<ReturnType<TimelineRenderEntry>, Parameters<TimelineRenderEntry>>((entry) => (
+        <div data-testid={`static-${entry.id}`}>{entry.title}</div>
+      ));
+
+      render(
+        <TimelineContainer entries={sampleEntries} mode="static" renderEntry={renderEntry} />
+      );
+
+      expect(screen.getByTestId('static-1')).toBeInTheDocument();
+      expect(renderEntry).toHaveBeenCalledTimes(sampleEntries.length);
+      renderEntry.mock.calls.forEach(([, ctx]) => {
+        expect(ctx).toMatchObject({ isExpanded: true, isSelected: false });
+      });
+    });
+
+    it('does not affect year view (which renders bucket counts only)', () => {
+      const renderEntry = jest.fn<ReturnType<TimelineRenderEntry>, Parameters<TimelineRenderEntry>>(() => null);
+
+      render(
+        <TimelineContainer
+          entries={sampleEntries}
+          defaultZoomLevel="year"
+          renderEntry={renderEntry}
+        />
+      );
+
+      expect(renderEntry).not.toHaveBeenCalled();
+      expect(screen.getByText(/2 entries/)).toBeInTheDocument();
     });
   });
 });

--- a/src/components/TimelineContainer/components/TimelineContainer.tsx
+++ b/src/components/TimelineContainer/components/TimelineContainer.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '../../../utils/cn';
-import type { TimelineEntryData, ZoomLevel, DateBucket } from './types';
+import type { TimelineEntryData, TimelineRenderEntry, ZoomLevel, DateBucket } from './types';
 import { useDrillDown } from './useDrillDown';
 import { useSelection } from './useSelection';
 import { groupEntriesByZoom, filterBucketsByPeriod } from './timelineUtils';
@@ -67,6 +67,17 @@ export interface TimelineContainerProps extends React.HTMLAttributes<HTMLDivElem
    * @default true
    */
   keyboardShortcuts?: boolean;
+
+  /**
+   * Pluggable entry renderer. When provided, this is called for every entry
+   * in every zoom-level view (and in static mode) instead of rendering the
+   * built-in `TimelineEntryCard`. Return `context.defaultRender()` to keep
+   * the default card for some entries while customising others.
+   *
+   * Use this to render different card UIs per entry type — blog posts,
+   * photos, financial records, etc.
+   */
+  renderEntry?: TimelineRenderEntry;
 }
 
 /**
@@ -91,6 +102,7 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
   sortOrder = 'desc',
   scrollToZoom = true,
   keyboardShortcuts = true,
+  renderEntry,
   ...props
 }) => {
   const isStatic = mode === 'static';
@@ -292,14 +304,21 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
         ) : isStatic ? (
           <TimelineAxis>
             <div className="eidotter-timeline-container__static" role="list" aria-label="Timeline">
-              {sortedEntries.map((entry) => (
-                <div key={entry.id} className="eidotter-timeline-container__static-entry" role="listitem">
-                  <div className="timeline-view__node">
-                    <TimelineNode shape="circle" size="medium" variant="default" label={formatDate(entry.date)} labelPosition="right" />
-                  </div>
+              {sortedEntries.map((entry) => {
+                const defaultRender = () => (
                   <TimelineEntryCard entry={entry} isSelected={false} isExpanded={true} />
-                </div>
-              ))}
+                );
+                return (
+                  <div key={entry.id} className="eidotter-timeline-container__static-entry" role="listitem">
+                    <div className="timeline-view__node">
+                      <TimelineNode shape="circle" size="medium" variant="default" label={formatDate(entry.date)} labelPosition="right" />
+                    </div>
+                    {renderEntry
+                      ? renderEntry(entry, { isExpanded: true, isSelected: false, defaultRender })
+                      : defaultRender()}
+                  </div>
+                );
+              })}
             </div>
           </TimelineAxis>
         ) : buckets.length === 0 && currentPeriod ? (
@@ -317,6 +336,7 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
               selectedEntryId={selectedEntryId}
               onEntrySelect={toggle}
               onBucketClick={handleBucketClick}
+              renderEntry={renderEntry}
             />
           </TimelineAxis>
         )}

--- a/src/components/TimelineContainer/components/TimelineContent.tsx
+++ b/src/components/TimelineContainer/components/TimelineContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ZoomLevel, DateBucket } from './types';
+import type { ZoomLevel, DateBucket, TimelineRenderEntry } from './types';
 import { YearView, MonthView, DayView, HourView } from './views';
 
 export interface TimelineContentProps {
@@ -8,6 +8,7 @@ export interface TimelineContentProps {
   selectedEntryId: string | null;
   onEntrySelect?: (entryId: string) => void;
   onBucketClick?: (bucket: DateBucket) => void;
+  renderEntry?: TimelineRenderEntry;
 }
 
 /**
@@ -19,9 +20,11 @@ export const TimelineContent: React.FC<TimelineContentProps> = ({
   selectedEntryId,
   onEntrySelect,
   onBucketClick,
+  renderEntry,
 }) => {
   switch (zoomLevel) {
     case 'year':
+      // Year view shows bucket counts, not individual entries — renderEntry not applicable.
       return <YearView buckets={buckets} onBucketClick={onBucketClick} />;
     case 'month':
       return (
@@ -30,6 +33,7 @@ export const TimelineContent: React.FC<TimelineContentProps> = ({
           selectedEntryId={selectedEntryId}
           onEntrySelect={onEntrySelect}
           onBucketClick={onBucketClick}
+          renderEntry={renderEntry}
         />
       );
     case 'day':
@@ -38,6 +42,7 @@ export const TimelineContent: React.FC<TimelineContentProps> = ({
           buckets={buckets}
           selectedEntryId={selectedEntryId}
           onEntrySelect={onEntrySelect}
+          renderEntry={renderEntry}
         />
       );
     case 'hour':
@@ -46,6 +51,7 @@ export const TimelineContent: React.FC<TimelineContentProps> = ({
           buckets={buckets}
           selectedEntryId={selectedEntryId}
           onEntrySelect={onEntrySelect}
+          renderEntry={renderEntry}
         />
       );
     default: {

--- a/src/components/TimelineContainer/components/index.ts
+++ b/src/components/TimelineContainer/components/index.ts
@@ -1,5 +1,12 @@
 export { TimelineContainer } from './TimelineContainer';
 export type { TimelineContainerProps } from './TimelineContainer';
 export { ZOOM_LEVELS } from './types';
-export type { TimelineEntry, TimelineEntryData, DateBucket, ZoomLevel } from './types';
+export type {
+  TimelineEntry,
+  TimelineEntryData,
+  TimelineEntryRenderContext,
+  TimelineRenderEntry,
+  DateBucket,
+  ZoomLevel,
+} from './types';
 export type { DrillDownEntry, UseDrillDownReturn } from './useDrillDown';

--- a/src/components/TimelineContainer/components/types.ts
+++ b/src/components/TimelineContainer/components/types.ts
@@ -33,6 +33,29 @@ export interface TimelineEntryData {
  */
 export type TimelineEntry = TimelineEntryData;
 
+/**
+ * Context passed to a `renderEntry` function so consumers can decide how
+ * to render their custom entry, while still being able to fall back to
+ * the built-in `TimelineEntryCard` rendering when needed.
+ */
+export interface TimelineEntryRenderContext {
+  /** True when this entry is currently expanded (its content is visible). */
+  isExpanded: boolean;
+  /** True when this entry is the currently selected entry. */
+  isSelected: boolean;
+  /** Render the built-in `TimelineEntryCard` for this entry. */
+  defaultRender: () => ReactNode;
+}
+
+/**
+ * Pluggable entry renderer. Return `defaultRender()` to delegate back to the
+ * built-in card, or any custom ReactNode to take over the entry slot.
+ */
+export type TimelineRenderEntry = (
+  entry: TimelineEntryData,
+  context: TimelineEntryRenderContext,
+) => ReactNode;
+
 export interface DateBucket {
   /** Human-readable label, e.g. "2024", "March 2024", "Mar 15" */
   label: string;
@@ -52,4 +75,6 @@ export interface TimelineViewProps {
   selectedEntryId?: string | null;
   /** Callback when a bucket header is clicked (for drill-down) */
   onBucketClick?: (bucket: DateBucket) => void;
+  /** Optional pluggable entry renderer */
+  renderEntry?: TimelineRenderEntry;
 }

--- a/src/components/TimelineContainer/components/views/DayView.tsx
+++ b/src/components/TimelineContainer/components/views/DayView.tsx
@@ -12,6 +12,7 @@ export const DayView = React.memo<TimelineViewProps>(({
   buckets,
   selectedEntryId,
   onEntrySelect,
+  renderEntry,
 }) => {
   return (
     <div className="timeline-view timeline-view--day" role="list">
@@ -31,26 +32,35 @@ export const DayView = React.memo<TimelineViewProps>(({
             />
           </div>
           <div className="timeline-view__content">
-            {bucket.entries.map((entry) => (
-              <TimelineEntryCard
-                key={entry.id}
-                entry={entry}
-                isSelected={selectedEntryId === entry.id}
-                isExpanded={selectedEntryId === entry.id}
-                onSelect={onEntrySelect}
-                footer={
-                  entry.tags && entry.tags.length > 0 ? (
-                    <TagGroup gap="tight" aria-label={`Tags for ${entry.title}`}>
-                      {entry.tags.map((tag) => (
-                        <Tag key={tag} size="small" variant="outlined">
-                          {tag}
-                        </Tag>
-                      ))}
-                    </TagGroup>
-                  ) : undefined
-                }
-              />
-            ))}
+            {bucket.entries.map((entry) => {
+              const isSelected = selectedEntryId === entry.id;
+              const defaultRender = () => (
+                <TimelineEntryCard
+                  entry={entry}
+                  isSelected={isSelected}
+                  isExpanded={isSelected}
+                  onSelect={onEntrySelect}
+                  footer={
+                    entry.tags && entry.tags.length > 0 ? (
+                      <TagGroup gap="tight" aria-label={`Tags for ${entry.title}`}>
+                        {entry.tags.map((tag) => (
+                          <Tag key={tag} size="small" variant="outlined">
+                            {tag}
+                          </Tag>
+                        ))}
+                      </TagGroup>
+                    ) : undefined
+                  }
+                />
+              );
+              return (
+                <React.Fragment key={entry.id}>
+                  {renderEntry
+                    ? renderEntry(entry, { isExpanded: isSelected, isSelected, defaultRender })
+                    : defaultRender()}
+                </React.Fragment>
+              );
+            })}
           </div>
         </div>
       ))}

--- a/src/components/TimelineContainer/components/views/HourView.tsx
+++ b/src/components/TimelineContainer/components/views/HourView.tsx
@@ -14,6 +14,7 @@ export const HourView = React.memo<TimelineViewProps>(({
   buckets,
   selectedEntryId,
   onEntrySelect,
+  renderEntry,
 }) => {
   return (
     <div className="timeline-view timeline-view--hour" role="list">
@@ -33,43 +34,52 @@ export const HourView = React.memo<TimelineViewProps>(({
             />
           </div>
           <div className="timeline-view__content">
-            {bucket.entries.map((entry) => (
-              <TimelineEntryCard
-                key={entry.id}
-                entry={entry}
-                isSelected={selectedEntryId === entry.id}
-                isExpanded={true}
-                onSelect={onEntrySelect}
-                footer={
-                  <div className="timeline-view__entry-footer">
-                    {entry.tags && entry.tags.length > 0 && (
-                      <TagGroup gap="tight" aria-label={`Tags for ${entry.title}`}>
-                        {entry.tags.map((tag) => (
-                          <Tag key={tag} size="small" variant="outlined">
-                            {tag}
-                          </Tag>
-                        ))}
-                      </TagGroup>
-                    )}
-                    {entry.type && (
-                      <Badge variant="default" size="small">
-                        {entry.type}
-                      </Badge>
-                    )}
-                  </div>
-                }
-              >
-                <time
-                  className="timeline-view__timestamp"
-                  dateTime={entry.date}
+            {bucket.entries.map((entry) => {
+              const isSelected = selectedEntryId === entry.id;
+              const defaultRender = () => (
+                <TimelineEntryCard
+                  entry={entry}
+                  isSelected={isSelected}
+                  isExpanded={true}
+                  onSelect={onEntrySelect}
+                  footer={
+                    <div className="timeline-view__entry-footer">
+                      {entry.tags && entry.tags.length > 0 && (
+                        <TagGroup gap="tight" aria-label={`Tags for ${entry.title}`}>
+                          {entry.tags.map((tag) => (
+                            <Tag key={tag} size="small" variant="outlined">
+                              {tag}
+                            </Tag>
+                          ))}
+                        </TagGroup>
+                      )}
+                      {entry.type && (
+                        <Badge variant="default" size="small">
+                          {entry.type}
+                        </Badge>
+                      )}
+                    </div>
+                  }
                 >
-                  {formatTimestamp(entry.date)}
-                </time>
-                <div className="timeline-view__entry-content">
-                  {entry.content}
-                </div>
-              </TimelineEntryCard>
-            ))}
+                  <time
+                    className="timeline-view__timestamp"
+                    dateTime={entry.date}
+                  >
+                    {formatTimestamp(entry.date)}
+                  </time>
+                  <div className="timeline-view__entry-content">
+                    {entry.content}
+                  </div>
+                </TimelineEntryCard>
+              );
+              return (
+                <React.Fragment key={entry.id}>
+                  {renderEntry
+                    ? renderEntry(entry, { isExpanded: true, isSelected, defaultRender })
+                    : defaultRender()}
+                </React.Fragment>
+              );
+            })}
           </div>
         </div>
       ))}

--- a/src/components/TimelineContainer/components/views/MonthView.tsx
+++ b/src/components/TimelineContainer/components/views/MonthView.tsx
@@ -11,6 +11,7 @@ export const MonthView = React.memo<TimelineViewProps>(({
   selectedEntryId,
   onEntrySelect,
   onBucketClick,
+  renderEntry,
 }) => {
   return (
     <div className="timeline-view timeline-view--month" role="list">
@@ -31,15 +32,24 @@ export const MonthView = React.memo<TimelineViewProps>(({
             />
           </div>
           <div className="timeline-view__content">
-            {bucket.entries.map((entry) => (
-              <TimelineEntryCard
-                key={entry.id}
-                entry={entry}
-                isSelected={selectedEntryId === entry.id}
-                isExpanded={selectedEntryId === entry.id}
-                onSelect={onEntrySelect}
-              />
-            ))}
+            {bucket.entries.map((entry) => {
+              const isSelected = selectedEntryId === entry.id;
+              const defaultRender = () => (
+                <TimelineEntryCard
+                  entry={entry}
+                  isSelected={isSelected}
+                  isExpanded={isSelected}
+                  onSelect={onEntrySelect}
+                />
+              );
+              return (
+                <React.Fragment key={entry.id}>
+                  {renderEntry
+                    ? renderEntry(entry, { isExpanded: isSelected, isSelected, defaultRender })
+                    : defaultRender()}
+                </React.Fragment>
+              );
+            })}
           </div>
         </div>
       ))}

--- a/src/components/TimelineContainer/index.ts
+++ b/src/components/TimelineContainer/index.ts
@@ -1,3 +1,11 @@
 export { TimelineContainer } from './components';
-export type { TimelineContainerProps, TimelineEntry, TimelineEntryData, DateBucket, ZoomLevel } from './components';
+export type {
+  TimelineContainerProps,
+  TimelineEntry,
+  TimelineEntryData,
+  TimelineEntryRenderContext,
+  TimelineRenderEntry,
+  DateBucket,
+  ZoomLevel,
+} from './components';
 export { ZOOM_LEVELS } from './components';

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,15 @@ export type { SwitchProps } from './components/Switch';
 export type { BreadcrumbProps, BreadcrumbItem } from './components/Breadcrumb';
 export type { RetroEffectsProps, PowerState } from './components/RetroEffects';
 export type { TimelineNodeProps, TimelineNodeShape, TimelineNodeVariant } from './components/TimelineNode';
-export type { TimelineContainerProps, TimelineEntry, TimelineEntryData, DateBucket, ZoomLevel } from './components/TimelineContainer';
+export type {
+  TimelineContainerProps,
+  TimelineEntry,
+  TimelineEntryData,
+  TimelineEntryRenderContext,
+  TimelineRenderEntry,
+  DateBucket,
+  ZoomLevel,
+} from './components/TimelineContainer';
 export type { ModalProps } from './components/Modal';
 export type { StatProps } from './components/Stat';
 export type { FilterBarProps, FilterBarItem } from './components/FilterBar';


### PR DESCRIPTION
## Summary

Adds `renderEntry` to `TimelineContainer` so consumers can swap the default `TimelineEntryCard` for any custom node — blog posts, photos, financial records, anything domain-specific.

```tsx
<TimelineContainer
  entries={entries}
  renderEntry={(entry, ctx) =>
    entry.type === 'photo'
      ? <PhotoCard entry={entry} expanded={ctx.isExpanded} />
      : ctx.defaultRender()
  }
/>
```

The render context exposes `defaultRender()` so consumers can opt-in per-entry while letting the rest fall through to the default card. `isExpanded` and `isSelected` are passed through unchanged so custom cards stay in sync with selection state.

## What changed

- New `TimelineEntryRenderContext` and `TimelineRenderEntry` types in `types.ts`
- `renderEntry` threaded through `TimelineContainer` → `TimelineContent` → `MonthView`, `DayView`, `HourView`, plus the static-mode rendering path in `TimelineContainer`
- `YearView` intentionally skipped — it shows bucket counts, not individual entries
- New types exported from package surface (`eidotter`) and the `TimelineContainer` subpath
- 7 new tests covering: custom render replacement, context propagation (selected/expanded), `defaultRender()` fall-through, every applicable view (month, day, hour, static), and that year view does not invoke `renderEntry`
- New `CustomRenderEntry` Storybook story showing the milestone-as-special-card pattern

## Test plan
- [x] `npm test` — 942 / 942 pass (47 suites; 7 new)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — no new errors (pre-existing `@/components/registry` story-import errors unchanged)
- [x] `npm run build` — vite + tsc both green
- [ ] Visual: Storybook `Components/TimelineContainer/Custom Render Entry`

Closes DMNC-602. Unblocks DMNC-603 (feed mode) and DMNC-581 (adaptive content disclosure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)