### PR TITLE
feat(timeline): add mode='feed' with pagination

### DIFF
--- a/src/components/TimelineContainer/components/TimelineContainer.css
+++ b/src/components/TimelineContainer/components/TimelineContainer.css
@@ -57,7 +57,7 @@
   margin-top: var(--spacing-4);
   padding: var(--spacing-3) var(--spacing-4);
   background: transparent;
-  border: 2px solid var(--color-semantic-border-default, var(--color-cga-amber));
+  border: 2px solid var(--color-cga-amber);
   border-radius: var(--border-radius-sm, 2px);
   color: var(--color-cga-amber);
   font-family: var(--typography-font-family-primary);

--- a/src/components/TimelineContainer/components/TimelineContainer.css
+++ b/src/components/TimelineContainer/components/TimelineContainer.css
@@ -58,7 +58,7 @@
   padding: var(--spacing-3) var(--spacing-4);
   background: transparent;
   border: 2px solid var(--color-semantic-border-default, var(--color-cga-amber));
-  border-radius: var(--radius-dos-sm, 2px);
+  border-radius: var(--border-radius-sm, 2px);
   color: var(--color-cga-amber);
   font-family: var(--typography-font-family-primary);
   font-size: var(--typography-font-size-text-md);

--- a/src/components/TimelineContainer/components/TimelineContainer.css
+++ b/src/components/TimelineContainer/components/TimelineContainer.css
@@ -36,3 +36,64 @@
   flex-direction: column;
   gap: var(--spacing-2);
 }
