### PR TITLE
fix(build): externalize use-sync-external-store shim chain (v0.22.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.1] - 2026-05-03
+
+### Fixed
+- **Bundler externalises `use-sync-external-store` shim chain.** 0.22.0 inlined the CJS `use-sync-external-store-shim.production.js` into the ESM `dist/index.es.js`, breaking consumer Vite builds (the duplicated React-export wrapper made consumer bundlers refuse the module). The shim is a transitive dep of `react-aria` / `react-stately`. `vite.config.ts` now externalises any path matching `use-sync-external-store` (bare package and Rolldown-resolved subpaths), and adds UMD globals mapping each subpath to the host `React` global (React 18+ exposes `useSyncExternalStore` natively). ESM bundle drops from 349KB → 345KB; consumer interop restored.
+
 ## [0.22.0] - 2026-05-02
 
 AI-content provenance primitive (phase 1 of DMNC-884), font swap to Perfect DOS VGA 437, and a small TimelineContainer convention fix.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,17 +16,34 @@ export default defineConfig({
       fileName: (format) => `index.${format}.js`,
     },
     rollupOptions: {
-      // Defense-in-depth: externalize @untitledui-pro/* entirely. UTI Pro is
-      // no longer a dependency (see CLAUDE.md "External Dependencies: Untitled
-      // UI"), but this guardrail prevents a rogue future import from silently
-      // bundling licensed assets into dist. Such imports would now fail at
-      // build time (UTI is not installed) — and at consumer runtime if
-      // somehow bundled — instead of quietly shipping non-redistributable code.
+      // Externalize React + the use-sync-external-store shim chain.
+      //
+      // Why use-sync-external-store: react-aria / react-stately depend on
+      // `use-sync-external-store/shim/with-selector` for their stores. The
+      // shim is a CJS package; if Rollup bundles it into the ESM dist, the
+      // CJS-wrapper code lands inside our ESM bundle and breaks consumer
+      // builds (Vite/Rollup at the consumer side flag the duplicated React
+      // export and refuse to evaluate the module). React 18+ exports
+      // `useSyncExternalStore` natively, and react-aria's transitive
+      // resolution gives the consumer the right version. Marking it
+      // external keeps the CJS shim out of our bundle entirely.
+      //
+      // Defense-in-depth: also externalize @untitledui-pro/*. UTI Pro is no
+      // longer a dependency (see CLAUDE.md "External Dependencies: Untitled
+      // UI"), but this guardrail prevents a rogue future import from
+      // silently bundling licensed assets into dist. Such imports would now
+      // fail at build time (UTI is not installed) — and at consumer runtime
+      // if somehow bundled — instead of quietly shipping non-redistributable
+      // code.
       external: (id) =>
         id === 'react' ||
         id === 'react-dom' ||
         id === 'react/jsx-runtime' ||
         id === 'react/jsx-dev-runtime' ||
+        // Match bare package imports AND Rolldown-resolved paths
+        // (e.g. node_modules/use-sync-external-store/cjs/…). The package
+        // name is unique enough that substring matching is safe.
+        id.includes('use-sync-external-store') ||
         id.startsWith('@untitledui-pro/'),
       output: {
         globals: {
@@ -34,6 +51,12 @@ export default defineConfig({
           'react-dom': 'ReactDOM',
           'react/jsx-runtime': 'jsxRuntime',
           'react/jsx-dev-runtime': 'jsxDevRuntime',
+          // UMD builds: pull the shim from React's global runtime.
+          // React 18+ exposes useSyncExternalStore on React itself.
+          'use-sync-external-store': 'React',
+          'use-sync-external-store/shim': 'React',
+          'use-sync-external-store/shim/with-selector': 'React',
+          'use-sync-external-store/with-selector': 'React',
         },
       },
     },


### PR DESCRIPTION
0.22.0 silently bundled the CJS \`use-sync-external-store-shim.production.js\` into \`dist/index.es.js\`. dmnc.tech caught it: their consumer Vite refuses the module because the duplicated React-export wrapping breaks ESM evaluation. Same will hit any consumer with a strict ESM build.

## What changed

\`vite.config.ts\` external matcher now uses \`id.includes('use-sync-external-store')\` instead of strict-equality on each subpath. This covers:
- bare \`use-sync-external-store\`
- \`use-sync-external-store/shim\`, \`/shim/with-selector\`, \`/with-selector\`
- Rolldown-resolved paths like \`node_modules/use-sync-external-store/cjs/use-sync-external-store-shim.production.js\`

Plus UMD globals: each subpath maps to the host \`React\` global (React 18+ exposes \`useSyncExternalStore\` natively, so the shim resolves transparently).

## Verified
- \`npm run build\` → green
- \`grep use-sync-external-store dist/index.es.js\` → 1 hit, an \`import { useSyncExternalStore } from "use-sync-external-store/shim/index.js"\` statement. Implementation is no longer inlined.
- ES bundle size: 349KB → 345KB.
- 1028/1028 tests pass.

## Release plan
After merge: tag \`v0.22.1\`, push tag, GitHub Release triggers npm publish workflow. dmnctech bumps from 0.22.0 → 0.22.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)