### PR TITLE
fix(lint): resolve rules-of-hooks errors + warnings surfaced by eslint 10.4

### DIFF
--- a/src/components/Lightbox/components/Lightbox.stories.tsx
+++ b/src/components/Lightbox/components/Lightbox.stories.tsx
@@ -19,26 +19,23 @@ export default meta;
 
 type Story = StoryObj<typeof Lightbox>;
 
+const LightboxDemo: React.FC<{ images: typeof SAMPLE_IMAGES; label: string }> = ({
+  images,
+  label,
+}) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <Button onClick={() => setOpen(true)}>{label}</Button>
+      <Lightbox images={images} isOpen={open} onClose={() => setOpen(false)} />
+    </div>
+  );
+};
+
 export const Default: Story = {
-  render: () => {
-    const [open, setOpen] = useState(false);
-    return (
-      <div>
-        <Button onClick={() => setOpen(true)}>OPEN LIGHTBOX</Button>
-        <Lightbox images={SAMPLE_IMAGES} isOpen={open} onClose={() => setOpen(false)} />
-      </div>
-    );
-  },
+  render: () => <LightboxDemo images={SAMPLE_IMAGES} label="OPEN LIGHTBOX" />,
 };
 
 export const SingleImage: Story = {
-  render: () => {
-    const [open, setOpen] = useState(false);
-    return (
-      <div>
-        <Button onClick={() => setOpen(true)}>OPEN SINGLE</Button>
-        <Lightbox images={[SAMPLE_IMAGES[0]]} isOpen={open} onClose={() => setOpen(false)} />
-      </div>
-    );
-  },
+  render: () => <LightboxDemo images={[SAMPLE_IMAGES[0]]} label="OPEN SINGLE" />,
 };

--- a/src/components/TimelineContainer/components/variants/TimelineEntryCardGallery.tsx
+++ b/src/components/TimelineContainer/components/variants/TimelineEntryCardGallery.tsx
@@ -36,6 +36,16 @@ export const TimelineEntryCardGallery: React.FC<TimelineEntryCardGalleryProps> =
     if (!isExpanded) setState({ phase: 'grid' });
   }, [isExpanded]);
 
+  // Re-validate state.index when entry.images shrinks — otherwise a stale
+  // index can feed an out-of-range value into the Lightbox below.
+  useEffect(() => {
+    setState((prev) => {
+      if (prev.phase === 'grid') return prev;
+      if (prev.index >= entry.images.length) return { phase: 'grid' };
+      return prev;
+    });
+  }, [entry.images.length]);
+
   if (entry.images.length === 0) {
     if (process.env.NODE_ENV !== 'production') {
       console.error(`[eidotter] TimelineEntryCard kind="gallery" entry "${entry.id}" has no images.`);
@@ -60,16 +70,6 @@ export const TimelineEntryCardGallery: React.FC<TimelineEntryCardGalleryProps> =
       return { phase: 'focused', index };
     });
   };
-
-  // Re-validate state.index when entry.images shrinks — otherwise a stale
-  // index can feed an out-of-range value into the Lightbox below.
-  useEffect(() => {
-    setState((prev) => {
-      if (prev.phase === 'grid') return prev;
-      if (prev.index >= entry.images.length) return { phase: 'grid' };
-      return prev;
-    });
-  }, [entry.images.length]);
 
   const focusedIndex =
     state.phase === 'focused' || state.phase === 'lightbox' ? state.index : null;

--- a/src/styles/tailwind-preset.test.ts
+++ b/src/styles/tailwind-preset.test.ts
@@ -10,9 +10,6 @@
  * investigate why).
  */
 
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
-
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const preset = require('../../tailwind.preset.cjs') as {
   theme: {

--- a/src/styles/tokens.test.ts
+++ b/src/styles/tokens.test.ts
@@ -95,21 +95,26 @@ describe('Font-family fallback contract', () => {
  * See plans/2026-05-02-001-feat-ai-content-provenance-marker-plan.md.
  */
 describe('AI-content provenance token contract', () => {
+  type DtcgValue = { $value: string };
+  const provenanceTokens = (
+    baseTokens as unknown as {
+      color: { semantic: { text: { aiDraft: DtcgValue; aiDraftGlow: DtcgValue } } };
+    }
+  ).color.semantic.text;
+
   // ---- Source ----
   it('source token semantic.text.aiDraft equals Signalnoise hot pink', () => {
-    expect((baseTokens as any).color.semantic.text.aiDraft.$value).toBe('#FF1A8C');
+    expect(provenanceTokens.aiDraft.$value).toBe('#FF1A8C');
   });
 
   it('source token semantic.text.aiDraftGlow is 50% rgba of the aiDraft hex', () => {
     // #FF1A8C = rgb(255, 26, 140). Glow at 50% alpha.
-    expect((baseTokens as any).color.semantic.text.aiDraftGlow.$value).toBe(
-      'rgba(255, 26, 140, 0.5)',
-    );
+    expect(provenanceTokens.aiDraftGlow.$value).toBe('rgba(255, 26, 140, 0.5)');
   });
 
   // ---- Source ↔ generated cross-check ----
   it('source aiDraft hex (lowercased) matches the hex emitted in tokens.css', () => {
-    const sourceHex = (baseTokens as any).color.semantic.text.aiDraft.$value.toLowerCase();
+    const sourceHex = provenanceTokens.aiDraft.$value.toLowerCase();
     const css = readFileSync(resolve(__dirname, 'tokens.css'), 'utf-8');
     const m = css.match(/--color-semantic-text-ai-draft:\s*(#[0-9a-fA-F]{6})/);
     expect(m).not.toBeNull();


### PR DESCRIPTION
## Summary

The eslint 10.2→10.4 bump in #341 tightened `react-hooks/rules-of-hooks` detection, surfacing **3 pre-existing latent errors**. CI gates on `npm run lint-tokens`, not full `npm run lint`, so these (and 5 older `--max-warnings 0` warnings) were never caught — `npm run lint` was already exit-1 before the bump.

This PR clears all of it; `npm run lint` now exits 0.

- **TimelineEntryCardGallery** — hoisted the images-revalidation `useEffect` above the empty-images early `return`. The hook was called conditionally: a **genuine rules-of-hooks bug** latent since #321 — a gallery entry emptying its `images` across renders would mismatch React's hook order. Behavior-preserving (the effect already no-ops in the grid phase). All 126 TimelineContainer tests pass.
- **Lightbox.stories** — extracted the `render:` `useState` into a `LightboxDemo` component so hooks live in a real (capitalized) React component.
- **tokens.test** — replaced 3 `(baseTokens as any)` casts with a narrow DTCG-shaped type. Contract assertions unchanged.
- **tailwind-preset.test** — dropped unused `readFileSync`/`resolve` imports.

## Test plan

- [x] `npm run lint` → exit 0 (was exit-1: 3 errors + 5 warnings)
- [x] `npm test` → 1033/1033 pass
- [x] `npm run build` → green
- [x] `npx jest TimelineContainer` → 126/126 (hook-hoist behavior-safe)

## Follow-up (not in this PR)

CI runs `lint-tokens` only — full ESLint never gates `main`, which is how these slipped in. Worth a Linear issue to add `npm run lint` to `build.yml` once the tree is green (it is now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)