### PR TITLE
chore(deps): ignore tailwindcss major-version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,12 @@ updates:
       prefix: "chore(deps)"
     labels:
       - "dependencies"
+    ignore:
+      # Tailwind v4 is a rewrite (CSS-first config, Oxide engine,
+      # tailwindcss-animate incompatible). Plan a deliberate migration
+      # via Linear; don't accept Dependabot bumps.
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]
     groups:
       # Group minor/patch updates together
       minor-and-patch:


### PR DESCRIPTION
## Summary

Adds a Dependabot \`ignore\` rule so we stop seeing weekly v3 → v4 PRs while we plan the actual Tailwind v4 migration.

Tailwind v4 isn't a bump — it's a rewrite (CSS-first config via \`@theme\`, Oxide content scanner, \`tailwindcss\` is no longer a PostCSS plugin, \`tailwindcss-animate\` incompatible). The realistic effort is 1–3 days plus visual regression on the published \`dist/eidotter.css\`. Research summary lives on PR #314.

Minor + patch bumps continue normally (the \`minor-and-patch\` group is unaffected).

## Follow-ups
- Open Linear issue: \"Migrate eidotter to Tailwind v4\"
- Close #314 with a comment pointing to that issue
- When the migration is scheduled, remove this ignore rule

## Test plan
- [x] YAML still parses (no syntax errors)
- Verify on next Dependabot run that no major-version Tailwind PR opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)