### PR TITLE
feat(figcli): DOSBTS Figma design-system pipeline (Track A)

### DIFF
--- a/figcli/DOSBTS.design.md
+++ b/figcli/DOSBTS.design.md
@@ -26,8 +26,7 @@ eidotter's own CGA primitives are amber-monochromed.
 ```json design-tokens
 {
   "meta": {
-    "source": "DOSBTS / eiDotter Amber",
-    "generated": "2026-06-05T22:15:48.958Z"
+    "source": "DOSBTS / eiDotter Amber"
   },
   "color": {
     "bg": "#0A0A0A",

--- a/figcli/DOSBTS.design.md
+++ b/figcli/DOSBTS.design.md
@@ -1,0 +1,80 @@
+# DOSBTS — eiDotter Amber `DESIGN.md`
+
+**Generated** by `scripts/figcli/export-design-md.ts` — do not hand-edit. Re-run
+`npm run export-figcli-design-md` after changing DOSBTS AmberTheme values.
+
+Source: `DOSBTS / eiDotter Amber` · figcli variable-collection name.
+
+## How figcli consumes this
+
+With Figma Desktop open on `DOSBTS_fig` and figcli connected in **Safe mode** (never Yolo):
+
+```bash
+node /path/to/figma-cli/src/index.js tokens import-design-md figcli/DOSBTS.design.md
+```
+
+This creates color/radius/typography variables. **Spacing is not created by figcli's
+import** — add the spacing variables via the figma-console MCP (`figma_batch_create_variables`)
+from the same block. See `figcli/README.md`.
+
+Glucose-status colors are **literal CGA** (`success #00AA00` in-range, `error #AA0000`
+out-of-range, `info #00AAAA` sensor) — sourced from the DOSBTS override map, because
+eidotter's own CGA primitives are amber-monochromed.
+
+## Machine-readable tokens
+
+```json design-tokens
+{
+  "meta": {
+    "source": "DOSBTS / eiDotter Amber",
+    "generated": "2026-06-05T22:15:48.958Z"
+  },
+  "color": {
+    "bg": "#0A0A0A",
+    "card": "#1B1917",
+    "amber": "#FFB000",
+    "amber-dark": "#CC8C00",
+    "amber-light": "#FFD580",
+    "muted": "#594F47",
+    "border": "#594F47",
+    "text-primary": "#FFB000",
+    "text-secondary": "#CC8C00",
+    "text-muted": "#594F47",
+    "white": "#AAAAAA",
+    "success": "#00AA00",
+    "error": "#AA0000",
+    "info": "#00AAAA"
+  },
+  "radius": {
+    "none": "0px",
+    "sm": "2px",
+    "base": "4px"
+  },
+  "typography": {
+    "fontFamily": "SF Mono, ui-monospace, monospace",
+    "size": {
+      "hero": 60,
+      "title": 28,
+      "header": 22,
+      "body": 17,
+      "body-small": 15,
+      "button": 15,
+      "caption": 13,
+      "data": 17
+    }
+  },
+  "spacing": {
+    "0": "0px",
+    "1": "4px",
+    "2": "8px",
+    "3": "12px",
+    "4": "16px",
+    "5": "20px",
+    "6": "24px",
+    "8": "32px",
+    "10": "40px",
+    "12": "48px",
+    "16": "64px"
+  }
+}
+```

--- a/figcli/README.md
+++ b/figcli/README.md
@@ -10,6 +10,12 @@ execution). Tracks the work in **DMNC-976**. Plan: review-hardened, 7-persona pa
 
 Target Figma file: **`DOSBTS_fig`** (key `1Hemp6DehvK1a5uMrPJyhr`).
 
+> **Why this lives in the public `eidotter` repo:** DOSBTS is already a public project
+> (public GitHub repo + TestFlight), so this is not a privacy exposure, and `figcli/` is
+> excluded from the npm package (`files` in `package.json`) — consumers never receive it.
+> Intentionally committed here for reproducibility + CI; extract to a shared submodule only
+> when a second consumer (DOOMBTS / EatThisDie) needs the same specs.
+
 ---
 
 ## Execution environment (read first)