+
+/* Feed mode — paginated vertical list */
+.eidotter-timeline-container__feed {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.eidotter-timeline-container__feed-entry {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+/* LOAD MORE... button — DOS amber, full-width, phosphor glow on hover/focus */
+.eidotter-timeline-container__load-more {
+  display: block;
+  width: 100%;
+  margin-top: var(--spacing-4);
+  padding: var(--spacing-3) var(--spacing-4);
+  background: transparent;
+  border: 2px solid var(--color-semantic-border-default, var(--color-cga-amber));
+  border-radius: var(--radius-dos-sm, 2px);
+  color: var(--color-cga-amber);
+  font-family: var(--typography-font-family-primary);
+  font-size: var(--typography-font-size-text-md);
+  font-weight: 400;
+  letter-spacing: 0.1em;
+  text-align: center;
+  cursor: pointer;
+  transition: box-shadow var(--duration-normal, 200ms) ease,
+              border-color var(--duration-normal, 200ms) ease,
+              color var(--duration-normal, 200ms) ease;
+}
+
+.eidotter-timeline-container__load-more:hover,
+.eidotter-timeline-container__load-more:focus-visible {
+  border-color: var(--color-cga-amber);
+  color: var(--color-cga-amber);
+  box-shadow: var(--shadow-glow-md, 0 0 8px rgba(255, 176, 0, 0.6));
+  outline: none;
+}
+
+.eidotter-timeline-container__load-more:active {
+  box-shadow: var(--shadow-glow-sm, 0 0 4px rgba(255, 176, 0, 0.4));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .eidotter-timeline-container__load-more {
+    transition: none;
+  }
+}
+
+@media (prefers-contrast: high) {
+  .eidotter-timeline-container__load-more,
+  .eidotter-timeline-container__load-more:hover,
+  .eidotter-timeline-container__load-more:focus-visible {
+    box-shadow: none;
+    text-decoration: underline;
+  }
+}

--- a/src/components/TimelineContainer/components/TimelineContainer.stories.tsx
+++ b/src/components/TimelineContainer/components/TimelineContainer.stories.tsx
@@ -137,6 +137,61 @@ export const StaticMode: Story = {
   },
 };
 
+const feedEntries: TimelineEntry[] = Array.from({ length: 25 }, (_, i) => ({
+  id: `feed-${i + 1}`,
+  type: (['event', 'milestone', 'project'] as const)[i % 3],
+  date: new Date(2025, 11 - (i % 12), 15 - (i % 14), 10 + (i % 8), 0).toISOString(),
+  title: `Update #${i + 1}`,
+  content: `Body copy for update #${i + 1}. Sample feed entry to demonstrate paginated rendering with collapse / expand on selection.`,
+  tags: i % 2 === 0 ? ['weekly'] : ['announcement'],
+}));
+
+/**
+ * Feed mode: paginated vertical list, collapsed-by-default with click-to-expand
+ * via selection, and a DOS-styled "LOAD MORE..." button while more entries are
+ * available. No zoom controls. Use this when you want a Twitter / changelog-
+ * style read of a single chronological list rather than a multi-zoom timeline.
+ */
+export const FeedMode: Story = {
+  args: {
+    entries: feedEntries,
+    mode: 'feed',
+    pageSize: 5,
+  },
+};
+
+const FeedModeOnLoadMoreExample = () => {
+  const [loadCount, setLoadCount] = useState(0);
+  return (
+    <div>
+      <div
+        style={{
+          color: 'var(--color-cga-amber)',
+          fontFamily: 'var(--typography-font-family-primary)',
+          fontSize: 'var(--typography-font-size-text-sm)',
+          marginBottom: 'var(--spacing-4)',
+        }}
+      >
+        onLoadMore fired: {loadCount} {loadCount === 1 ? 'time' : 'times'}
+      </div>
+      <TimelineContainer
+        entries={feedEntries}
+        mode="feed"
+        pageSize={5}
+        onLoadMore={() => setLoadCount((n) => n + 1)}
+      />
+    </div>
+  );
+};
+
+/**
+ * `onLoadMore` fires after each LOAD MORE click with the new visible count.
+ * Use it to trigger backend fetches and append to `entries`, or for analytics.
+ */
+export const FeedModeWithOnLoadMore: Story = {
+  render: () => <FeedModeOnLoadMoreExample />,
+};
+
 export const Ascending: Story = {
   args: {
     entries: sampleEntries,

--- a/src/components/TimelineContainer/components/TimelineContainer.test.tsx
+++ b/src/components/TimelineContainer/components/TimelineContainer.test.tsx
@@ -459,4 +459,176 @@ describe('TimelineContainer', () => {
       expect(screen.getByText(/2 entries/)).toBeInTheDocument();
     });
   });
+
+  describe('feed mode', () => {
+    const manyEntries: TimelineEntry[] = Array.from({ length: 25 }, (_, i) => ({
+      id: `entry-${i + 1}`,
+      type: 'event' as const,
+      date: `2025-${String(((i % 12) + 1)).padStart(2, '0')}-15T10:00:00Z`,
+      title: `Entry ${i + 1}`,
+      content: `Content for entry ${i + 1}`,
+    }));
+
+    it('shows only the first pageSize entries by default', () => {
+      render(<TimelineContainer entries={manyEntries} mode="feed" pageSize={5} />);
+      // Sorted desc by date — 25 entries spanning 2025-01 to 2025-01 (cycles through months)
+      // Just assert exactly 5 cards rendered, regardless of which.
+      const cards = document.querySelectorAll('.eidotter-timeline-container__feed-entry');
+      expect(cards).toHaveLength(5);
+    });
+
+    it('uses default pageSize of 10 when not specified', () => {
+      render(<TimelineContainer entries={manyEntries} mode="feed" />);
+      const cards = document.querySelectorAll('.eidotter-timeline-container__feed-entry');
+      expect(cards).toHaveLength(10);
+    });
+
+    it('shows LOAD MORE button when more entries exist', () => {
+      render(<TimelineContainer entries={manyEntries} mode="feed" pageSize={5} />);
+      expect(screen.getByRole('button', { name: /Load more entries/ })).toBeInTheDocument();
+    });
+
+    it('hides LOAD MORE button when all entries are visible', () => {
+      render(<TimelineContainer entries={manyEntries.slice(0, 3)} mode="feed" pageSize={5} />);
+      expect(screen.queryByRole('button', { name: /Load more entries/ })).not.toBeInTheDocument();
+    });
+
+    it('expands visible entries by pageSize when LOAD MORE clicked', () => {
+      render(<TimelineContainer entries={manyEntries} mode="feed" pageSize={5} />);
+
+      expect(document.querySelectorAll('.eidotter-timeline-container__feed-entry')).toHaveLength(5);
+
+      fireEvent.click(screen.getByRole('button', { name: /Load more entries/ }));
+      expect(document.querySelectorAll('.eidotter-timeline-container__feed-entry')).toHaveLength(10);
+
+      fireEvent.click(screen.getByRole('button', { name: /Load more entries/ }));
+      expect(document.querySelectorAll('.eidotter-timeline-container__feed-entry')).toHaveLength(15);
+    });
+
+    it('caps visible count at total entries (no over-fetch)', () => {
+      render(<TimelineContainer entries={manyEntries.slice(0, 7)} mode="feed" pageSize={5} />);
+
+      expect(document.querySelectorAll('.eidotter-timeline-container__feed-entry')).toHaveLength(5);
+      fireEvent.click(screen.getByRole('button', { name: /Load more entries/ }));
+
+      expect(document.querySelectorAll('.eidotter-timeline-container__feed-entry')).toHaveLength(7);
+      // After loading all, button disappears
+      expect(screen.queryByRole('button', { name: /Load more entries/ })).not.toBeInTheDocument();
+    });
+
+    it('fires onLoadMore with the new visible count', () => {
+      const onLoadMore = jest.fn();
+      render(
+        <TimelineContainer
+          entries={manyEntries}
+          mode="feed"
+          pageSize={5}
+          onLoadMore={onLoadMore}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /Load more entries/ }));
+      expect(onLoadMore).toHaveBeenCalledWith(10);
+
+      fireEvent.click(screen.getByRole('button', { name: /Load more entries/ }));
+      expect(onLoadMore).toHaveBeenCalledWith(15);
+    });
+
+    it('hides zoom controls', () => {
+      render(<TimelineContainer entries={manyEntries} mode="feed" />);
+      expect(screen.queryByRole('toolbar', { name: /zoom/i })).not.toBeInTheDocument();
+    });
+
+    it('toggles entry expansion on click', () => {
+      const onSelectEntry = jest.fn();
+      render(
+        <TimelineContainer
+          entries={manyEntries.slice(0, 3)}
+          mode="feed"
+          onSelectEntry={onSelectEntry}
+        />
+      );
+      const trigger = document.querySelector('.eidotter-timeline-card__trigger');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+      fireEvent.click(trigger!);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(onSelectEntry).toHaveBeenCalled();
+    });
+
+    it('uses renderEntry when provided', () => {
+      const renderEntry = jest.fn<ReturnType<TimelineRenderEntry>, Parameters<TimelineRenderEntry>>(
+        (entry) => <div data-testid={`feed-${entry.id}`}>{entry.title}</div>
+      );
+
+      render(
+        <TimelineContainer
+          entries={manyEntries}
+          mode="feed"
+          pageSize={3}
+          renderEntry={renderEntry}
+        />
+      );
+
+      expect(renderEntry).toHaveBeenCalledTimes(3);
+      expect(screen.getAllByTestId(/^feed-/)).toHaveLength(3);
+    });
+
+    it('renderEntry context reflects selection state in feed mode', () => {
+      const renderEntry = jest.fn<ReturnType<TimelineRenderEntry>, Parameters<TimelineRenderEntry>>(
+        (entry, ctx) => (
+          <div data-testid={`feed-${entry.id}`} data-selected={ctx.isSelected}>
+            {entry.title}
+          </div>
+        )
+      );
+
+      render(
+        <TimelineContainer
+          entries={manyEntries.slice(0, 3)}
+          mode="feed"
+          renderEntry={renderEntry}
+          selectedEntryId="entry-2"
+        />
+      );
+
+      const calls = renderEntry.mock.calls;
+      const selectedCall = calls.find(([entry]) => entry.id === 'entry-2');
+      expect(selectedCall?.[1]).toMatchObject({ isSelected: true, isExpanded: true });
+    });
+
+    it('resets pagination when entries change', () => {
+      const { rerender } = render(
+        <TimelineContainer entries={manyEntries} mode="feed" pageSize={5} />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /Load more entries/ }));
+      expect(document.querySelectorAll('.eidotter-timeline-container__feed-entry')).toHaveLength(10);
+
+      // Swap to a new, shorter list — pagination should reset to pageSize
+      rerender(
+        <TimelineContainer entries={manyEntries.slice(0, 8)} mode="feed" pageSize={5} />
+      );
+      expect(document.querySelectorAll('.eidotter-timeline-container__feed-entry')).toHaveLength(5);
+    });
+
+    it('respects sortOrder', () => {
+      const dated: TimelineEntry[] = [
+        { id: 'a', date: '2025-01-01', title: 'Oldest' },
+        { id: 'b', date: '2025-06-01', title: 'Middle' },
+        { id: 'c', date: '2025-12-01', title: 'Newest' },
+      ];
+
+      const { rerender } = render(
+        <TimelineContainer entries={dated} mode="feed" pageSize={2} sortOrder="desc" />
+      );
+      // desc → Newest first
+      let cards = document.querySelectorAll('.eidotter-timeline-card__title');
+      expect(cards[0]).toHaveTextContent('Newest');
+
+      rerender(<TimelineContainer entries={dated} mode="feed" pageSize={2} sortOrder="asc" />);
+      cards = document.querySelectorAll('.eidotter-timeline-card__title');
+      expect(cards[0]).toHaveTextContent('Oldest');
+    });
+  });
 });

