### PR TITLE
feat(footer): add linkComponent prop for SPA-aware internal navigation (DMNC-872)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.0] - 2026-05-05
+
+### Added
+- **`<Footer>` `linkComponent` prop** — accepts a custom link component (e.g. react-router's `<Link>`) so internal links can do SPA-style navigation instead of triggering full-page reloads. Matches the shape already used by `<Header>`, `<Nav>`, and `<Breadcrumb>`. External links (`external: true`) still render as plain `<a target="_blank">` regardless. Default behavior (plain `<a href>`) is unchanged when the prop is omitted, so this is backward-compatible. Closes [DMNC-872](https://linear.app/lizomorf/issue/DMNC-872).
+
 ## [0.22.2] - 2026-05-03
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",

--- a/src/components/Footer/components/Footer.test.tsx
+++ b/src/components/Footer/components/Footer.test.tsx
@@ -123,4 +123,58 @@ describe('Footer', () => {
     expect(defaultLegalLinks[0].label).toBe('Impressum');
     expect(defaultLegalLinks[1].label).toBe('Datenschutz');
   });
+
+  describe('linkComponent prop', () => {
+    const FakeRouterLink: React.FC<{ href: string; className?: string; children: React.ReactNode }> = ({
+      href,
+      className,
+      children,
+    }) => (
+      <a data-router-link="true" href={href} className={className}>
+        {children}
+      </a>
+    );
+
+    it('renders internal links via linkComponent', () => {
+      render(
+        <Footer
+          linkComponent={FakeRouterLink}
+          links={[{ label: 'Impressum', href: '/impressum' }]}
+        />
+      );
+
+      const link = screen.getByText('Impressum');
+      expect(link).toHaveAttribute('data-router-link', 'true');
+      expect(link).toHaveAttribute('href', '/impressum');
+      expect(link).toHaveClass('eidotter-footer__link');
+    });
+
+    it('still renders external links as plain <a> when linkComponent is provided', () => {
+      render(
+        <Footer
+          linkComponent={FakeRouterLink}
+          links={[
+            { label: 'Internal', href: '/about' },
+            { label: 'GitHub', href: 'https://github.com', external: true },
+          ]}
+        />
+      );
+
+      const internal = screen.getByText('Internal');
+      const external = screen.getByText('GitHub');
+
+      expect(internal).toHaveAttribute('data-router-link', 'true');
+      expect(external).not.toHaveAttribute('data-router-link');
+      expect(external).toHaveAttribute('target', '_blank');
+      expect(external).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('falls back to plain <a> when linkComponent is omitted', () => {
+      render(<Footer links={[{ label: 'Home', href: '/' }]} />);
+
+      const link = screen.getByText('Home');
+      expect(link.tagName).toBe('A');
+      expect(link).not.toHaveAttribute('data-router-link');
+    });
+  });
 });

--- a/src/components/Footer/components/Footer.tsx
+++ b/src/components/Footer/components/Footer.tsx
@@ -16,6 +16,18 @@ export interface FooterProps {
   copyright?: string;
   /** Array of navigation/legal links */
   links?: FooterLink[];
+  /**
+   * Custom link component for internal navigation (e.g. react-router's
+   * `<Link>`). Renders only non-external links (`external !== true`).
+   * Accepts `href`, `className`, and `children` — matches the shape used
+   * by `<Header>`, `<Nav>`, and `<Breadcrumb>`. When omitted, internal
+   * links render as plain `<a href>` (full page reload).
+   */
+  linkComponent?: React.ComponentType<{
+    href: string;
+    className?: string;
+    children: React.ReactNode;
+  }>;
   /** Optional content between separator and links */
   children?: React.ReactNode;
   /** Additional CSS class name */
@@ -35,11 +47,14 @@ export const defaultLegalLinks: FooterLink[] = [
 export const Footer: React.FC<FooterProps & React.HTMLAttributes<HTMLElement>> = ({
   copyright,
   links,
+  linkComponent,
   children,
   className,
   ...props
 }) => {
   const resolvedLinks = links ?? defaultLegalLinks;
+  const LinkTag = linkComponent ?? 'a';
+  const linkClassName = 'eidotter-footer__link text-cga-amber no-underline';
 
   return (
     <footer
@@ -57,13 +72,20 @@ export const Footer: React.FC<FooterProps & React.HTMLAttributes<HTMLElement>> =
           {resolvedLinks.map((link, index) => (
             <React.Fragment key={link.href}>
               {index > 0 && <span className="text-dos-text-muted select-none eidotter-footer__dot" aria-hidden="true">·</span>}
-              <a
-                className="eidotter-footer__link text-cga-amber no-underline"
-                href={link.href}
-                {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-              >
-                {link.label}
-              </a>
+              {link.external ? (
+                <a
+                  className={linkClassName}
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {link.label}
+                </a>
+              ) : (
+                <LinkTag className={linkClassName} href={link.href}>
+                  {link.label}
+                </LinkTag>
+              )}
             </React.Fragment>
           ))}
         </nav>


### PR DESCRIPTION
## Summary

Adds an optional `linkComponent` prop to `<Footer>` so internal links can use SPA navigation (e.g. react-router's `<Link>`) instead of triggering full-page reloads. Matches the shape already used by `<Header>`, `<Nav>`, and `<Breadcrumb>` — Footer was the inconsistent one.

External links (`external: true`) keep rendering as plain `<a target="_blank" rel="noopener noreferrer">` regardless of `linkComponent` — react-router's `Link` doesn't make sense for external URLs.

Default behavior unchanged when `linkComponent` is omitted, so this is **backward-compatible** (additive 0.23.0 minor release).

## API

```ts
linkComponent?: React.ComponentType<{
  href: string;
  className?: string;
  children: React.ReactNode;
}>;
```

Same shape as the existing `Nav` / `Header` / `Breadcrumb` `linkComponent` prop.

## Usage

```tsx
import { Link } from 'react-router';
import { Footer } from 'eidotter';

<Footer
  linkComponent={Link}
  links={[
    { label: 'Impressum', href: '/impressum' },
    { label: 'Datenschutz', href: '/datenschutz' },
    { label: 'GitHub', href: 'https://github.com/...', external: true },
  ]}
/>
```

`/impressum` and `/datenschutz` route via `<Link>` (SPA), `https://github.com/...` stays a plain anchor.

## Test plan

- [x] 17/17 Footer tests pass (14 existing + 3 new for linkComponent)
- [x] `npm run build` clean

## Closes

Closes [DMNC-872](https://linear.app/lizomorf/issue/DMNC-872) — surfaced during PR review of [spacewar_landing#4](https://github.com/CinimoDY/spacewar_landing/pull/4) and again during the dmnc-online PR #1 review.

## Adoption order (for next PR)

1. Land here, release 0.23.0
2. Bump `dmnc-online`, `dmnctech`, `spacewar_landing` to `^0.23.0` and pass `linkComponent={Link}` on the Footer
3. (Re-)check that `/impressum` and `/datenschutz` no longer cause full-page reload from the home Footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)