### PR TITLE
fix(timeline): drop bg-dos-bg-primary from TimelineContainer root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **`<TimelineContainer>` no longer paints its own background.** The root `<div>` previously applied `bg-dos-bg-primary` unconditionally, forcing the page-background colour onto every host. It now inherits from its parent — consumers who relied on the implicit dark backdrop should wrap the timeline in a host element that sets the desired background. Aligns with the convention enforced by `<Alert>` and `<Notification>` (verified via regression test).
+
 ## [0.21.0] - 2026-04-29
 
 Timeline overhaul Phase 2. Two new TimelineContainer capabilities for pluggable content + paginated reads. Purely additive — no breaking changes.

--- a/src/components/TimelineContainer/components/TimelineContainer.stories.tsx
+++ b/src/components/TimelineContainer/components/TimelineContainer.stories.tsx
@@ -214,6 +214,24 @@ export const Empty: Story = {
   },
 };
 
+/**
+ * Verifies that TimelineContainer does not paint its own background.
+ * The component renders against a light backdrop (overridden via
+ * Storybook's `backgrounds` parameter) — if a `bg-dos-bg-primary`
+ * regression slips back in, this story will show a black box.
+ */
+export const OnLightBackdrop: Story = {
+  args: {
+    entries: sampleEntries,
+  },
+  parameters: {
+    backgrounds: {
+      default: 'light',
+      values: [{ name: 'light', value: '#FFE8A8' }],
+    },
+  },
+};
+
 export const SingleEntry: Story = {
   args: {
     entries: [sampleEntries[0]],

--- a/src/components/TimelineContainer/components/TimelineContainer.test.tsx
+++ b/src/components/TimelineContainer/components/TimelineContainer.test.tsx
@@ -49,6 +49,13 @@ describe('TimelineContainer', () => {
     expect(screen.getByText(/No entries found/)).toBeInTheDocument();
   });
 
+  it('does not impose a page background on its root', () => {
+    render(<TimelineContainer entries={sampleEntries} aria-label="Test timeline" />);
+    expect(screen.getByRole('region', { name: 'Test timeline' })).not.toHaveClass(
+      'bg-dos-bg-primary',
+    );
+  });
+
   it('renders zoom controls', () => {
     render(<TimelineContainer entries={sampleEntries} />);
     expect(screen.getByRole('toolbar', { name: /zoom/i })).toBeInTheDocument();

--- a/src/components/TimelineContainer/components/TimelineContainer.tsx
+++ b/src/components/TimelineContainer/components/TimelineContainer.tsx
@@ -317,7 +317,7 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
       ref={containerRef}
       {...props}
       className={cn(
-        'font-dos text-cga-amber bg-dos-bg-primary p-4 min-h-[200px]',
+        'font-dos text-cga-amber p-4 min-h-[200px]',
         'eidotter-timeline-container',
         isStatic && 'eidotter-timeline-container--static',
         isFeed && 'eidotter-timeline-container--feed',


### PR DESCRIPTION
## Summary
- TimelineContainer's root was unconditionally applying `bg-dos-bg-primary`, forcing the page-background colour onto every consumer regardless of host context.
- This violated the same convention Alert and Notification enforce via test (`.not.toHaveClass('bg-dos-bg-primary')`).
- Other timeline backgrounds were audited and confirmed intentional (axis line, node markers).

## Test plan
- [x] `npm test -- --testPathPatterns="TimelineContainer"` → 125/125 pass
- [ ] Storybook visual check — TimelineContainer in stories that don't set their own backdrop

🤖 Generated with [Claude Code](https://claude.com/claude-code)