--- a/src/components/TimelineContainer/components/TimelineContainer.test.tsx
+++ b/src/components/TimelineContainer/components/TimelineContainer.test.tsx
@@ -597,7 +597,7 @@ describe('TimelineContainer', () => {
       expect(selectedCall?.[1]).toMatchObject({ isSelected: true, isExpanded: true });
     });
 
-    it('resets pagination when entries change', () => {
+    it('clamps visibleCount when entries shrink below it', () => {
       const { rerender } = render(
         <TimelineContainer entries={manyEntries} mode="feed" pageSize={5} />
       );
@@ -605,11 +605,57 @@ describe('TimelineContainer', () => {
       fireEvent.click(screen.getByRole('button', { name: /Load more entries/ }));
       expect(document.querySelectorAll('.eidotter-timeline-container__feed-entry')).toHaveLength(10);
 
-      // Swap to a new, shorter list — pagination should reset to pageSize
+      // Swap to a list shorter than current visibleCount → clamp to new length
       rerender(
-        <TimelineContainer entries={manyEntries.slice(0, 8)} mode="feed" pageSize={5} />
+        <TimelineContainer entries={manyEntries.slice(0, 7)} mode="feed" pageSize={5} />
       );
+      expect(document.querySelectorAll('.eidotter-timeline-container__feed-entry')).toHaveLength(7);
+    });
+
+    it('preserves visibleCount when entries grow (backend-pagination append flow)', () => {
+      const initial = manyEntries.slice(0, 5);
+      const { rerender } = render(
+        <TimelineContainer entries={initial} mode="feed" pageSize={5} />
+      );
+
+      // Initial: 5 of 5 visible, no LOAD MORE button
       expect(document.querySelectorAll('.eidotter-timeline-container__feed-entry')).toHaveLength(5);
+      expect(screen.queryByRole('button', { name: /Load more entries/ })).not.toBeInTheDocument();
+
+      // Consumer fetches next batch and appends → entries grows from 5 to 15.
+      // visibleCount stays at 5 (the previously visible entries don't get hidden,
+      // the new entries don't get auto-shown — LOAD MORE re-appears).
+      const expanded = manyEntries.slice(0, 15);
+      rerender(<TimelineContainer entries={expanded} mode="feed" pageSize={5} />);
+
+      expect(document.querySelectorAll('.eidotter-timeline-container__feed-entry')).toHaveLength(5);
+      expect(screen.getByRole('button', { name: /Load more entries/ })).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: /Load more entries/ }));
+      expect(document.querySelectorAll('.eidotter-timeline-container__feed-entry')).toHaveLength(10);
+    });
+
+    it('clamps pageSize=0 to 1 to avoid infinite LOAD MORE loop', () => {
+      render(<TimelineContainer entries={manyEntries} mode="feed" pageSize={0} />);
+      // safePageSize = 1, so 1 entry visible
+      expect(document.querySelectorAll('.eidotter-timeline-container__feed-entry')).toHaveLength(1);
+      // Each click reveals exactly one more
+      fireEvent.click(screen.getByRole('button', { name: /Load more entries/ }));
+      expect(document.querySelectorAll('.eidotter-timeline-container__feed-entry')).toHaveLength(2);
+    });
+
+    it('does not fire onLoadMore when already at cap', () => {
+      const onLoadMore = jest.fn();
+      render(
+        <TimelineContainer
+          entries={manyEntries.slice(0, 5)}
+          mode="feed"
+          pageSize={5}
+          onLoadMore={onLoadMore}
+        />
+      );
+      expect(screen.queryByRole('button', { name: /Load more entries/ })).not.toBeInTheDocument();
+      expect(onLoadMore).not.toHaveBeenCalled();
     });
 
     it('respects sortOrder', () => {

--- a/src/components/TimelineContainer/components/TimelineContainer.tsx
+++ b/src/components/TimelineContainer/components/TimelineContainer.tsx
@@ -267,18 +267,26 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
     });
   }, [isVerticalFeed, entries, sortOrder]);
 