--- a/figcli/README.md
+++ b/figcli/README.md
@@ -1,0 +1,114 @@
+# DOSBTS Figma design system — runbook (figcli pipeline)
+
+The seam between **Track A** (this repo, committed) and **Track B** (local Figma
+execution). Tracks the work in **DMNC-976**. Plan: review-hardened, 7-persona pass.
+
+- **Track A — committed here, reproducible without Figma:** `scripts/figcli/export-design-md.ts`
+  → `figcli/DOSBTS.design.md` (tokens), `figcli/components/*.jsx` (DOS-custom specs), this runbook, tests.
+- **Track B — run locally from this runbook:** import tokens → variables, retheme the
+  Apple iOS 26 kit, render the DOS-custom components, assemble the four screens, verify.
+
+Target Figma file: **`DOSBTS_fig`** (key `1Hemp6DehvK1a5uMrPJyhr`).
+
+---
+
+## Execution environment (read first)
+
+- **Figma cannot be written remotely.** Every Figma-touching step runs on the local
+  machine with Figma Desktop open. (`figma_get_status` fails in cloud/headless — no bridge.)
+- **This is Windows (WSL2), not macOS.** Figma Desktop runs on the **Windows host**.
+  figcli is macOS-tested and its WSL↔Windows connect path is unverified, so **lead Track B
+  with the proven figma-console MCP desktop bridge (port 9223+)**; evaluate figcli
+  opportunistically (run it from Windows-native Node against `localhost`, or from WSL
+  reaching the Windows host IP). Record whichever connects in this file.
+
+## Security hardening (non-negotiable)
+
+- **figcli Yolo mode is PROHIBITED** — it patches the Figma Desktop binary, re-enabling an
+  unauthenticated CDP endpoint on `localhost:9222`. Use **Safe mode** (dev plugin) or the
+  figma-console MCP only.
+- Before installing figcli: pin a **specific commit SHA** (not branch tip), run `npm audit`,
+  and review `src/figma-patch.js`, `src/credentials.js`, `src/daemon.js`.
+- Keep **only `DOSBTS_fig` open** during sessions — the Safe-mode plugin can write to any
+  open file (close Foundation `KoGTFX8INOAjFaOKPXnSlX` and eiDotter iOS DS `TEnlcIgXrB3akHvtjMy3po`).
+- Verify the Apple iOS 26 Community file (`1527721578857867021`) is published by the
+  **verified Apple account**; cross-check its license at developer.apple.com/design/resources/.
+
+---
+
+## Track A (committed — regenerate tokens here)
+
+```bash
+npm run export-figcli-design-md     # rebuilds figcli/DOSBTS.design.md from token sources
+npx jest --testPathPatterns=export-design-md
+```
+
+Token values: DOSBTS AmberTheme (`#0A0A0A` bg, `#1B1917` card, `#594F47` muted, SF Mono).
+Glucose-status colors are **literal CGA** (`success #00AA00` / `error #AA0000` /
+`info #00AAAA`) from the override map — eidotter's own CGA primitives are amber-monochromed.
+
+---
+
+## Track B (local — Figma Desktop open on `DOSBTS_fig`)
+
+### U1 · Connect
+- Lead with figma-console MCP bridge; confirm `figma_get_status` is connected to `DOSBTS_fig`.
+- (Optional) install figcli at a pinned SHA, Safe mode; pin its `tokens import-design-md`
+  JSON schema from `src/` — it must match `figcli/DOSBTS.design.md`'s `json design-tokens` block.
+- Record the working connect path here: _______________________________________________
+
+### U2 · Inventory + pages
+- MCP `figma_get_file_data` / `figma_get_variables` on `DOSBTS_fig` and the eiDotter iOS DS.
+- Create 3 pages: **Tokens**, **Components**, **Screens**. On Components, two sections:
+  "iOS Chrome (rethemed Apple)" and "DOS-Custom".
+
+### U3 · Apple iOS 26 kit retheme spike — **hard go/no-go gate**
+- Duplicate the Community kit into a scratch page; check whether Tab Bar / Button / List
+  row fills bind to color **variables**.
+- **If variable-bound** → proceed to U6 (full chrome).
+- **If NOT** → STOP and re-scope: build only the minimum chrome the 4 screens need
+  (tab bar, nav bar, list row, button), or defer the retheme. Do not absorb a full
+  native-chrome rebuild silently. Record decision: _______________________________________
+
+### U5 · Import tokens → amber variable collection
+```bash
+# figcli (color/radius/typography only):
+node /path/to/figma-cli/src/index.js tokens import-design-md figcli/DOSBTS.design.md
+```
+- **Spacing is NOT created by figcli's import** → add spacing variables via MCP
+  `figma_batch_create_variables` from the same block. figcli import is single-mode; build
+  any light/dark/amber modes via MCP too.
+- Verify `var:amber`, `var:bg`, `var:card`, `var:muted`, `var:success/error/info`,
+  **spacing**, radius, type all resolve in a probe render.
+
+### U6 · Retheme Apple chrome to amber
+- Apply the U3 strategy (amber mode, or remap fills to the amber `var:` collection) via
+  figma-console MCP / native Figma. Keep SF Mono, sharp corners. Scope per the U3 gate.
+
+### U7 · Render DOS-custom components
+- See `figcli/components/README.md`. Render each spec → `node to-component` →
+  `combos`/`sizes` → combine into variant sets. **Glow floor:** Hero + primary Button
+  carry the 3-layer phosphor glow. Confirm glucose thresholds from DOSBTS before final render.
+
+### U8 · Assemble the four screens
+- Canonical artboard: one iPhone size (e.g. iPhone 16 Pro 393×852) with safe areas;
+  decide whether the 60pt Hero scales with Dynamic Type.
+- **Reference: README screenshots + `design-system.md` + the live app. NOT `ui-mockups.md`**
+  (it describes EatThisDie food-logging, not the DOSBTS CGM app).
+- Layouts (from DOSBTS `CLAUDE.md`):
+  - **Overview:** event-lane → hero (+IOB) → treatment banner → chart + report selector
+    (GLUCOSE / TIME IN RANGE / STATISTICS) → action buttons → connection → sensor.
+  - **Daily Digest:** date-nav → 2×3 color-coded stats grid → AI-insight card (cyan border)
+    → chronological event timeline.
+  - **Meal Entry:** QUICK favourites + recents + type-ahead; Manual/Scan/Photo/Ask-AI paths;
+    states empty/typing/AI-result(editable)/low-confidence-follow-up/confirmed.
+  - **Settings:** grouped iOS list (glucose · alarms day/night · insulin · data), rethemed amber.
+- Verify: `figma_capture_screenshot` side-by-side vs the four TestFlight screenshots.
+
+---
+
+## Reproducibility & ownership
+
+- A fresh local run of this runbook reproduces `DOSBTS_fig` from the committed Track-A inputs.
+- **Component-source home:** specs stay in `eidotter` for now. Extract to a shared submodule
+  only when a second consumer (DOOMBTS / EatThisDie) needs the same specs.

