### PR TITLE
chore(release): 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0] - 2026-04-29
+
+Timeline overhaul Phase 2. Two new TimelineContainer capabilities for pluggable content + paginated reads. Purely additive — no breaking changes.
+
+### Added
+- **`renderEntry` prop on `<TimelineContainer>`** — pluggable entry renderer. Lets consumers swap the default `TimelineEntryCard` for any custom node (blog posts, photos, financial records, anything domain-specific). Render context exposes `defaultRender()` so consumers can opt in per-entry while letting the rest fall through to the default card. `isSelected` and `isExpanded` flow through unchanged so custom cards stay in sync with selection state. Threads through MonthView, DayView, HourView, and static-mode rendering. YearView is intentionally unaffected (renders bucket counts, not entries). New types `TimelineEntryRenderContext` and `TimelineRenderEntry` exported from the package surface and the `eidotter/components/TimelineContainer` subpath.
+- **`mode="feed"` on `<TimelineContainer>`** — paginated, expandable vertical-list mode for changelogs, devlogs, and notification feeds. Distinct from `static` (always-expanded, no pagination) and from `interactive` (multi-zoom, drill-down). Entries are collapsed by default; click-to-expand via selection. New props:
+  - `pageSize` (default `10`, clamped to ≥1) — initial slice + LOAD MORE step size.
+  - `onLoadMore(visibleCount)` — fires once per LOAD MORE click after a real advance; safe under React StrictMode.
+  - DOS-styled `LOAD MORE...` button with amber phosphor glow on hover/focus, with `prefers-reduced-motion` and `prefers-contrast: high` handling.
+  - Pagination clamps when entries shrink below the current visible count, but **preserves visibleCount when entries grow** — the documented backend-pagination append flow works correctly. Composes with `renderEntry`.
+- **Storybook stories**: `CustomRenderEntry` (milestone-as-special-card pattern), `FeedMode`, `FeedModeWithOnLoadMore` (analytics callback example).
+
+### Changed
+- `tailwindcss-animate` is currently incompatible with Tailwind v4. Dependabot is configured to ignore Tailwind major-version bumps until a deliberate v4 migration is planned (see `.github/dependabot.yml`).
+- Vite bumped from `^6.4.2` to `^8.0.10`. Verified `dist/*` parity against published `0.20.1`: 54 named exports identical; ES bundle ~16% smaller from Rolldown's tree-shaking; CSS and UMD output near-identical (±1%). Default browser baseline raised to Chrome 107+ / Safari 16+ / Firefox 104+.
+- PostCSS bumped from `8.5.10` to `8.5.12` (patch).
+
+### Fixed
+- Several feed-mode correctness issues caught in adversarial review before initial release:
+  - Append flow no longer hidden by reset-on-length-change.
+  - `onLoadMore` no longer fires inside the `setState` updater (was double-firing under StrictMode).
+  - `pageSize=0` clamped to 1 to avoid the LOAD MORE button advancing forever with no progress.
+  - LOAD MORE border now reads amber, not gray (was using a semantic token that resolved to light-gray).
+
+### Notes
+- 942 → 958 Jest tests (47 suites). 16 new tests across renderEntry (custom render replacement, context propagation, defaultRender fallthrough, all applicable views) and feed-mode pagination (append flow, pageSize=0 clamp, no-fire-at-cap, sortOrder, shrink-clamp).
+- No new top-level component exports — both features are extensions of the existing `<TimelineContainer>`. Component count remains 36.
+
 ## [0.20.1] - 2026-04-24
 
 First-class brand-mark components. Purely additive.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,9 +232,15 @@ eiDotter uses Untitled UI as a **pattern reference**, not a dependency. **No UTI
 - **Figma:** UTI Figma library is set up with eiDotter's DOS tokens. eiDotter's Figma file is the source of truth for component design.
 - **License rationale:** eidotter is published under CC-BY-NC-4.0. UTI Pro is a paid commercial license that does not permit sublicensing/redistribution. Bundling UTI Pro assets into `dist/eidotter.css` / `dist/index.es.js` would have been a license violation. Pixelarticons (MIT) avoids this entirely.
 
-## Current Component Status (v0.20.0, April 2026)
+## Current Component Status (v0.21.0, April 2026)
 