-  // Pagination for feed mode
-  const [visibleCount, setVisibleCount] = useState<number>(pageSize);
+  // Pagination for feed mode. Clamp pageSize at the boundary — pageSize=0 or
+  // negative would otherwise produce a permanent LOAD MORE button that never
+  // advances. Step is always ≥1.
+  const safePageSize = Math.max(1, pageSize);
+  const [visibleCount, setVisibleCount] = useState<number>(safePageSize);
 
-  // Reset pagination when entries change or pageSize changes — only relevant
-  // in feed mode, but guarded so other modes don't cause extra renders.
+  // Clamp visibleCount when entries shrink. Crucially, do NOT reset to
+  // pageSize when entries grow — consumers using `onLoadMore` to fetch and
+  // append the next batch (the documented backend-pagination flow) need
+  // visibleCount to stay where the user clicked. Reset to pageSize only
+  // happens when the new entries length is below the current visibleCount.
   useEffect(() => {
     if (!isFeed) return;
     setVisibleCount((prev) => {
-      const target = Math.min(pageSize, sortedEntries.length || pageSize);
-      return prev === target ? prev : target;
+      const max = sortedEntries.length;
+      if (max === 0) return safePageSize;
+      if (prev > max) return Math.max(safePageSize, max);
+      return prev;
     });
-  }, [isFeed, pageSize, sortedEntries.length]);
+  }, [isFeed, safePageSize, sortedEntries.length]);
 
   const visibleEntries = useMemo(
     () => (isFeed ? sortedEntries.slice(0, visibleCount) : sortedEntries),
@@ -288,12 +296,11 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
   const hasMore = isFeed && visibleCount < sortedEntries.length;
 
   const handleLoadMore = useCallback(() => {
-    setVisibleCount((prev) => {
-      const next = Math.min(prev + pageSize, sortedEntries.length);
-      onLoadMore?.(next);
-      return next;
-    });
-  }, [pageSize, sortedEntries.length, onLoadMore]);
+    const next = Math.min(visibleCount + safePageSize, sortedEntries.length);
+    if (next <= visibleCount) return; // already at cap — no-op, no callback
+    setVisibleCount(next);
+    onLoadMore?.(next);
+  }, [visibleCount, safePageSize, sortedEntries.length, onLoadMore]);
 
   const dateFormatter = useMemo(
     () => new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }),