--- a/figcli/components/README.md
+++ b/figcli/components/README.md
@@ -1,0 +1,51 @@
+# DOS-custom component specs (figcli render dialect)
+
+Track-A inputs for the DOSBTS Figma design system (DMNC-976 · U7). These `.jsx` files
+are **figcli render specs**, not React — primitives (`<Frame>`, `<Text>`, `<Rectangle>`,
+`<Icon>`, `<SVG>`) with layout props and `var:token` bindings. They are rendered into
+`DOSBTS_fig` locally in Track B, then turned into Figma components.
+
+> **Dialect caveat:** the exact figcli JSX prop set (e.g. `glow`, `padding`, `var:` font
+> sizing) is **pinned against figcli `src/` in U1** before the first render. Treat these
+> specs as faithful intent; adjust prop names to the pinned dialect when rendering.
+
+## Render workflow (Track B, local, Windows — Figma Desktop open on `DOSBTS_fig`)
+
+For each spec file:
+
+```bash
+node /path/to/figma-cli/src/index.js render figcli/components/<file>.jsx
+node /path/to/figma-cli/src/index.js node to-component "<frame-id>"   # per named frame
+node /path/to/figma-cli/src/index.js component combine ...            # into one variant set
+node /path/to/figma-cli/src/index.js sizes "<id>" --base md           # where size variants apply
+```
+
+## `var:` token reference (created by U5 from `figcli/DOSBTS.design.md`)
+
+| Token | Value | Use |
+|---|---|---|
+| `var:bg` | `#0A0A0A` | screen background |
+| `var:card` | `#1B1917` | card / surface |
+| `var:amber` | `#FFB000` | primary accent / data |
+| `var:amber-dark` | `#CC8C00` | secondary / pressed |
+| `var:muted` | `#594F47` | borders, disabled, captions |
+| `var:success` | `#00AA00` | **in-range glucose** |
+| `var:error` | `#AA0000` | **out-of-range glucose** |
+| `var:info` | `#00AAAA` | sensor / insulin / info |
+
+## Component → state matrix (R8: every component carries its real states)
+
+| Spec file | Component | States / variants |
+|---|---|---|
+| `glucose-hero.jsx` | Glucose Hero (60pt) | in-range · low · high · critical-low · critical-high · **stale** |
+| `dos-button.jsx` | DOS Button | variant primary/ghost × state default/pressed/disabled/loading |
+| `stat.jsx` | Stat | trend up/down/neutral × size sm/md/lg + no-data |
+| `cards-feedback.jsx` | CRT Card (`.dosCard` variant), Badge, TIR bars, Alert | success/error/info status states |
+| `timeline.jsx` | Event Marker Lane, IOB chip, Stale indicator | empty/single/grouped · zero/active/predicted · warn/error |
+
+**Glow floor:** Glucose Hero and primary DOS Button MUST carry the 3-layer CRT phosphor
+glow (radius 2@0.6 / 6@0.3 / 12@0.15). Chart bodies / event lane may be static.
+
+**Medical values:** glucose threshold numbers in `glucose-hero.jsx` are placeholders —
+confirm the real in-range/low/high/critical thresholds from DOSBTS `AmberTheme.swift` /
+state code before the final render. Do not invent.

--- a/figcli/components/cards-feedback.jsx
+++ b/figcli/components/cards-feedback.jsx
@@ -1,0 +1,35 @@
+/* figcli render spec — CRT Card + feedback components (DMNC-976 · U7). Track B input.
+ * crt-card is a VARIANT of eiDotter Card (.dosCard), not a new component.
+ * var: tokens from figcli/DOSBTS.design.md. Sharp corners (rounded=0).
+ * Workflow: render → node to-component each named frame → combine into per-component sets.
+ */
+<Frame name="CardsAndFeedback" flex="col" gap={16} bg="var:bg" padding={16}>
+
+  {/* CRT Phosphor Card — Card variant; 1px amber-muted border, card bg, glow on container */}
+  <Frame name="Card/Dos" flex="col" gap={8} bg="var:card" stroke="var:muted" rounded={0} padding={16} glow="phosphor">
+    <Text size={22} color="var:amber">SENSOR</Text>
+    <Text size={17} color="var:text-secondary">Libre 3 · 9 days left</Text>
+  </Frame>
+
+  {/* Badge — status color states */}
+  <Frame name="Badge" flex="row" gap={8}>
+    <Frame name="Badge/Success" bg="var:success" rounded={0} padding={4}><Text size={13} color="var:bg">IN RANGE</Text></Frame>
+    <Frame name="Badge/Error" bg="var:error" rounded={0} padding={4}><Text size={13} color="var:bg">HIGH</Text></Frame>
+    <Frame name="Badge/Info" bg="var:info" rounded={0} padding={4}><Text size={13} color="var:bg">SENSOR</Text></Frame>
+    <Frame name="Badge/Amber" stroke="var:amber" rounded={0} padding={4}><Text size={13} color="var:amber">45g</Text></Frame>
+  </Frame>
+
+  {/* TIR / Progress bars — Time-in-Range stacked bar (green/amber/red segments) */}
+  <Frame name="TIRBars" flex="row" gap={0} w={320} h={20}>
+    <Rectangle name="TIR/Low" bg="var:error" w={48} h={20} />
+    <Rectangle name="TIR/InRange" bg="var:success" w={224} h={20} />
+    <Rectangle name="TIR/High" bg="var:error" w={48} h={20} />
+  </Frame>
+
+  {/* Alert — uniform dark bg, status-colored left accent */}
+  <Frame name="Alert/Warning" flex="row" gap={8} bg="var:card" stroke="var:error" rounded={0} padding={12}>
+    <Text size={17} color="var:error">⚠</Text>
+    <Text size={15} color="var:text-primary">Stacking insulin — 2.1U still active</Text>
+  </Frame>
+
+</Frame>

