### PR TITLE
chore(gitignore): ignore local eiDotter Design System/ export scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ ingest/
 social-preview.html
 eidotter-social-preview.png
 .devjournal/
+
+# Local Figma/design export scratch dir (brand assets exported ad hoc; not source of truth)
+eiDotter Design System/


### PR DESCRIPTION
## Summary

A repo-root `eiDotter Design System/` folder (ad-hoc Figma brand exports — fried-egg icon + v1 logo, PNG sizes light/dark + 2 SVGs + a `.zip`) was showing as untracked. The PNGs and `.zip` were already caught by `*.png` / `*.zip`, but **`eidotter-fried-egg.svg` and `eidotter-logo-v1.svg` were unignored** — a `git add -A` would have committed brand art into a non-source location of this **public** repo.

This ignores the whole folder. It's a local export staging area, not a source of truth — canonical brand assets live under `src/`. Aligns with the CLAUDE.md "local-only folders stay local-only unless explicitly approved" policy.

## Change

One `.gitignore` entry: `eiDotter Design System/`

## Verification

- [x] `git check-ignore` confirms both SVGs now ignored via the new rule
- [x] `git status` no longer lists the folder as untracked
- [x] `git add -A` (dry run) stages nothing from the folder
- [x] No existing tracked files affected (folder was never committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)