--- a/src/components/TimelineContainer/components/TimelineContainer.tsx
+++ b/src/components/TimelineContainer/components/TimelineContainer.tsx
@@ -21,10 +21,13 @@ export interface TimelineContainerProps extends React.HTMLAttributes<HTMLDivElem
   /**
    * Display mode
    * - "interactive" (default): zoom controls, selection, keyboard shortcuts
-   * - "static": read-only vertical feed of expandable entries (replaces TimelineList)
+   * - "static": read-only vertical feed of always-expanded entries (replaces TimelineList)
+   * - "feed": paginated vertical list with collapsed-by-default entries that
+   *   expand on selection. Renders a DOS-style "LOAD MORE..." button while
+   *   more entries are available. No zoom controls.
    * @default 'interactive'
    */
-  mode?: 'interactive' | 'static';
+  mode?: 'interactive' | 'static' | 'feed';
 
   /**
    * Controlled zoom level — overrides internal state when provided.
@@ -70,14 +73,27 @@ export interface TimelineContainerProps extends React.HTMLAttributes<HTMLDivElem
 
   /**
    * Pluggable entry renderer. When provided, this is called for every entry
-   * in every zoom-level view (and in static mode) instead of rendering the
-   * built-in `TimelineEntryCard`. Return `context.defaultRender()` to keep
+   * in every zoom-level view (and in static / feed modes) instead of rendering
+   * the built-in `TimelineEntryCard`. Return `context.defaultRender()` to keep
    * the default card for some entries while customising others.
    *
    * Use this to render different card UIs per entry type — blog posts,
    * photos, financial records, etc.
    */
   renderEntry?: TimelineRenderEntry;
