### PR TITLE
feat(legal-page): LegalPage primitive + DDG/DSGVO clauses (DMNC-881)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,9 @@ eiDotter uses Untitled UI as a **pattern reference**, not a dependency. **No UTI
 
 ## Current Component Status (v0.21.0, April 2026)
 
-**Components** (36): Accordion, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, Modal, Nav, Notification, Progress, RetroEffects, Separator, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
+**Components** (37): Accordion, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Modal, Nav, Notification, Progress, RetroEffects, Separator, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
+
+**LegalPage (DMNC-881):** Layout primitive for Impressum / Datenschutz pages — `<h1>` + "Stand: …" date hero, optional intro, optional `home` slot (back-link), and styled body that targets `<h2>`/`<p>`/`<ul>`/`<address>` children directly. Compact 14-px scale codified locally rather than in global tokens (eidotter's `text-sm = 20px` is too big for legal-document body copy; portfolio sites were already overriding to 14 px). Ships alongside reusable German DDG/DSGVO clause components (`ImpressumAddress`, `ImpressumLiabilityContent`, `DatenschutzController`, `DatenschutzPostHog`, etc.) so consumers stop copy-pasting paragraph wording across surfaces.
 
 **v0.21.0 — Timeline overhaul Phase 2.** Two additive `<TimelineContainer>` capabilities, no new top-level components:
 - **`renderEntry` prop** — pluggable entry renderer with `defaultRender()` opt-in. Threads through MonthView, DayView, HourView, and static mode. New types: `TimelineEntryRenderContext`, `TimelineRenderEntry`.

--- a/src/components/LegalPage/components/LegalPage.css
+++ b/src/components/LegalPage/components/LegalPage.css
@@ -10,7 +10,7 @@
   min-height: 100vh;
   background: var(--color-semantic-background-primary);
   color: var(--color-semantic-text-primary);
-  font-family: var(--typography-font-family-mono, 'Flexi IBM VGA True', monospace);
+  font-family: var(--typography-font-family-primary);
   padding: 32px 24px 64px;
   max-width: 720px;
   margin: 0 auto;

--- a/src/components/LegalPage/components/LegalPage.css
+++ b/src/components/LegalPage/components/LegalPage.css
@@ -1,0 +1,131 @@
+/* LegalPage — compact-density layout for Impressum / Datenschutz pages.
+ *
+ * Sizing is hardcoded (12-24px) on purpose: the eidotter `text-sm = 20px`
+ * default is too big for legal-document body copy, and consumers were already
+ * deviating into local 14px overrides before this primitive existed. Keeping
+ * the scale local avoids polluting global tokens for a single use-case.
+ */
+
+.eidotter-legal-page {
+  min-height: 100vh;
+  background: var(--color-semantic-background-primary);
+  color: var(--color-semantic-text-primary);
+  font-family: var(--typography-font-family-mono, 'Flexi IBM VGA True', monospace);
+  padding: 32px 24px 64px;
+  max-width: 720px;
+  margin: 0 auto;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.eidotter-legal-page__home {
+  display: inline-block;
+  margin-bottom: 32px;
+}
+
+.eidotter-legal-page__home > a,
+.eidotter-legal-page__home > button {
+  color: var(--color-semantic-text-accent);
+  text-decoration: none;
+  font-size: 14px;
+  font-family: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.eidotter-legal-page__home > a:hover,
+.eidotter-legal-page__home > button:hover {
+  text-decoration: underline;
+}
+
+.eidotter-legal-page__hero {
+  text-align: center;
+  margin-bottom: 32px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--color-semantic-border-default);
+}
+
+.eidotter-legal-page__date {
+  font-size: 12px;
+  color: var(--color-semantic-text-accent);
+  margin-bottom: 8px;
+}
+
+.eidotter-legal-page__hero h1 {
+  font-size: 24px;
+  font-weight: 400;
+  color: var(--color-semantic-text-accent);
+  margin: 0 0 12px;
+  line-height: 1.2;
+}
+
+.eidotter-legal-page__intro {
+  font-size: 13px;
+  opacity: 0.7;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.eidotter-legal-page__body {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.eidotter-legal-page__body h2 {
+  margin-top: 32px;
+  margin-bottom: 12px;
+  font-size: 16px;
+  font-weight: 400;
+  color: var(--color-semantic-text-accent);
+}
+
+.eidotter-legal-page__body h2:first-child {
+  margin-top: 0;
+}
+
+.eidotter-legal-page__body p,
+.eidotter-legal-page__body ul {
+  margin: 0 0 12px;
+}
+
+.eidotter-legal-page__body ul {
+  padding-left: 16px;
+  list-style: none;
+}
+
+.eidotter-legal-page__body li {
+  margin-bottom: 4px;
+}
+
+.eidotter-legal-page__body li::before {
+  content: '> ';
+  color: var(--color-semantic-text-accent);
+}
+
+.eidotter-legal-page__body a {
+  color: var(--color-semantic-text-accent);
+  text-decoration: none;
+}
+
+.eidotter-legal-page__body a:hover {
+  text-decoration: underline;
+}
+
+.eidotter-legal-page__body address {
+  font-style: normal;
+  margin-bottom: 12px;
+}
+
+.eidotter-legal-page__body .eidotter-legal-page__basis {
+  font-size: 12px;
+  opacity: 0.6;
+  margin-top: 4px;
+}
+
+@media (max-width: 480px) {
+  .eidotter-legal-page {
+    padding: 24px 16px 48px;
+  }
+}

--- a/src/components/LegalPage/components/LegalPage.stories.tsx
+++ b/src/components/LegalPage/components/LegalPage.stories.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { LegalPage } from './LegalPage';
+import {
+  ImpressumAddress,
+  ImpressumContact,
+  ImpressumResponsible,
+  ImpressumLiabilityContent,
+  ImpressumLiabilityLinks,
+  DatenschutzController,
+  DatenschutzHosting,
+  DatenschutzPostHog,
+  DatenschutzFonts,
+  DatenschutzEncryption,
+  DatenschutzRights,
+} from './clauses';
+
+const meta = {
+  title: 'Components/LegalPage',
+  component: LegalPage,
+  parameters: {
+    layout: 'fullscreen',
+    backgrounds: {
+      default: 'dos',
+      values: [{ name: 'dos', value: '#000000' }],
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof LegalPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Impressum: Story = {
+  args: {
+    title: 'Impressum',
+    date: 'Stand: April 2026',
+    home: <a href="/">← Home</a>,
+    children: (
+      <>
+        <ImpressumAddress />
+        <ImpressumContact email="hello@example.com" />
+        <ImpressumResponsible />
+        <ImpressumLiabilityContent />
+        <ImpressumLiabilityLinks />
+      </>
+    ),
+  },
+};
+
+export const Datenschutz: Story = {
+  args: {
+    title: 'Datenschutzerklärung',
+    date: 'Stand: April 2026',
+    intro:
+      'Diese Erklärung beschreibt, welche Daten auf dieser Website erhoben und wie sie verwendet werden.',
+    home: <a href="/">← Home</a>,
+    children: (
+      <>
+        <DatenschutzController email="hello@example.com" />
+        <DatenschutzHosting />
+        <DatenschutzPostHog />
+        <DatenschutzFonts />
+        <DatenschutzEncryption />
+        <DatenschutzRights email="hello@example.com" />
+      </>
+    ),
+  },
+};
+
+export const WithoutBackLink: Story = {
+  args: {
+    title: 'Impressum',
+    date: 'Stand: April 2026',
+    children: (
+      <>
+        <ImpressumAddress />
+        <ImpressumContact email="hello@example.com" />
+        <ImpressumLiabilityContent />
+      </>
+    ),
+  },
+};
+
+export const FreeformBody: Story = {
+  args: {
+    title: 'About this page',
+    date: 'Stand: April 2026',
+    intro: 'A short example showing freeform body content rather than canned clauses.',
+    children: (
+      <>
+        <h2>Section A</h2>
+        <p>The body styles work for any h2 + p + ul content, not just the canned clauses.</p>
+        <h2>Section B</h2>
+        <ul>
+          <li>List items render with a DOS-style "&gt;" bullet.</li>
+          <li>List spacing matches paragraph rhythm.</li>
+        </ul>
+      </>
+    ),
+  },
+};

--- a/src/components/LegalPage/components/LegalPage.test.tsx
+++ b/src/components/LegalPage/components/LegalPage.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { LegalPage } from './LegalPage';
+
+describe('LegalPage', () => {
+  it('renders title, date, and body content', () => {
+    render(
+      <LegalPage title="Impressum" date="Stand: April 2026">
+        <h2>Section</h2>
+        <p>Body paragraph.</p>
+      </LegalPage>
+    );
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Impressum' })).toBeInTheDocument();
+    expect(screen.getByText('Stand: April 2026')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Section' })).toBeInTheDocument();
+    expect(screen.getByText('Body paragraph.')).toBeInTheDocument();
+  });
+
+  it('renders intro when provided', () => {
+    render(
+      <LegalPage title="Datenschutz" date="Stand: April 2026" intro="Lead paragraph.">
+        <p>Body.</p>
+      </LegalPage>
+    );
+
+    expect(screen.getByText('Lead paragraph.')).toBeInTheDocument();
+  });
+
+  it('does not render intro slot when omitted', () => {
+    const { container } = render(
+      <LegalPage title="Impressum" date="Stand: April 2026">
+        <p>Body.</p>
+      </LegalPage>
+    );
+
+    expect(container.querySelector('.eidotter-legal-page__intro')).not.toBeInTheDocument();
+  });
+
+  it('renders home slot when provided', () => {
+    render(
+      <LegalPage
+        title="Impressum"
+        date="Stand: April 2026"
+        home={<a href="/">← Home</a>}
+      >
+        <p>Body.</p>
+      </LegalPage>
+    );
+
+    expect(screen.getByRole('link', { name: '← Home' })).toBeInTheDocument();
+  });
+
+  it('does not render home wrapper when home slot is absent', () => {
+    const { container } = render(
+      <LegalPage title="Impressum" date="Stand: April 2026">
+        <p>Body.</p>
+      </LegalPage>
+    );
+
+    expect(container.querySelector('.eidotter-legal-page__home')).not.toBeInTheDocument();
+  });
+
+  it('applies custom className alongside the eidotter base class', () => {
+    const { container } = render(
+      <LegalPage title="Impressum" date="Stand: April 2026" className="custom-page">
+        <p>Body.</p>
+      </LegalPage>
+    );
+
+    const root = container.querySelector('.eidotter-legal-page');
+    expect(root).toBeInTheDocument();
+    expect(root).toHaveClass('custom-page');
+  });
+
+  it('spreads additional HTML attributes onto the wrapper', () => {
+    const { container } = render(
+      <LegalPage
+        title="Impressum"
+        date="Stand: April 2026"
+        data-testid="legal-root"
+      >
+        <p>Body.</p>
+      </LegalPage>
+    );
+
+    expect(container.querySelector('[data-testid="legal-root"]')).toBeInTheDocument();
+  });
+
+  it('wraps body in an <article> for semantics', () => {
+    const { container } = render(
+      <LegalPage title="Impressum" date="Stand: April 2026">
+        <p>Body.</p>
+      </LegalPage>
+    );
+
+    const article = container.querySelector('article');
+    expect(article).toBeInTheDocument();
+    expect(article).toContainHTML('<p>Body.</p>');
+  });
+});

--- a/src/components/LegalPage/components/LegalPage.tsx
+++ b/src/components/LegalPage/components/LegalPage.tsx
@@ -7,10 +7,15 @@ export interface LegalPageProps {
   title: string;
   /** "Stand: …" date stamp shown above the heading */
   date: string;
-  /** Optional intro paragraph rendered inside the hero, below the heading */
+  /** Optional intro paragraph rendered inside the hero, below the heading.
+   * Wrapped in a `<div>` (not `<p>`) so consumers can pass block-level
+   * children like fragments or multiple paragraphs without invalid HTML. */
   intro?: React.ReactNode;
-  /** Optional back-link slot rendered above the article. Consumers pass a
-   * router-aware element (e.g., react-router `<Link>`) or a plain `<a>`. */
+  /** Optional back-link slot rendered above the article. Should be a single
+   * `<a>` or `<button>` element so the styling selectors can reach it —
+   * react-router `<Link>` and react-router `<NavLink>` (without a function
+   * child) both render a single `<a>`. Wrapping the link in extra elements
+   * will leave it unstyled. */
   home?: React.ReactNode;
   /** Body content — `<h2>`, `<p>`, `<ul>`, `<address>` children styled by the wrapper. */
   children: React.ReactNode;
@@ -41,7 +46,7 @@ export const LegalPage: React.FC<LegalPageProps & React.HTMLAttributes<HTMLDivEl
       <header className="eidotter-legal-page__hero">
         <p className="eidotter-legal-page__date">{date}</p>
         <h1>{title}</h1>
-        {intro && <p className="eidotter-legal-page__intro">{intro}</p>}
+        {intro && <div className="eidotter-legal-page__intro">{intro}</div>}
       </header>
       <div className="eidotter-legal-page__body">{children}</div>
     </article>

--- a/src/components/LegalPage/components/LegalPage.tsx
+++ b/src/components/LegalPage/components/LegalPage.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { cn } from '../../../utils/cn';
+import './LegalPage.css';
+
+export interface LegalPageProps {
+  /** Heading shown in the hero (e.g., "Impressum", "Datenschutzerklärung") */
+  title: string;
+  /** "Stand: …" date stamp shown above the heading */
+  date: string;
+  /** Optional intro paragraph rendered inside the hero, below the heading */
+  intro?: React.ReactNode;
+  /** Optional back-link slot rendered above the article. Consumers pass a
+   * router-aware element (e.g., react-router `<Link>`) or a plain `<a>`. */
+  home?: React.ReactNode;
+  /** Body content — `<h2>`, `<p>`, `<ul>`, `<address>` children styled by the wrapper. */
+  children: React.ReactNode;
+  /** Extra class on the outer wrapper */
+  className?: string;
+}
+
+/**
+ * Layout primitive for Impressum / Datenschutz / other compact legal pages.
+ *
+ * Wraps the `.legal-hero` + `.legal-body` chrome that previously lived
+ * duplicated across portfolio surfaces. Consumers compose freeform
+ * `<h2>`/`<p>`/`<ul>` body content (or pre-built clauses from this module)
+ * and the wrapper handles spacing, type scale, and the `>` list bullet.
+ */
+export const LegalPage: React.FC<LegalPageProps & React.HTMLAttributes<HTMLDivElement>> = ({
+  title,
+  date,
+  intro,
+  home,
+  children,
+  className,
+  ...props
+}) => (
+  <div className={cn('eidotter-legal-page', className)} {...props}>
+    {home && <div className="eidotter-legal-page__home">{home}</div>}
+    <article>
+      <header className="eidotter-legal-page__hero">
+        <p className="eidotter-legal-page__date">{date}</p>
+        <h1>{title}</h1>
+        {intro && <p className="eidotter-legal-page__intro">{intro}</p>}
+      </header>
+      <div className="eidotter-legal-page__body">{children}</div>
+    </article>
+  </div>
+);

--- a/src/components/LegalPage/components/clauses.test.tsx
+++ b/src/components/LegalPage/components/clauses.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  AddressBlock,
+  ImpressumAddress,
+  ImpressumContact,
+  ImpressumResponsible,
+  ImpressumLiabilityContent,
+  ImpressumLiabilityLinks,
+  DatenschutzController,
+  DatenschutzHosting,
+  DatenschutzPostHog,
+  DatenschutzFonts,
+  DatenschutzEncryption,
+  DatenschutzRights,
+} from './clauses';
+
+describe('AddressBlock', () => {
+  it('renders the canonical Düsseldorf address by default', () => {
+    const { container } = render(<AddressBlock />);
+
+    expect(container.querySelector('address')).toBeInTheDocument();
+    expect(screen.getByText('Dominic Kennedy', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText(/Haus-Endt-Str\. 149A/)).toBeInTheDocument();
+    expect(screen.getByText(/40593 Düsseldorf/)).toBeInTheDocument();
+  });
+
+  it('renders email as a mailto link when provided', () => {
+    render(<AddressBlock email="hello@example.com" />);
+
+    const link = screen.getByRole('link', { name: 'hello@example.com' });
+    expect(link).toHaveAttribute('href', 'mailto:hello@example.com');
+  });
+
+  it('omits email line when no email prop given', () => {
+    render(<AddressBlock />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});
+
+describe('Impressum clauses', () => {
+  it('ImpressumAddress renders the § 5 DDG header', () => {
+    render(<ImpressumAddress />);
+    expect(screen.getByRole('heading', { name: /§ 5 DDG/ })).toBeInTheDocument();
+  });
+
+  it('ImpressumContact renders a mailto link', () => {
+    render(<ImpressumContact email="hello@dmnc.tech" />);
+    const link = screen.getByRole('link', { name: 'hello@dmnc.tech' });
+    expect(link).toHaveAttribute('href', 'mailto:hello@dmnc.tech');
+  });
+
+  it('ImpressumResponsible cites § 18 Abs. 2 MStV', () => {
+    render(<ImpressumResponsible />);
+    expect(screen.getByRole('heading', { name: /§ 18 Abs\. 2 MStV/ })).toBeInTheDocument();
+  });
+
+  it('ImpressumLiabilityContent cites §§ 7-10 DDG', () => {
+    render(<ImpressumLiabilityContent />);
+    expect(screen.getByText(/§§ 8–10 DDG/)).toBeInTheDocument();
+  });
+
+  it('ImpressumLiabilityLinks renders Haftung für Links heading', () => {
+    render(<ImpressumLiabilityLinks />);
+    expect(screen.getByRole('heading', { name: 'Haftung für Links' })).toBeInTheDocument();
+  });
+});
+
+describe('Datenschutz clauses', () => {
+  it('DatenschutzController renders the email as mailto', () => {
+    render(<DatenschutzController email="hello@dmnc.tech" />);
+    expect(screen.getByRole('link', { name: 'hello@dmnc.tech' })).toHaveAttribute(
+      'href',
+      'mailto:hello@dmnc.tech',
+    );
+  });
+
+  it('DatenschutzHosting cites Cloudflare and Art. 6 Abs. 1 lit. f', () => {
+    render(<DatenschutzHosting />);
+    expect(screen.getAllByText(/Cloudflare/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Art\. 6 Abs\. 1 lit\. f DSGVO/)).toBeInTheDocument();
+  });
+
+  it('DatenschutzPostHog defaults proxy host to e.dmnc.tech', () => {
+    render(<DatenschutzPostHog />);
+    expect(screen.getByText(/e\.dmnc\.tech/)).toBeInTheDocument();
+  });
+
+  it('DatenschutzPostHog accepts a custom proxy host', () => {
+    render(<DatenschutzPostHog proxyHost="proxy.example.com" />);
+    expect(screen.getByText(/proxy\.example\.com/)).toBeInTheDocument();
+    expect(screen.queryByText(/e\.dmnc\.tech/)).not.toBeInTheDocument();
+  });
+
+  it('DatenschutzFonts mentions Flexi IBM VGA', () => {
+    render(<DatenschutzFonts />);
+    expect(screen.getByText(/Flexi IBM VGA True/)).toBeInTheDocument();
+  });
+
+  it('DatenschutzEncryption mentions SSL/TLS', () => {
+    render(<DatenschutzEncryption />);
+    expect(screen.getByText(/SSL-\/TLS-Verschlüsselung/)).toBeInTheDocument();
+  });
+
+  it('DatenschutzRights lists Art. 15-21', () => {
+    render(<DatenschutzRights />);
+    expect(screen.getByText(/Auskunft \(Art\. 15\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Widerspruch \(Art\. 21\)/)).toBeInTheDocument();
+  });
+
+  it('DatenschutzRights renders rights-exercise email when provided', () => {
+    render(<DatenschutzRights email="hello@dmnc.tech" />);
+    expect(screen.getByRole('link', { name: 'hello@dmnc.tech' })).toHaveAttribute(
+      'href',
+      'mailto:hello@dmnc.tech',
+    );
+  });
+
+  it('DatenschutzRights omits the email paragraph when email is absent', () => {
+    render(<DatenschutzRights />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('DatenschutzRights accepts a custom supervisory authority', () => {
+    render(<DatenschutzRights supervisoryAuthority="the Bavarian DPA" />);
+    expect(screen.getByText(/the Bavarian DPA/)).toBeInTheDocument();
+    expect(screen.queryByText(/Nordrhein-Westfalen/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/LegalPage/components/clauses.tsx
+++ b/src/components/LegalPage/components/clauses.tsx
@@ -1,0 +1,232 @@
+import React from 'react';
+
+/* German DDG / DSGVO boilerplate clauses — verbatim across portfolio surfaces.
+ *
+ * Each clause renders its own `<h2>` + body so consumers can drop them in any
+ * order. Use inside a <LegalPage> body. The `eidotter-legal-page__basis`
+ * class on small "Rechtsgrundlage" footnotes is styled by LegalPage.css.
+ */
+
+// ---------- Address (used by both Impressum and Datenschutz) ----------
+
+export interface AddressBlockProps {
+  /** Optional email shown after the address. When provided, rendered as a mailto link. */
+  email?: string;
+  /** Override the postal address. Defaults to the canonical Düsseldorf address. */
+  address?: React.ReactNode;
+  /** Override the legal name. Defaults to "Dominic Kennedy". */
+  name?: string;
+}
+
+const DEFAULT_ADDRESS = (
+  <>
+    Haus-Endt-Str. 149A<br />
+    40593 Düsseldorf<br />
+    Deutschland
+  </>
+);
+
+const DEFAULT_NAME = 'Dominic Kennedy';
+
+/** Standalone postal address block — wrapped in `<address>`. */
+export const AddressBlock: React.FC<AddressBlockProps> = ({
+  email,
+  address = DEFAULT_ADDRESS,
+  name = DEFAULT_NAME,
+}) => (
+  <address>
+    {name}<br />
+    {address}
+    {email && (
+      <>
+        <br />
+        E-Mail: <a href={`mailto:${email}`}>{email}</a>
+      </>
+    )}
+  </address>
+);
+
+// ---------- Impressum clauses ----------
+
+/** § 5 DDG header + address. */
+export const ImpressumAddress: React.FC<Omit<AddressBlockProps, 'email'>> = (props) => (
+  <>
+    <h2>Angaben gemäß § 5 DDG</h2>
+    <AddressBlock {...props} />
+  </>
+);
+
+/** "Kontakt" header + mailto link. */
+export const ImpressumContact: React.FC<{ email: string }> = ({ email }) => (
+  <>
+    <h2>Kontakt</h2>
+    <p>
+      E-Mail: <a href={`mailto:${email}`}>{email}</a>
+    </p>
+  </>
+);
+
+/** § 18 Abs. 2 MStV responsibility block — short address (no country line). */
+export const ImpressumResponsible: React.FC<{ name?: string }> = ({ name = DEFAULT_NAME }) => (
+  <>
+    <h2>Inhaltlich verantwortlich (§ 18 Abs. 2 MStV)</h2>
+    <address>
+      {name}<br />
+      Haus-Endt-Str. 149A<br />
+      40593 Düsseldorf
+    </address>
+  </>
+);
+
+/** §§ 7-10 DDG content liability disclaimer. */
+export const ImpressumLiabilityContent: React.FC = () => (
+  <>
+    <h2>Haftung für Inhalte</h2>
+    <p>
+      Ich erstelle die Inhalte dieser Seiten mit größter Sorgfalt, übernehme jedoch
+      keine Gewähr für Richtigkeit, Vollständigkeit oder Aktualität. Als Diensteanbieter
+      bin ich gemäß § 7 Abs. 1 DDG für eigene Inhalte verantwortlich. Eine Pflicht zur
+      Überwachung fremder Informationen besteht gemäß §§ 8–10 DDG nicht.
+    </p>
+  </>
+);
+
+/** External-link liability disclaimer. */
+export const ImpressumLiabilityLinks: React.FC = () => (
+  <>
+    <h2>Haftung für Links</h2>
+    <p>
+      Diese Website verlinkt auf externe Seiten Dritter, auf deren Inhalte ich keinen
+      Einfluss habe. Für verlinkte Inhalte haftet der jeweilige Anbieter. Eine
+      dauerhafte Kontrolle ist ohne Anhaltspunkte für Rechtsverletzungen nicht zumutbar.
+      Bei Bekanntwerden von Verstößen entferne ich solche Links umgehend.
+    </p>
+  </>
+);
+
+// ---------- Datenschutz clauses ----------
+
+export interface DatenschutzControllerProps {
+  /** Email address rendered as a mailto link inside the address block. */
+  email: string;
+  /** Override the legal name. Defaults to "Dominic Kennedy". */
+  name?: string;
+}
+
+/** "Verantwortlicher" header + address with email. */
+export const DatenschutzController: React.FC<DatenschutzControllerProps> = ({ email, name = DEFAULT_NAME }) => (
+  <>
+    <h2>Verantwortlicher</h2>
+    <address>
+      {name}<br />
+      Haus-Endt-Str. 149A<br />
+      40593 Düsseldorf, Deutschland<br />
+      E-Mail: <a href={`mailto:${email}`}>{email}</a>
+    </address>
+  </>
+);
+
+/** Cloudflare hosting clause + Art. 6 Abs. 1 lit. f legal basis. */
+export const DatenschutzHosting: React.FC = () => (
+  <>
+    <h2>Hosting</h2>
+    <p>
+      Cloudflare Pages stellt diese Website bereit. Beim Seitenaufruf erhebt Cloudflare
+      automatisch technische Zugriffsdaten (darunter Ihre IP-Adresse), um die Seite
+      auszuliefern.
+    </p>
+    <p className="eidotter-legal-page__basis">
+      Anbieter: Cloudflare, Inc., 101 Townsend St, San Francisco, CA 94107, USA.
+      Rechtsgrundlage: Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse).
+    </p>
+  </>
+);
+
+export interface DatenschutzPostHogProps {
+  /** Domain hosting the PostHog reverse-proxy (without protocol),
+   * e.g. `e.dmnc.tech`. Defaults to `e.dmnc.tech`. */
+  proxyHost?: string;
+}
+
+/** PostHog webanalytics clause — EU servers, reverse-proxied, no cookies. */
+export const DatenschutzPostHog: React.FC<DatenschutzPostHogProps> = ({ proxyHost = 'e.dmnc.tech' }) => (
+  <>
+    <h2>Webanalyse — PostHog</h2>
+    <p>
+      Diese Website nutzt PostHog zur Analyse des Nutzungsverhaltens. PostHog läuft
+      auf EU-Servern (eu.posthog.com). Die Datenübertragung erfolgt über einen
+      Reverse-Proxy auf der Domain {proxyHost} — es besteht keine direkte
+      Verbindung zu PostHog-Servern.
+    </p>
+    <p>
+      Es werden <strong>keine Cookies</strong> gesetzt. PostHog speichert Daten
+      ausschließlich im Arbeitsspeicher des Browsers (Session Memory). Personenbezogene
+      Profile entstehen nicht, solange Sie sich nicht aktiv identifizieren.
+    </p>
+    <p>
+      <strong>Session Recording:</strong> PostHog zeichnet anonymisierte
+      Sitzungswiederholungen auf. Alle Eingabefelder werden automatisch maskiert.
+    </p>
+    <p className="eidotter-legal-page__basis">
+      Rechtsgrundlage: Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse).
+    </p>
+  </>
+);
+
+/** Local Flexi IBM VGA True font clause. */
+export const DatenschutzFonts: React.FC = () => (
+  <>
+    <h2>Schriftarten</h2>
+    <p>
+      Die Schriftart „Flexi IBM VGA True" wird lokal von diesem Server
+      ausgeliefert. Es findet keine Verbindung zu externen Schriftarten-Diensten statt.
+    </p>
+  </>
+);
+
+/** SSL/TLS encryption clause. */
+export const DatenschutzEncryption: React.FC = () => (
+  <>
+    <h2>Verschlüsselung</h2>
+    <p>
+      Diese Website nutzt SSL-/TLS-Verschlüsselung. Eine verschlüsselte Verbindung
+      erkennen Sie am „https://" in der Adresszeile Ihres Browsers.
+    </p>
+  </>
+);
+
+export interface DatenschutzRightsProps {
+  /** Email for exercising data-subject rights. */
+  email?: string;
+  /** Override the supervisory authority. Defaults to NRW. */
+  supervisoryAuthority?: React.ReactNode;
+}
+
+/** DSGVO Art. 15-21 rights list + Art. 77 supervisory-authority complaint clause. */
+export const DatenschutzRights: React.FC<DatenschutzRightsProps> = ({
+  email,
+  supervisoryAuthority = 'die Landesbeauftragte für Datenschutz und Informationsfreiheit Nordrhein-Westfalen',
+}) => (
+  <>
+    <h2>Ihre Rechte</h2>
+    <p>Die DSGVO gewährt Ihnen folgende Rechte:</p>
+    <ul>
+      <li>Auskunft (Art. 15)</li>
+      <li>Berichtigung (Art. 16)</li>
+      <li>Löschung (Art. 17)</li>
+      <li>Einschränkung der Verarbeitung (Art. 18)</li>
+      <li>Datenübertragbarkeit (Art. 20)</li>
+      <li>Widerspruch (Art. 21)</li>
+    </ul>
+    {email && (
+      <p>
+        Zur Ausübung Ihrer Rechte genügt eine formlose E-Mail an{' '}
+        <a href={`mailto:${email}`}>{email}</a>.
+      </p>
+    )}
+    <p>
+      Sie können sich bei einer Aufsichtsbehörde beschweren (Art. 77 DSGVO).
+      Zuständig ist {supervisoryAuthority}.
+    </p>
+  </>
+);

--- a/src/components/LegalPage/components/clauses.tsx
+++ b/src/components/LegalPage/components/clauses.tsx
@@ -178,7 +178,7 @@ export const DatenschutzFonts: React.FC = () => (
   <>
     <h2>Schriftarten</h2>
     <p>
-      Die Schriftart „Flexi IBM VGA True" wird lokal von diesem Server
+      Die Schriftart „Flexi IBM VGA True“ wird lokal von diesem Server
       ausgeliefert. Es findet keine Verbindung zu externen Schriftarten-Diensten statt.
     </p>
   </>
@@ -190,7 +190,7 @@ export const DatenschutzEncryption: React.FC = () => (
     <h2>Verschlüsselung</h2>
     <p>
       Diese Website nutzt SSL-/TLS-Verschlüsselung. Eine verschlüsselte Verbindung
-      erkennen Sie am „https://" in der Adresszeile Ihres Browsers.
+      erkennen Sie am „https://“ in der Adresszeile Ihres Browsers.
     </p>
   </>
 );

--- a/src/components/LegalPage/components/index.ts
+++ b/src/components/LegalPage/components/index.ts
@@ -1,0 +1,24 @@
+export { LegalPage } from './LegalPage';
+export type { LegalPageProps } from './LegalPage';
+
+export {
+  AddressBlock,
+  ImpressumAddress,
+  ImpressumContact,
+  ImpressumResponsible,
+  ImpressumLiabilityContent,
+  ImpressumLiabilityLinks,
+  DatenschutzController,
+  DatenschutzHosting,
+  DatenschutzPostHog,
+  DatenschutzFonts,
+  DatenschutzEncryption,
+  DatenschutzRights,
+} from './clauses';
+
+export type {
+  AddressBlockProps,
+  DatenschutzControllerProps,
+  DatenschutzPostHogProps,
+  DatenschutzRightsProps,
+} from './clauses';

--- a/src/components/LegalPage/index.ts
+++ b/src/components/LegalPage/index.ts
@@ -1,0 +1,23 @@
+export {
+  LegalPage,
+  AddressBlock,
+  ImpressumAddress,
+  ImpressumContact,
+  ImpressumResponsible,
+  ImpressumLiabilityContent,
+  ImpressumLiabilityLinks,
+  DatenschutzController,
+  DatenschutzHosting,
+  DatenschutzPostHog,
+  DatenschutzFonts,
+  DatenschutzEncryption,
+  DatenschutzRights,
+} from './components';
+
+export type {
+  LegalPageProps,
+  AddressBlockProps,
+  DatenschutzControllerProps,
+  DatenschutzPostHogProps,
+  DatenschutzRightsProps,
+} from './components';

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,21 @@ export { InlineLink } from './components/InlineLink';
 export { DosFigure } from './components/DosFigure';
 export { CmdPalette } from './components/CmdPalette';
 export { Logo, Wordmark, BrandLockup } from './components/Brand';
+export {
+  LegalPage,
+  AddressBlock,
+  ImpressumAddress,
+  ImpressumContact,
+  ImpressumResponsible,
+  ImpressumLiabilityContent,
+  ImpressumLiabilityLinks,
+  DatenschutzController,
+  DatenschutzHosting,
+  DatenschutzPostHog,
+  DatenschutzFonts,
+  DatenschutzEncryption,
+  DatenschutzRights,
+} from './components/LegalPage';
 
 // Component Types
 export type { AlertProps, AlertAction, AlertColor } from './components/Alert';
@@ -86,6 +101,13 @@ export type { InlineLinkProps } from './components/InlineLink';
 export type { DosFigureProps, DosFigurePin } from './components/DosFigure';
 export type { CmdPaletteProps, CmdPaletteItem } from './components/CmdPalette';
 export type { LogoProps, WordmarkProps, BrandLockupProps } from './components/Brand';
+export type {
+  LegalPageProps,
+  AddressBlockProps,
+  DatenschutzControllerProps,
+  DatenschutzPostHogProps,
+  DatenschutzRightsProps,
+} from './components/LegalPage';
 
 // Hooks
 export { useTextScramble } from './hooks/useTextScramble';


### PR DESCRIPTION
## Summary

Extracts the Impressum/Datenschutz chrome and verbatim § paragraph wording that was duplicated across **three** portfolio surfaces (dmnctech, spacewar_landing, dmnc-online). [DMNC-881](https://linear.app/lizomorf/issue/DMNC-881/extract-legalpage-boilerplate-clauses-to-eidotter).

**Layout primitive `<LegalPage>`** — `title`, `date`, optional `intro`, optional `home` slot, body children. Compact 14-px scale lives in the component CSS rather than in global tokens (the three consumers were already overriding `text-sm = 20px` to ~14 px in their own stylesheets — single-use-case scale doesn't earn a token addition).

**Clauses module** — `ImpressumAddress`, `ImpressumLiabilityContent`, `DatenschutzController`, `DatenschutzPostHog`, `DatenschutzRights`, etc. Each renders its own `<h2>` + body; consumers compose them inside the LegalPage body. Variable bits accept props (`email`, `proxyHost`, `supervisoryAuthority`).

The `home` slot is intentionally a `ReactNode` rather than a `linkComponent` prop — consumers pass their own `<Link>` element so router choice stays local, no eidotter-side abstraction over react-router vs Tanstack vs plain `<a>`.

## Out of scope

- **Adoption** in the three consumer repos — separate PRs per the issue's order: dmnc-online → spacewar_landing → dmnctech.
- The pre-existing Vite 8 / Rolldown CJS-shim build issue (the v0.22.x dist still contains `S("react")` calls that throw in the browser). Verified my changes do not introduce or aggravate it; build still succeeds. Worth tracking as its own bug.

## Test plan

- [x] `npx jest src/components/LegalPage` — 26 tests, all pass
- [x] `npx tsc -p tsconfig.build.json` — clean
- [x] `npx eslint src/components/LegalPage --max-warnings 0` — clean
- [x] `npx vite build` — clean
- [ ] Storybook visual check on `Components/LegalPage` (Impressum, Datenschutz, WithoutBackLink, FreeformBody)

## Related

- [DMNC-572](https://linear.app/lizomorf/issue/DMNC-572) — parent: Impressum required on all public websites
- [DMNC-872](https://linear.app/lizomorf/issue/DMNC-872) — Footer linkComponent (different surface, same "client-side nav for legal links" theme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)