--- a/figcli/components/dos-button.jsx
+++ b/figcli/components/dos-button.jsx
@@ -1,0 +1,37 @@
+/* figcli render spec — DOS Button (DMNC-976 · U7). Track B (local) input.
+ *
+ * Two variants for DOSBTS (eiDotter's full set is 6×5; scope here is primary/ghost).
+ * GLOW FLOOR: primary Button must carry the 3-layer CRT phosphor glow.
+ * var: tokens from figcli/DOSBTS.design.md. Sharp corners (rounded=0). SF Mono via var.
+ *
+ * Workflow: render → node to-component each Btn/* → component combine into "DOS Button"
+ * with `variant` (primary|ghost) × `state` (default|pressed|disabled|loading) props.
+ */
+<Frame name="DOSButton" flex="col" gap={12} bg="var:bg" padding={16}>
+
+  {/* primary: amber fill, black text, 1px border */}
+  <Frame name="Btn/Primary/Default" bg="var:amber" stroke="var:amber" rounded={0} padding={12} glow="phosphor">
+    <Text size={15} color="var:bg">LOG MEAL</Text>
+  </Frame>
+  <Frame name="Btn/Primary/Pressed" bg="var:amber-dark" stroke="var:amber-dark" rounded={0} padding={12}>
+    <Text size={15} color="var:bg">LOG MEAL</Text>
+  </Frame>
+  <Frame name="Btn/Primary/Disabled" bg="var:muted" stroke="var:muted" rounded={0} padding={12}>
+    <Text size={15} color="var:bg">LOG MEAL</Text>
+  </Frame>
+  <Frame name="Btn/Primary/Loading" bg="var:amber" stroke="var:amber" rounded={0} padding={12}>
+    <Text size={15} color="var:bg">···</Text>
+  </Frame>
+
+  {/* ghost: transparent fill, amber text, 1px amber border */}
+  <Frame name="Btn/Ghost/Default" stroke="var:amber" rounded={0} padding={12}>
+    <Text size={15} color="var:amber">ADD INSULIN</Text>
+  </Frame>
+  <Frame name="Btn/Ghost/Pressed" stroke="var:amber-dark" rounded={0} padding={12}>
+    <Text size={15} color="var:amber-dark">ADD INSULIN</Text>
+  </Frame>
+  <Frame name="Btn/Ghost/Disabled" stroke="var:muted" rounded={0} padding={12}>
+    <Text size={15} color="var:muted">ADD INSULIN</Text>
+  </Frame>
+
+</Frame>

--- a/figcli/components/glucose-hero.jsx
+++ b/figcli/components/glucose-hero.jsx
@@ -1,0 +1,49 @@
+/* figcli render spec — Glucose Hero (DMNC-976 · U7). Track B (local) input.
+ *
+ * The single most-looked-at element in the app. MANDATORY glucose-state variants —
+ * without them, screen assembly (U8) would invent thresholds and the screens diverge.
+ *
+ * var: tokens come from figcli/DOSBTS.design.md (imported in U5).
+ * Glucose threshold NUMBERS below are placeholders — CONFIRM the real in-range /
+ * low / high / critical thresholds from DOSBTS AmberTheme/state code before final
+ * render; do not invent medical values.
+ *
+ * GLOW FLOOR: the Hero must carry the 3-layer CRT phosphor glow (radius 2@0.6 /
+ * 6@0.3 / 12@0.15). `glow` prop syntax is pinned against figcli src/ in U1.
+ *
+ * Workflow: render this sheet → `node to-component` each Hero/* frame →
+ * `component combine` into one "Glucose Hero" component with a `state` variant prop.
+ */
+<Frame name="GlucoseHero" flex="row" gap={24} bg="var:bg" padding={24} wrap={true}>
+
+  <Frame name="Hero/InRange" flex="col" gap={2} items="start">
+    <Text size={60} color="var:success" glow="phosphor">128</Text>
+    <Text size={15} color="var:muted">mg/dL · → stable</Text>
+  </Frame>
+
+  <Frame name="Hero/Low" flex="col" gap={2} items="start">
+    <Text size={60} color="var:error" glow="phosphor">58</Text>
+    <Text size={15} color="var:muted">mg/dL · ↘ falling</Text>
+  </Frame>
+
+  <Frame name="Hero/High" flex="col" gap={2} items="start">
+    <Text size={60} color="var:error" glow="phosphor">214</Text>
+    <Text size={15} color="var:muted">mg/dL · ↗ rising</Text>
+  </Frame>
+
+  <Frame name="Hero/CriticalLow" flex="col" gap={2} items="start">
+    <Text size={60} color="var:error" glow="phosphor-strong">44</Text>
+    <Text size={15} color="var:error">mg/dL · LOW · ↓↓</Text>
+  </Frame>
+
+  <Frame name="Hero/CriticalHigh" flex="col" gap={2} items="start">
+    <Text size={60} color="var:error" glow="phosphor-strong">301</Text>
+    <Text size={15} color="var:error">mg/dL · HIGH · ↑↑</Text>
+  </Frame>
+
+  <Frame name="Hero/Stale" flex="col" gap={2} items="start">
+    <Text size={60} color="var:muted">--</Text>
+    <Text size={15} color="var:muted">no signal · 12 MIN AGO</Text>
+  </Frame>
+
+</Frame>

--- a/figcli/components/stat.jsx
+++ b/figcli/components/stat.jsx
@@ -1,0 +1,35 @@
+/* figcli render spec — Stat (DMNC-976 · U7). Track B (local) input.
+ * Mirrors eiDotter Stat taxonomy: trend (up|down|neutral) × size (sm|md|lg) + a no-data state.
+ * Trend colors: up=var:success, down=var:error, neutral=var:amber (per eiDotter Stat).
+ * var: tokens from figcli/DOSBTS.design.md.
+ *
+ * Workflow: render → node to-component each Stat/* → sizes "Stat/..." --base md →
+ * component combine into "Stat" with `trend` × `size` × `state` props.
+ */
+<Frame name="Stat" flex="row" gap={16} bg="var:bg" padding={16} wrap={true}>
+
+  <Frame name="Stat/Up" flex="col" gap={1} items="start">
+    <Text size={13} color="var:muted">TIME IN RANGE</Text>
+    <Text size={28} color="var:amber">72%</Text>
+    <Text size={13} color="var:success">↑ +4%</Text>
+  </Frame>
+
+  <Frame name="Stat/Down" flex="col" gap={1} items="start">
+    <Text size={13} color="var:muted">AVG GLUCOSE</Text>
+    <Text size={28} color="var:amber">141</Text>
+    <Text size={13} color="var:error">↓ -8</Text>
+  </Frame>
+
+  <Frame name="Stat/Neutral" flex="col" gap={1} items="start">
+    <Text size={13} color="var:muted">GMI</Text>
+    <Text size={28} color="var:amber">6.8%</Text>
+    <Text size={13} color="var:amber">→ 0</Text>
+  </Frame>
+
+  <Frame name="Stat/NoData" flex="col" gap={1} items="start">
+    <Text size={13} color="var:muted">STD DEV</Text>
+    <Text size={28} color="var:muted">--</Text>
+    <Text size={13} color="var:muted">no data</Text>
+  </Frame>
+
+</Frame>

