### PR TITLE
chore(claude): allow exit-code echo and dotfiles read

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -168,7 +168,9 @@
       "mcp__linear__list_issues",
       "mcp__linear__save_issue",
       "Bash(ls .context/compound-engineering/todos/)",
-      "Bash(ls todos/)"
+      "Bash(ls todos/)",
+      "Bash(echo \"---exit: $?---\")",
+      "Read(//mnt/d/Coding/dotfiles-repo/.claude/**)"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
## Summary
- Adds two entries to `.claude/settings.local.json` allowlist:
  - `Bash(echo "---exit: $?---")` — exit-code echo helper used during shell debugging
  - `Read(//mnt/d/Coding/dotfiles-repo/.claude/**)` — read access to dotfiles repo for settings inspection

## Test plan
- [x] JSON parses (verified via Python json.load)
- [ ] No side effects — pure permission allowlist additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)