+
+  /**
+   * Number of entries to show per page in feed mode. Ignored for other modes.
+   * @default 10
+   */
+  pageSize?: number;
+
+  /**
+   * Fired in feed mode after the user clicks "LOAD MORE…", with the new total
+   * number of visible entries. Use this to fetch the next batch from a backend
+   * and append to `entries`, or for analytics.
+   */
+  onLoadMore?: (visibleCount: number) => void;
 }
 
 /**
@@ -103,9 +119,13 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
   scrollToZoom = true,
   keyboardShortcuts = true,
   renderEntry,
+  pageSize = 10,
+  onLoadMore,
   ...props
 }) => {
   const isStatic = mode === 'static';
+  const isFeed = mode === 'feed';
+  const isVerticalFeed = isStatic || isFeed;
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
 
@@ -158,7 +178,7 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
 
   // Scroll-to-zoom: Ctrl/Cmd + wheel (interactive mode only)
   useEffect(() => {
-    if (isStatic || !scrollToZoom) return;
+    if (isVerticalFeed || !scrollToZoom) return;
 
     const el = containerRef.current;
     if (!el) return;
@@ -187,11 +207,11 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
       el.removeEventListener('wheel', handleWheel);
       if (rafId !== null) cancelAnimationFrame(rafId);
     };
-  }, [isStatic, scrollToZoom, isDrillDownEnabled, canZoomIn, drillUp]);
+  }, [isVerticalFeed, scrollToZoom, isDrillDownEnabled, canZoomIn, drillUp]);
 
   // Keyboard shortcuts (interactive mode only)
   useEffect(() => {
-    if (isStatic || !keyboardShortcuts) return;
+    if (isVerticalFeed || !keyboardShortcuts) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (!containerRef.current?.contains(document.activeElement) &&
@@ -216,7 +236,7 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isStatic, keyboardShortcuts, drillUp, reset, deselect]);
+  }, [isVerticalFeed, keyboardShortcuts, drillUp, reset, deselect]);
 
   // Bucket click triggers drill-down
   const handleBucketClick = useCallback((bucket: DateBucket) => {
@@ -238,14 +258,42 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
     }
   }, [breadcrumbs.length]);
 
-  // Sort entries for static mode
+  // Sort entries for vertical-feed modes (static and feed)
   const sortedEntries = useMemo(() => {
-    if (!isStatic) return entries;
+    if (!isVerticalFeed) return entries;
     return [...entries].sort((a, b) => {
       const cmp = a.date.localeCompare(b.date);
       return sortOrder === 'desc' ? -cmp : cmp;
     });
-  }, [isStatic, entries, sortOrder]);
+  }, [isVerticalFeed, entries, sortOrder]);
+
+  // Pagination for feed mode
+  const [visibleCount, setVisibleCount] = useState<number>(pageSize);
+
+  // Reset pagination when entries change or pageSize changes — only relevant
+  // in feed mode, but guarded so other modes don't cause extra renders.
+  useEffect(() => {
+    if (!isFeed) return;
+    setVisibleCount((prev) => {
+      const target = Math.min(pageSize, sortedEntries.length || pageSize);
+      return prev === target ? prev : target;
+    });
+  }, [isFeed, pageSize, sortedEntries.length]);
+
+  const visibleEntries = useMemo(
+    () => (isFeed ? sortedEntries.slice(0, visibleCount) : sortedEntries),
+    [isFeed, sortedEntries, visibleCount],
+  );
+
+  const hasMore = isFeed && visibleCount < sortedEntries.length;
+
+  const handleLoadMore = useCallback(() => {
+    setVisibleCount((prev) => {
+      const next = Math.min(prev + pageSize, sortedEntries.length);
+      onLoadMore?.(next);
+      return next;
+    });
+  }, [pageSize, sortedEntries.length, onLoadMore]);
 
   const dateFormatter = useMemo(
     () => new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }),
@@ -265,18 +313,19 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
         'font-dos text-cga-amber bg-dos-bg-primary p-4 min-h-[200px]',
         'eidotter-timeline-container',
         isStatic && 'eidotter-timeline-container--static',
+        isFeed && 'eidotter-timeline-container--feed',
         props.className,
       )}
       role="region"
       aria-label={props['aria-label'] ?? 'Timeline'}
-      tabIndex={isStatic ? undefined : 0}
+      tabIndex={isVerticalFeed ? undefined : 0}
     >
       {/* Screen reader announcements for drill-down navigation */}
       <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
         {announcement}
       </div>
 