-**Components** (36): Accordion, Alert, Badge, Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, Modal, Nav, Notification, Progress, RetroEffects, Separator, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
+**Components** (36): Accordion, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, Modal, Nav, Notification, Progress, RetroEffects, Separator, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
+
+**v0.21.0 — Timeline overhaul Phase 2.** Two additive `<TimelineContainer>` capabilities, no new top-level components:
+- **`renderEntry` prop** — pluggable entry renderer with `defaultRender()` opt-in. Threads through MonthView, DayView, HourView, and static mode. New types: `TimelineEntryRenderContext`, `TimelineRenderEntry`.
+- **`mode="feed"`** — paginated vertical-list mode. New props: `pageSize` (default 10, ≥1), `onLoadMore(visibleCount)`. DOS-styled LOAD MORE button. Append-flow safe (visibleCount preserved when entries grow). Composes with `renderEntry`.
+
+Also: Vite bumped to `^8.0.10` (Rolldown bundler — verified `dist/*` parity, ES bundle ~16% smaller from better tree-shaking). Tailwind major-version bumps now ignored by Dependabot (v4 migration is a deliberate project, not a bump).
 
 **v0.20.0 — three new components from the April 2026 design handoff:** `<InlineLink>` (navigational anchor; rizomorf parity #03), `<DosFigure>` (demoscene media placeholder; rizomorf parity #02), `<CmdPalette>` (⌘K command palette). All built to the V.37 pattern (React Aria + Tailwind + CSS for phosphor).
 
@@ -333,7 +339,7 @@ See the workspace-level `CLAUDE.md` for the full project portfolio.
 
 - **text-secondary:** Only use `--color-semantic-text-secondary` / `text-dos-text-secondary` on amber/light backgrounds — it resolves to near-black (#020003)
 - **Generated files:** `tokens.css`, `tokens.js`, `tokens.json`, `tailwind.preset.cjs`, `theme.*.css`, `EiDotterTokens.swift` are generated — edit JSON sources in `src/tokens/` instead. CI enforces freshness: `build.yml` rebuilds tokens and fails if generated files don't match committed output. Run `npm run build-tokens` after editing token JSON sources.
-- **CI guardrails (post-v0.20.0):** `main` is branch-protected; `build (22.x)` must be green before merge (strict mode — CI re-runs on every HEAD). `build.yml` runs: token freshness check → `npm run lint-tokens` → build → `npm test` (916 suites) → build storybook. The token-ref lint (`scripts/lint-token-refs.mjs`) catches any `var(--*)` ref or `text-dos-*`/`bg-dos-*`/etc. Tailwind class that doesn't resolve to a declared token or preset key. The preset parity contract (`src/styles/tailwind-preset.test.ts`) asserts every `semanticVarMap` entry in `style-dictionary.config.mjs` has a matching `theme.extend.colors` key. Never add `--no-verify`, `--admin`, or force-push workarounds to bypass — fix the underlying drift.
+- **CI guardrails (post-v0.20.0):** `main` is branch-protected; `build (22.x)` must be green before merge (strict mode — CI re-runs on every HEAD). `build.yml` runs: token freshness check → `npm run lint-tokens` → build → `npm test` (958 tests) → build storybook. The token-ref lint (`scripts/lint-token-refs.mjs`) catches any `var(--*)` ref or `text-dos-*`/`bg-dos-*`/etc. Tailwind class that doesn't resolve to a declared token or preset key. The preset parity contract (`src/styles/tailwind-preset.test.ts`) asserts every `semanticVarMap` entry in `style-dictionary.config.mjs` has a matching `theme.extend.colors` key. Never add `--no-verify`, `--admin`, or force-push workarounds to bypass — fix the underlying drift.
 - **Linear project:** eiDotter issues go in project "eiDotter", team "dmnc"
 - **Storybook viewports:** Custom DOS viewports configured in `.storybook/preview.ts` (phone320, phone375, tablet768, desktop1024, ultrawide)
 - **Button sizes (V.37):** xs=24px, sm=28px, md=32px, lg=40px, xl=44px min-height. Old aliases (small/medium/large) still work. Button/Badge/Tag/Stat/Checkbox text uses `text-dos-text-*` (18–26px) or `text-dos-display-*` (30–78px) utilities — never hardcoded `text-[Npx]`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eidotter",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eidotter",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "license": "CC-BY-NC-4.0",
       "dependencies": {
         "pixelarticons": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,4 +104,4 @@ export type {
 } from './components/registry';
 
 // Version information
-export const version = '0.20.1';
+export const version = '0.21.0';


### PR DESCRIPTION
## Summary

Cuts the **0.21.0** release — Timeline overhaul Phase 2.

## Highlights

### Two new TimelineContainer capabilities
- **`renderEntry` prop** — pluggable per-entry renderer with `defaultRender()` opt-in. Threads through MonthView, DayView, HourView, and static mode. Year view is intentionally unaffected (counts, not entries). New types `TimelineEntryRenderContext` and `TimelineRenderEntry` exported from package surface and the `eidotter/components/TimelineContainer` subpath.
- **`mode="feed"`** — paginated, expandable vertical-list mode. New props: `pageSize` (default 10, clamped ≥1) and `onLoadMore(visibleCount)`. DOS-styled LOAD MORE button with phosphor glow + reduced-motion + high-contrast handling. Append-flow safe: `visibleCount` is preserved when entries grow (so the documented backend-pagination workflow works correctly). Composes with `renderEntry`.

### Dependency moves
- Vite `^6.4.2` → `^8.0.10`. Verified `dist/*` parity against published `0.20.1`: 54 named exports identical, ES bundle ~16% smaller from Rolldown's tree-shaking, CSS and UMD output near-identical (±1%). Browser baseline raised to Chrome 107+ / Safari 16+ / Firefox 104+.
- PostCSS `8.5.10` → `8.5.12` (patch).
- Dependabot now ignores Tailwind major-version bumps. Tailwind v4 is a deliberate migration project (CSS-first config, Oxide engine, `tailwindcss-animate` incompatible) — not a bump.

## Numbers
- Tests: 942 → **958** (47 suites). 16 new tests across renderEntry and feed mode.
- Components: 36 (unchanged — both new features are extensions of `<TimelineContainer>`).
- Bundle: ES `index.es.js` ~16% smaller, CSS and UMD essentially flat.

## Files

- `package.json`, `package-lock.json`, `src/index.ts` — version bumped to `0.21.0`
- `CHANGELOG.md` — new `[0.21.0]` entry at the top
- `CLAUDE.md` — Component Status section updated for v0.21.0

## Test plan
- [x] `npm test` — 958/958 pass
- [x] `npm run lint` — clean
- [x] `npm run build` — clean (vite + tsc)
- [x] `npm run lint-tokens` — clean (verified during fixes)
- [ ] Tag `v0.21.0` after merge
- [ ] `npm publish` (requires `npm login` — not pre-authenticated on this machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)