--- a/figcli/components/timeline.jsx
+++ b/figcli/components/timeline.jsx
@@ -1,0 +1,36 @@
+/* figcli render spec — Event Marker Lane + IOB chip + Stale indicator (DMNC-976 · U7).
+ * Track B input. var: tokens from figcli/DOSBTS.design.md.
+ * Workflow: render → node to-component each named frame → combine into per-component sets.
+ */
+<Frame name="Timeline" flex="col" gap={16} bg="var:bg" padding={16}>
+
+  {/* Event Marker Lane — 32px lane above the glucose chart. SF Symbol-style glyphs. */}
+  <Frame name="EventLane/Empty" w={320} h={32} stroke="var:muted" rounded={0}>
+    <Text size={13} color="var:muted">no events</Text>
+  </Frame>
+  <Frame name="EventLane/Single" flex="row" gap={24} w={320} h={32} items="center">
+    <Text size={17} color="var:amber">◇</Text>{/* meal (diamond) */}
+    <Text size={17} color="var:info">|</Text>{/* insulin */}
+    <Text size={17} color="var:success">⬤</Text>{/* exercise */}
+  </Frame>
+  <Frame name="EventLane/Grouped" flex="row" gap={24} w={320} h={32} items="center">
+    <Frame name="Group" flex="row" gap={2} items="center">
+      <Text size={17} color="var:amber">◯</Text>{/* group (circle) */}
+      <Text size={13} color="var:muted">3× 45g</Text>
+    </Frame>
+  </Frame>
+
+  {/* IOB chip — zero / active / predicted */}
+  <Frame name="IOB" flex="row" gap={8}>
+    <Frame name="IOB/Zero" stroke="var:muted" rounded={0} padding={4}><Text size={13} color="var:muted">IOB 0.0U</Text></Frame>
+    <Frame name="IOB/Active" stroke="var:info" rounded={0} padding={4}><Text size={13} color="var:info">IOB 2.1U</Text></Frame>
+    <Frame name="IOB/Predicted" stroke="var:info" rounded={0} padding={4}><Text size={13} color="var:info">IOB 2.1U → 1.4U</Text></Frame>
+  </Frame>
+
+  {/* Stale-data indicator — 5–14min amber, ≥15min red (ties to Hero/Stale) */}
+  <Frame name="Stale" flex="row" gap={8}>
+    <Frame name="Stale/Warn" rounded={0} padding={2}><Text size={13} color="var:amber">8 MIN AGO</Text></Frame>
+    <Frame name="Stale/Error" rounded={0} padding={2}><Text size={13} color="var:error">22 MIN AGO</Text></Frame>
+  </Frame>
+
+</Frame>

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -36,7 +36,9 @@ module.exports = {
     '!src/**/*.d.ts',
     '!src/**/index.ts',
     '!src/**/*.stories.*',
-    '!src/vite-env.d.ts'
+    '!src/vite-env.d.ts',
+    'scripts/figcli/**/*.ts',
+    '!scripts/figcli/**/__tests__/**'
   ],
   coverageReporters: ['text', 'lcov', 'html'],
   coverageDirectory: 'coverage',

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -22,7 +22,9 @@ module.exports = {
   ],
   testMatch: [
     '<rootDir>/src/**/__tests__/**/*.ts?(x)',
-    '<rootDir>/src/**/*.test.ts?(x)'
+    '<rootDir>/src/**/*.test.ts?(x)',
+    '<rootDir>/scripts/**/__tests__/**/*.ts?(x)',
+    '<rootDir>/scripts/**/*.test.ts?(x)'
   ],
   testPathIgnorePatterns: [
     '/node_modules/',

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "test": "jest",
     "create-component": "ts-node scripts/create-component.ts",
     "sync-to-figma": "ts-node scripts/sync-to-figma.ts",
+    "export-figcli-design-md": "ts-node scripts/figcli/export-design-md.ts",
     "sync-figma-to-swift": "ts-node scripts/sync-figma-to-swift.ts",
     "validate-tokens": "node scripts/validate-tokens.cjs"
   },