-      {!isStatic && (
+      {!isVerticalFeed && (
         <ZoomControls
           zoomLevel={zoomLevel}
           canZoomIn={canZoomIn}
@@ -320,6 +369,52 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
                 );
               })}
             </div>
+          </TimelineAxis>
+        ) : isFeed ? (
+          <TimelineAxis>
+            <div className="eidotter-timeline-container__feed" role="list" aria-label="Timeline">
+              {visibleEntries.map((entry) => {
+                const isSelected = selectedEntryId === entry.id;
+                const defaultRender = () => (
+                  <TimelineEntryCard
+                    entry={entry}
+                    isSelected={isSelected}
+                    isExpanded={isSelected}
+                    onSelect={toggle}
+                  />
+                );
+                return (
+                  <div
+                    key={entry.id}
+                    className="eidotter-timeline-container__feed-entry"
+                    role="listitem"
+                  >
+                    <div className="timeline-view__node">
+                      <TimelineNode
+                        shape="circle"
+                        size="medium"
+                        variant="default"
+                        label={formatDate(entry.date)}
+                        labelPosition="right"
+                      />
+                    </div>
+                    {renderEntry
+                      ? renderEntry(entry, { isExpanded: isSelected, isSelected, defaultRender })
+                      : defaultRender()}
+                  </div>
+                );
+              })}
+            </div>
+            {hasMore && (
+              <button
+                type="button"
+                className="eidotter-timeline-container__load-more"
+                onClick={handleLoadMore}
+                aria-label={`Load more entries (showing ${visibleCount} of ${sortedEntries.length})`}
+              >
+                LOAD MORE...
+              </button>
+            )}
           </TimelineAxis>
         ) : buckets.length === 0 && currentPeriod ? (
           <TimelineAxis>


### PR DESCRIPTION
## Summary

Adds `mode="feed"` to TimelineContainer: paginated vertical list, collapsed-by-default with click-to-expand on selection, DOS-styled LOAD MORE button, `pageSize` (default 10), and `onLoadMore(visibleCount)` callback. Composes with the `renderEntry` prop from #310 (now in main).

> Re-opened after #310 was squash-merged with `--delete-branch`, which auto-closed the original #311 because its base branch was deleted. This PR is the same content, rebased onto main with the duplicate #310 commits dropped.

## API

- `mode="feed"`
- `pageSize` (default `10`) — initial slice + LOAD MORE step size, clamped to ≥1
- `onLoadMore(visibleCount)` — fires once per click after a real advance; safe in StrictMode
- Pagination clamps when entries shrink, **preserves visibleCount when entries grow** (backend-pagination append flow works)
- Composes with `renderEntry` from #310 — `isSelected` / `isExpanded` reflect per-entry selection

## Adversarial review fixes baked in

This branch already incorporates the 4 fixes from the post-#310 adversarial review of this feature:
1. Append-flow no longer hidden by reset-on-length-change
2. `onLoadMore` no longer fires inside `setState` updater (was double-firing under StrictMode)
3. `pageSize=0` clamped to 1 (was infinite-loop button)
4. LOAD MORE border now reads amber (was resolving to gray)

## Tests

58 / 58 timeline tests pass, including new coverage for: append flow, pageSize=0 clamp, no-fire-at-cap, all original feed-mode behaviour.

## Closes

DMNC-603. Unblocks DMNC-581 (adaptive content disclosure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)