### PR TITLE
ci(build): add full ESLint gate to CI (DMNC-936)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,9 @@ jobs:
     - name: Lint token references
       run: npm run lint-tokens
 
+    - name: Lint (ESLint)
+      run: npm run lint
+
     - name: Create env file
       run: |
         echo "FIGMA_ACCESS_TOKEN=" >> .env


### PR DESCRIPTION
## What & why

CI gated on `npm run lint-tokens` (token-ref linter) but **never ran full ESLint**. That gap let a genuine `react-hooks/rules-of-hooks` bug live in `main` from #321 until the eslint 10.2→10.4 bump (#341) surfaced it during local verification — fixed in #342. `npm run lint` was in fact exit-1 even before the bump (5 unenforced `--max-warnings 0` warnings).

This adds a `Lint (ESLint)` step to `.github/workflows/build.yml`, right after `Lint token references` and before `Create env file`, so any ESLint error or warning fails the required `build (22.x)` check at PR time instead of slipping into `main`.

```yaml
- name: Lint token references
  run: npm run lint-tokens

+ - name: Lint (ESLint)
+   run: npm run lint

- name: Create env file
```

## Why this is safe / correct

- **Non-breaking:** the tree is verified lint-green (`npm run lint` exits 0 on this branch off `main @ 7597f72`; `--max-warnings 0` already in the script).
- **R3 — no escape hatches:** no `--no-verify` / `--admin` / force-push added; only a step (project-standards review confirmed CLAUDE.md CI-guardrail compliance).
- **R4 — branch protection intact:** the step runs *inside* the existing `build (22.x)` required job, so the required-check name is unchanged and no branch-protection settings edit is needed. A step inside the already-required job has blocking teeth automatically (confirmed against `solutions/workflow-issues/token-staleness-ci-check-2026-04-17.md`).

## Known limitations (documented, follow-ups — not this PR)

- **Blast radius:** tightening a required check is retroactive — open PRs whose `src/` diff carries an ESLint error/warning flip to red on next CI. Intended (lint debt shouldn't merge); authors fix as part of their own PR.
- **`src/`-only:** `eslint.config.js` ignores `scripts/`, `*.config.*`, `*.preset.*`, so non-trivial TS like `scripts/sync-figma-to-swift.ts` remains un-lintable even locally. A permanent blind spot, tracked for a follow-up (widen ESLint scope) — out of DMNC-936.

## Verification

- [x] `npm run lint` exits 0 on the branch
- [x] Step ordering correct (after `lint-tokens`, before `Create env file`)
- [x] ce-code-review: clean, Ready to merge (zero findings)
- [ ] CI green on this PR

Plan: `plans/2026-05-18-001-feat-ci-eslint-gate-plan.md` · Closes DMNC-936

🤖 Generated with [Claude Code](https://claude.com/claude-code)