--- a/scripts/figcli/__tests__/export-design-md.test.ts
+++ b/scripts/figcli/__tests__/export-design-md.test.ts
@@ -1,0 +1,54 @@
+import {
+  loadSources,
+  buildDesignTokens,
+  renderDesignMd,
+} from '../export-design-md';
+
+describe('DOSBTS figcli DESIGN.md export', () => {
+  const tokens = buildDesignTokens(loadSources());
+
+  test('names the figcli variable collection', () => {
+    expect(tokens.meta.source).toBe('DOSBTS / eiDotter Amber');
+  });
+
+  test('includes every required token group', () => {
+    expect(Object.keys(tokens)).toEqual(
+      expect.arrayContaining(['meta', 'color', 'radius', 'typography', 'spacing']),
+    );
+    for (const key of ['bg', 'card', 'amber', 'muted', 'success', 'error', 'info']) {
+      expect(tokens.color[key]).toBeDefined();
+    }
+    expect(tokens.spacing['4']).toBe('16px'); // eidotter 8px-grid structure
+    expect(tokens.radius.none).toBe('0px');
+    expect(tokens.typography.fontFamily).toMatch(/SF Mono/);
+    expect(tokens.typography.size.hero).toBe(60); // DOSBTS glucose hero
+  });
+
+  test('uses DOSBTS amber/bg/card/muted values, not eidotter amber-mono', () => {
+    expect(tokens.color.amber).toBe('#FFB000');
+    expect(tokens.color.bg).toBe('#0A0A0A'); // not eidotter black #020003
+    expect(tokens.color.card).toBe('#1B1917'); // not eidotter darkGray #010103
+    expect(tokens.color.muted).toBe('#594F47');
+  });
+
+  test('glucose-status colors are literal CGA, not amber-mono browns', () => {
+    expect(tokens.color.success).toBe('#00AA00'); // in-range — NOT #CB9529
+    expect(tokens.color.error).toBe('#AA0000'); // out-of-range — NOT #DCA934
+    expect(tokens.color.info).toBe('#00AAAA'); // sensor/info — NOT #D4A030
+  });
+
+  test('renders a parseable figcli design-tokens block', () => {
+    const md = renderDesignMd(tokens);
+    const match = md.match(/```json design-tokens\n([\s\S]*?)\n```/);
+    expect(match).not.toBeNull();
+    const parsed = JSON.parse(match![1]);
+    expect(parsed.meta.source).toBe('DOSBTS / eiDotter Amber');
+    expect(parsed.color.success).toBe('#00AA00');
+  });
+
+  test('fails loudly when a required source group is missing', () => {
+    expect(() => buildDesignTokens({ base: {}, web: {} } as never)).toThrow(
+      /spacing|radius|typography|source/i,
+    );
+  });
+});

--- a/scripts/figcli/__tests__/export-design-md.test.ts
+++ b/scripts/figcli/__tests__/export-design-md.test.ts
@@ -1,8 +1,16 @@
+import * as fs from 'fs';
 import {
   loadSources,
   buildDesignTokens,
   renderDesignMd,
+  main,
 } from '../export-design-md';
+
+// Mock only the write side of fs; reads (loadSources) stay real.
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return { ...actual, mkdirSync: jest.fn(), writeFileSync: jest.fn() };
+});
 
 describe('DOSBTS figcli DESIGN.md export', () => {
   const tokens = buildDesignTokens(loadSources());
@@ -46,9 +54,47 @@ describe('DOSBTS figcli DESIGN.md export', () => {
     expect(parsed.color.success).toBe('#00AA00');
   });
 
-  test('fails loudly when a required source group is missing', () => {
-    expect(() => buildDesignTokens({ base: {}, web: {} } as never)).toThrow(
-      /spacing|radius|typography|source/i,
+  test('fails loudly when sources or a required group are missing', () => {
+    expect(() => buildDesignTokens(undefined as never)).toThrow(
+      /missing required eidotter source group: spacing/i,
     );
+    expect(() => buildDesignTokens({ web: {} } as never)).toThrow(/spacing/i);
+  });
+
+  test('throws when a source group has only DTCG metadata keys', () => {
+    expect(() =>
+      buildDesignTokens({
+        web: { spacing: { $type: 'dimension' }, borderRadius: { none: { $value: '0px' } } },
+      } as never),
+    ).toThrow(/empty eidotter source group: spacing/i);
+  });
+
+  test('drops non-string $value leaves but keeps string ones', () => {
+    const tokens = buildDesignTokens({
+      web: {
+        spacing: { '4': { $value: '16px' }, weird: { $value: 16 } },
+        borderRadius: { none: { $value: '0px' } },
+        typography: { fontSize: {} },
+      },
+    } as never);
+    expect(tokens.spacing['4']).toBe('16px');
+    expect(tokens.spacing.weird).toBeUndefined();
+  });
+
+  test('main() writes a parseable DESIGN.md to figcli/', () => {
+    const write = fs.writeFileSync as jest.Mock;
+    const mkdir = fs.mkdirSync as jest.Mock;
+    write.mockClear();
+    mkdir.mockClear();
+    const log = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    main();
+    expect(mkdir).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledTimes(1);
+    const [outPath, content] = write.mock.calls[0];
+    expect(String(outPath)).toMatch(/DOSBTS\.design\.md$/);
+    const m = String(content).match(/```json design-tokens\n([\s\S]*?)\n```/);
+    expect(m).not.toBeNull();
+    expect(JSON.parse(m![1]).meta.source).toBe('DOSBTS / eiDotter Amber');
+    log.mockRestore();
   });
 });

--- a/scripts/figcli/export-design-md.ts
+++ b/scripts/figcli/export-design-md.ts
@@ -1,0 +1,181 @@
+/**
+ * DOSBTS amber `DESIGN.md` generator (Track A of the DOSBTS Figma design system, DMNC-976).
+ *
+ * Emits `figcli/DOSBTS.design.md` — a Markdown file whose machine-readable
+ * `json design-tokens` block figcli ingests via `tokens import-design-md` to create
+ * the amber Figma variable collection in `DOSBTS_fig`.
+ *
+ * Sourcing: eidotter contributes *structure* (the 8px spacing grid + DOS radius scale
+ * from `web.tokens.json`); DOSBTS contributes *values* via DOSBTS_OVERRIDES. eidotter's
+ * own CGA primitives are amber-monochromed (green/red/cyan resolve to browns), so the
+ * literal CGA glucose-status colors a CGM display needs (#00AA00/#AA0000/#00AAAA) are
+ * defined in the override map, NOT read from eidotter tokens.
+ *
+ * Standalone on purpose — NOT wired into `style-dictionary.config.mjs`, which would
+ * pollute eidotter's published token set and trip the CI token-freshness guard.
+ *
+ * Run: `npm run export-figcli-design-md` (ts-node).
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface DesignTokens {
+  meta: { source: string; generated: string };
+  color: Record<string, string>;
+  radius: Record<string, string>;
+  typography: { fontFamily: string; size: Record<string, number> };
+  spacing: Record<string, string>;
+}
+
+export interface TokenSources {
+  base: Record<string, unknown>;
+  web: Record<string, unknown>;
+}
+
+// Resolve from cwd (repo root under `npm run`, ts-node, and jest) so the module works
+// in both ESM (ts-node, package "type":"module") and CJS (ts-jest) without __dirname.
+const TOKENS_DIR = path.resolve(process.cwd(), 'src/tokens');
+const OUTPUT = path.resolve(process.cwd(), 'figcli/DOSBTS.design.md');
+
+/**
+ * figcli ingests the fenced block whose info string is exactly `json design-tokens`.
+ * Pin this against figcli `src/` during Track-B U1; kept as a single constant so the
+ * schema is a one-line change if figcli's expected shape differs.
+ */
+export const FIGCLI_FENCE = 'json design-tokens';
+
+/**
+ * DOSBTS AmberTheme values (authoritative source: DOSBTS `AmberTheme.swift` /
+ * `docs/design-system.md`). Transcribe here when those values change.
+ */
+export const DOSBTS_OVERRIDES = {
+  color: {
+    bg: '#0A0A0A',
+    card: '#1B1917',
+    amber: '#FFB000',
+    'amber-dark': '#CC8C00',
+    'amber-light': '#FFD580',
+    muted: '#594F47',
+    border: '#594F47',
+    'text-primary': '#FFB000',
+    'text-secondary': '#CC8C00',
+    'text-muted': '#594F47',
+    white: '#AAAAAA',
+    success: '#00AA00', // in-range glucose (literal CGA green)
+    error: '#AA0000', // out-of-range glucose (literal CGA red)
+    info: '#00AAAA', // sensor / info (literal CGA cyan)
+  } as Record<string, string>,
+  typography: {
+    fontFamily: 'SF Mono, ui-monospace, monospace',
+    // DOSBTS iOS point sizes (DOSTypography.swift) — the Figma must match the app, not
+    // eidotter's rem web scale.
+    size: {
+      hero: 60,
+      title: 28,
+      header: 22,
+      body: 17,
+      'body-small': 15,
+      button: 15,
+      caption: 13,
+      data: 17,
+    } as Record<string, number>,
+  },
+};
+
+export function loadSources(): TokenSources {
+  const read = (file: string) =>
+    JSON.parse(fs.readFileSync(path.join(TOKENS_DIR, file), 'utf8'));
+  return { base: read('base.tokens.json'), web: read('web.tokens.json') };
+}
+
+/** Flatten a DTCG dimension group (`{ key: { $value } }`) to `{ key: value }`. Fail loud. */
+function flattenDimension(
+  group: Record<string, unknown> | undefined,
+  label: string,
+): Record<string, string> {
+  if (!group || typeof group !== 'object') {
+    throw new Error(`Missing required eidotter source group: ${label}`);
+  }
+  const out: Record<string, string> = {};
+  for (const [key, leaf] of Object.entries(group)) {
+    if (key.startsWith('$')) continue;
+    const value = (leaf as { $value?: unknown })?.$value;
+    if (typeof value === 'string') out[key] = value;
+  }
+  if (Object.keys(out).length === 0) {
+    throw new Error(`Empty eidotter source group: ${label}`);
+  }
+  return out;
+}
+
+export function buildDesignTokens(sources: TokenSources): DesignTokens {
+  const web = (sources?.web ?? {}) as Record<string, unknown>;
+  const spacing = flattenDimension(web.spacing as Record<string, unknown>, 'spacing');
+  const radius = flattenDimension(web.borderRadius as Record<string, unknown>, 'radius');
+  const typography = web.typography as { fontSize?: unknown } | undefined;
+  if (!typography?.fontSize) {
+    throw new Error('Missing required eidotter source group: typography');
+  }
+  return {
+    meta: { source: 'DOSBTS / eiDotter Amber', generated: new Date().toISOString() },
+    color: { ...DOSBTS_OVERRIDES.color },
+    radius,
+    typography: {
+      fontFamily: DOSBTS_OVERRIDES.typography.fontFamily,
+      size: { ...DOSBTS_OVERRIDES.typography.size },
+    },
+    spacing,
+  };
+}
+
+export function renderDesignMd(tokens: DesignTokens): string {
+  const json = JSON.stringify(tokens, null, 2);
+  return `# DOSBTS — eiDotter Amber \`DESIGN.md\`
+
+**Generated** by \`scripts/figcli/export-design-md.ts\` — do not hand-edit. Re-run
+\`npm run export-figcli-design-md\` after changing DOSBTS AmberTheme values.
+
+Source: \`${tokens.meta.source}\` · figcli variable-collection name.
+
+## How figcli consumes this
+
+With Figma Desktop open on \`DOSBTS_fig\` and figcli connected in **Safe mode** (never Yolo):
+
+\`\`\`bash
+node /path/to/figma-cli/src/index.js tokens import-design-md figcli/DOSBTS.design.md
+\`\`\`
+
+This creates color/radius/typography variables. **Spacing is not created by figcli's
+import** — add the spacing variables via the figma-console MCP (\`figma_batch_create_variables\`)
+from the same block. See \`figcli/README.md\`.
+
+Glucose-status colors are **literal CGA** (\`success #00AA00\` in-range, \`error #AA0000\`
+out-of-range, \`info #00AAAA\` sensor) — sourced from the DOSBTS override map, because
+eidotter's own CGA primitives are amber-monochromed.
+
+## Machine-readable tokens
+
+\`\`\`${FIGCLI_FENCE}
+${json}
+\`\`\`
+`;
+}
+
+export function main(): void {
+  const tokens = buildDesignTokens(loadSources());
+  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+  fs.writeFileSync(OUTPUT, renderDesignMd(tokens));
+  console.log(
+    `Wrote ${path.relative(process.cwd(), OUTPUT)} — ` +
+      `${Object.keys(tokens.color).length} colors, ` +
+      `${Object.keys(tokens.spacing).length} spacing, ` +
+      `${Object.keys(tokens.radius).length} radius, ` +
+      `${Object.keys(tokens.typography.size).length} type sizes`,
+  );
+}
+
+// ESM/CJS-safe "run when invoked directly" guard (no require.main / import.meta).
+const entry = process.argv[1] ? path.basename(process.argv[1]).replace(/\.[cm]?[jt]s$/, '') : '';
+if (entry === 'export-design-md') {
+  main();
+}

--- a/scripts/figcli/export-design-md.ts
+++ b/scripts/figcli/export-design-md.ts
@@ -20,7 +20,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 export interface DesignTokens {
-  meta: { source: string; generated: string };
+  meta: { source: string };
   color: Record<string, string>;
   radius: Record<string, string>;
   typography: { fontFamily: string; size: Record<string, number> };
@@ -28,7 +28,6 @@ export interface DesignTokens {
 }
 
 export interface TokenSources {
-  base: Record<string, unknown>;
   web: Record<string, unknown>;
 }
 
@@ -64,7 +63,7 @@ export const DOSBTS_OVERRIDES = {
     success: '#00AA00', // in-range glucose (literal CGA green)
     error: '#AA0000', // out-of-range glucose (literal CGA red)
     info: '#00AAAA', // sensor / info (literal CGA cyan)
-  } as Record<string, string>,
+  },
   typography: {
     fontFamily: 'SF Mono, ui-monospace, monospace',
     // DOSBTS iOS point sizes (DOSTypography.swift) — the Figma must match the app, not
@@ -78,14 +77,14 @@ export const DOSBTS_OVERRIDES = {
       button: 15,
       caption: 13,
       data: 17,
-    } as Record<string, number>,
+    },
   },
 };
 
 export function loadSources(): TokenSources {
   const read = (file: string) =>
     JSON.parse(fs.readFileSync(path.join(TOKENS_DIR, file), 'utf8'));
-  return { base: read('base.tokens.json'), web: read('web.tokens.json') };
+  return { web: read('web.tokens.json') };
 }
 
 /** Flatten a DTCG dimension group (`{ key: { $value } }`) to `{ key: value }`. Fail loud. */
@@ -112,12 +111,8 @@ export function buildDesignTokens(sources: TokenSources): DesignTokens {
   const web = (sources?.web ?? {}) as Record<string, unknown>;
   const spacing = flattenDimension(web.spacing as Record<string, unknown>, 'spacing');
   const radius = flattenDimension(web.borderRadius as Record<string, unknown>, 'radius');
-  const typography = web.typography as { fontSize?: unknown } | undefined;
-  if (!typography?.fontSize) {
-    throw new Error('Missing required eidotter source group: typography');
-  }
   return {
-    meta: { source: 'DOSBTS / eiDotter Amber', generated: new Date().toISOString() },
+    meta: { source: 'DOSBTS / eiDotter Amber' },
     color: { ...DOSBTS_OVERRIDES.color },
     radius,
     typography: {


### PR DESCRIPTION
## Summary

Stands up **Track A** of the DOSBTS Figma design system: the committed, reproducible repo pipeline that produces everything the local Figma build consumes — without needing Figma open at author time. DOSBTS is the shipping "DOS amber CGA" CGM iOS app; it has a Swift design system but no Figma source of truth, and this is the half of that work that lives in `eidotter`.

Figma can't be written from a remote/headless session, so the work is split into two tracks. **Track A** (this PR — token export, component specs, runbook, tests) is fully reproducible and committable. **Track B** (the actual Figma variables, components, and screens) runs locally from the runbook. This PR is Track A only.

### What's here

| File | Role |
|---|---|
| `scripts/figcli/export-design-md.ts` | Generates `figcli/DOSBTS.design.md` from eidotter token structure + DOSBTS values |
| `figcli/DOSBTS.design.md` | Generated amber token file figcli imports to create the Figma variable collection |
| `figcli/components/*.jsx` | DOS-custom component render specs, each carrying its real states |
| `figcli/README.md` | Windows-aware Track-B runbook |
| test + `npm run export-figcli-design-md` | TDD coverage + regeneration entrypoint |

### Decisions worth knowing

- **Glucose-status colors are literal CGA** (`#00AA00` in-range / `#AA0000` out-of-range / `#00AAAA` sensor), set in the DOSBTS override map — because eidotter's own CGA primitives are amber-monochromed (green/red/cyan resolve to browns). For a glucose monitor these are clinical-display colors, not cosmetic; a dedicated test guards them.
- **Standalone script, not a Style Dictionary theme** — wiring DOSBTS values into the core token build would pollute eidotter's published token set and trip the CI token-freshness guard. The script reads eidotter token *structure* (8px spacing grid, DOS radius) and overlays DOSBTS *values*.
- **figcli's import is single-mode, color/radius/typography only** — spacing variables and any modes are created via figma-console MCP, so MCP co-drives Track B rather than being a mere "fallback."
- **Windows/WSL reality** — Figma Desktop runs on the Windows host and figcli is macOS-tested, so the runbook leads with the proven figma-console MCP bridge. figcli **Yolo mode is prohibited** (it patches the Figma Desktop binary, opening an unauthenticated CDP port); Safe mode or MCP only.
- **Components carry their states** — the Glucose Hero ships in-range/low/high/critical/stale variants (the most-looked-at element); Button, Stat, Event Marker Lane, IOB chip, and the rest carry their real states so screen assembly can't invent them.

### Not in this PR

Track B — installing/connecting figcli, the Apple iOS 26 kit retheme spike, importing the tokens, rendering the components, and assembling the four screens — runs locally from `figcli/README.md`.

### Tests

Built test-first. Six new tests assert the figcli collection name, group completeness, DOSBTS value fidelity, and the literal-CGA status-color guard. `jest.config` `testMatch` extended to `scripts/**`. Full suite green: **1071 tests**.

Tracks [DMNC-976](https://linear.app/lizomorf/issue/DMNC-976/dosbts-figma-design-system-figcli-pipeline-eidotter-dosbts-fig).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
