### PR TITLE
docs: sync component docs to v0.24.x — 40 components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,9 +288,13 @@ eiDotter uses Untitled UI as a **pattern reference**, not a dependency. **No UTI
 - **Figma:** UTI Figma library is set up with eiDotter's DOS tokens. eiDotter's Figma file is the source of truth for component design.
 - **License rationale:** eidotter is published under CC-BY-NC-4.0. UTI Pro is a paid commercial license that does not permit sublicensing/redistribution. Bundling UTI Pro assets into `dist/eidotter.css` / `dist/index.es.js` would have been a license violation. Pixelarticons (MIT) avoids this entirely.
 
-## Current Component Status (v0.21.0, April 2026)
+## Current Component Status (v0.24.x, June 2026)
 
-**Components** (37): Accordion, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Modal, Nav, Notification, Progress, RetroEffects, Separator, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
+**Components** (40): Accordion, AIText, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Lightbox, Modal, Nav, Notification, Progress, RetroEffects, Separator, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
+
+**AIText (v0.24.x, DMNC-946):** Inline marker for AI-drafted prose — renders a `<span data-provenance="ai-draft">` with the magenta→white→cyan shimmer gradient from `src/styles/provenance.css` (shared with the per-paragraph diff pipeline, DMNC-884). Use for marking a phrase inside otherwise-human prose; for whole paragraphs in MDX prefer the raw `data-provenance` attribute.
+
+**Lightbox (v0.21.x+, DMNC-877):** Fullscreen image viewer built on Modal's React Aria primitives — prev/next navigation, counter, caption, keyboard nav, touch swipe. Used by TimelineContainer's image/gallery entry variants.
 
 **LegalPage (DMNC-881):** Layout primitive for Impressum / Datenschutz pages — `<h1>` + "Stand: …" date hero, optional intro, optional `home` slot (back-link), and styled body that targets `<h2>`/`<p>`/`<ul>`/`<address>` children directly. Compact 14-px scale codified locally rather than in global tokens (eidotter's `text-sm = 20px` is too big for legal-document body copy; portfolio sites were already overriding to 14 px). Ships alongside reusable German DDG/DSGVO clause components (`ImpressumAddress`, `ImpressumLiabilityContent`, `DatenschutzController`, `DatenschutzPostHog`, etc.) so consumers stop copy-pasting paragraph wording across surfaces.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![license](https://img.shields.io/badge/license-CC--BY--NC--4.0-ffb000?labelColor=020003)](./LICENSE.md)
 [![React](https://img.shields.io/badge/React-18%20%7C%2019-ffb000?labelColor=020003)](https://react.dev/)
 
-**eiDotter** is a React component library that takes the DOS/CGA terminal aesthetic seriously: authentic 16-color palette, bitmap-accurate typography, phosphor glow physics, keyboard-first interactions. 36 components across forms, navigation, windowing, timelines, and terminal chrome — shipped as ES modules with a prebuilt stylesheet so consumers don't need Tailwind to use it.
+**eiDotter** is a React component library that takes the DOS/CGA terminal aesthetic seriously: authentic 16-color palette, bitmap-accurate typography, phosphor glow physics, keyboard-first interactions. 40 components across forms, navigation, windowing, timelines, and terminal chrome — shipped as ES modules with a prebuilt stylesheet so consumers don't need Tailwind to use it.
 
 → **[Storybook](https://cinimody.github.io/eiDotter/)** &nbsp;·&nbsp; **[CHANGELOG](./CHANGELOG.md)** &nbsp;·&nbsp; **[Accessibility](./ACCESSIBILITY.md)** &nbsp;·&nbsp; **[Issues](https://github.com/CinimoDY/eiDotter/issues)** &nbsp;·&nbsp; **[npm](https://www.npmjs.com/package/eidotter)**
 
@@ -92,25 +92,27 @@ The preset auto-registers `tailwindcss-react-aria-components` and `tailwindcss-a
 
 ## Components
 
-36 components across five families — [complete catalog in Storybook](https://cinimody.github.io/eiDotter/).
+40 components across five families — [complete catalog in Storybook](https://cinimody.github.io/eiDotter/).
 
 <details>
-<summary><strong>Windowing &amp; shell</strong> — Terminal, Modal, CommandPrompt, CmdPalette, Header, Footer, Nav</summary>
+<summary><strong>Windowing &amp; shell</strong> — Terminal, Modal, Lightbox, CommandPrompt, CmdPalette, Header, Footer, Nav, Brand</summary>
 
 | Component | Purpose |
 |---|---|
 | `Terminal` | DOS window with title bar, minimize/maximize/close controls |
 | `Modal` | Dialog overlay on React Aria primitives (ModalOverlay + Modal + Dialog) |
+| `Lightbox` | Fullscreen image viewer on Modal's primitives — prev/next, counter, keyboard nav, swipe |
 | `CommandPrompt` | Interactive command-line input with blinking cursor |
 | `CmdPalette` | ⌘K overlay with scored search, keyboard nav, configurable hotkey |
 | `Header` | Sticky site header (retro / modern variants), composes branding + Nav |
 | `Footer` | Site footer with default legal links (Impressum + Datenschutz) |
 | `Nav` | Responsive navigation with desktop + mobile variants |
+| `Brand` | Logo, Wordmark, BrandLockup — eiDotter branding marks |
 
 </details>
 
 <details>
-<summary><strong>Content surfaces</strong> — Card, Accordion, Alert, Badge, Tag, Notification, Stat, Progress, Separator, Breadcrumb</summary>
+<summary><strong>Content surfaces</strong> — Card, Accordion, Alert, Badge, Tag, Notification, Stat, Progress, Separator, Breadcrumb, LegalPage</summary>
 
 | Component | Purpose |
 |---|---|
@@ -124,6 +126,7 @@ The preset auto-registers `tailwindcss-react-aria-components` and `tailwindcss-a
 | `Progress` | DOS-style progress bar with block characters |
 | `Separator` | Horizontal / vertical divider |
 | `Breadcrumb` | Navigation path display |
+| `LegalPage` | Impressum / Datenschutz layout primitive with reusable German DDG/DSGVO clauses |
 
 </details>
 
@@ -142,7 +145,7 @@ The preset auto-registers `tailwindcss-react-aria-components` and `tailwindcss-a
 </details>
 
 <details>
-<summary><strong>Chat &amp; media</strong> — ChatMessage, ChatHistory, ChatInput, ChatContainer, DosFigure, Icon, InlineLink, InlineExpand</summary>
+<summary><strong>Chat &amp; media</strong> — ChatMessage, ChatHistory, ChatInput, ChatContainer, DosFigure, Icon, InlineLink, InlineExpand, AIText</summary>
 
 | Component | Purpose |
 |---|---|
@@ -154,6 +157,7 @@ The preset auto-registers `tailwindcss-react-aria-components` and `tailwindcss-a
 | `Icon` | SVG icons backed by pixelarticons |
 | `InlineLink` | In-flow anchor with dotted underline + `▸` / `↗` glyph |
 | `InlineExpand` | Inline disclosure widget for prose |
+| `AIText` | Inline AI-content marker (`data-provenance="ai-draft"`) with shimmer gradient |
 
 </details>
 

--- a/guidelines/README.md
+++ b/guidelines/README.md
@@ -4,7 +4,7 @@ A DOS-themed React component library with authentic CGA/amber phosphor aesthetic
 
 ## Overview
 
-eidotter provides 36 ready-to-use components with consistent DOS terminal styling:
+eidotter provides 40 ready-to-use components with consistent DOS terminal styling:
 
 - **Dark theme only** - Amber-on-black phosphor CRT aesthetic
 - **CGA color palette** - 16 authentic CGA colors + amber extensions

--- a/guidelines/components.md
+++ b/guidelines/components.md
@@ -766,3 +766,66 @@ DOS-styled icons backed by pixelarticons (MIT).
 <Icon name="Check" size="M" />
 <Icon name="Warning" size="L" />
 ```
+
+---
+
+## Lightbox
+
+Fullscreen image viewer built on Modal's React Aria primitives — prev/next navigation, counter, caption, keyboard nav, touch swipe.
+
+### When to Use
+
+- Viewing images from a gallery or timeline entry at full size
+- Any "click thumbnail to expand" interaction
+- Used internally by `TimelineContainer`'s image/gallery entry variants
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| images | `TimelineImage[]` | - | **Required.** Images to navigate between |
+| isOpen | `boolean` | - | **Required.** Whether the lightbox is open |
+| onClose | `() => void` | - | **Required.** Called on close button, backdrop click, or Esc |
+| initialIndex | `number` | `0` | Index to start on when opened |
+| onIndexChange | `(index: number) => void` | - | Fired when navigation moves to a new image |
+
+### Examples
+
+```tsx
+const [open, setOpen] = useState(false);
+
+<Lightbox
+  images={entry.images}
+  isOpen={open}
+  onClose={() => setOpen(false)}
+  initialIndex={2}
+/>
+```
+
+---
+
+## AIText
+
+Inline marker for AI-drafted prose. Renders a `<span data-provenance="ai-draft">` with the magenta→white→cyan shimmer gradient from the eidotter provenance system.
+
+### When to Use
+
+- Marking a single AI-drafted phrase inside otherwise-human prose
+- Hand-authored MDX where `<AIText>…</AIText>` reads more naturally than the raw attribute
+- For whole paragraphs in MDX, prefer `<p data-provenance="ai-draft">` directly — the diff pipeline unwraps it once the text drifts ≥40% from its AI baseline
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| children | `ReactNode` | - | **Required.** The AI-drafted text |
+| title | `string` | `'AI-assisted text — being rewritten'` | Tooltip text |
+| className | `string` | - | Additional CSS classes |
+
+### Examples
+
+```tsx
+<p>
+  The release notes were <AIText>drafted with Claude and are being rewritten</AIText> by hand.
+</p>
+```

--- a/llms.txt
+++ b/llms.txt
@@ -3,11 +3,11 @@
 > DOS-themed React component library with authentic CGA/amber phosphor aesthetics.
 
 ## Quick Facts
-- 36 components (Accordion, Alert, Badge, Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, Modal, Nav, Notification, Progress, RetroEffects, Separator, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens)
+- 40 components (Accordion, AIText, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Lightbox, Modal, Nav, Notification, Progress, RetroEffects, Separator, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens)
 - Dark theme only (amber-on-black phosphor CRT aesthetic)
 - CSS custom properties + Tailwind preset
 - React 18/19, Tailwind 3/4 compatible
-- Published on npm: `npm install eidotter` (current v0.19.4)
+- Published on npm: `npm install eidotter` (current v0.24.x)
 - Consumer imports: `eidotter/styles` (required); `eidotter/themes/<name>.css` (optional theme); `eidotter/utilities` (optional `.dos-*` classes for raw HTML/MDX/prose; 12 classes; v0.19.4+)
 
 ## Key Principle
@@ -16,10 +16,11 @@ NEVER hardcode colors. Always use:
 - Tailwind: `text-cga-amber`, `bg-dos-bg-primary`, etc.
 
 ## Files for AI Agents
-- CLAUDE.md: Coding instructions and component patterns
-- docs/DESIGN_PRINCIPLES.md: DOS aesthetic paradigms (the "why")
-- docs/TOKENS.md: Token reference with usage examples (the "what")
-- docs/INTEGRATION.md: Framework integration patterns (the "how")
+- CLAUDE.md: Coding instructions, component patterns, and token reference
+- guidelines/README.md: Overview, quick-start, anti-patterns
+- guidelines/components.md: Per-component usage guides
+- guidelines/patterns.md: Composition + layout patterns
+- Note: docs/ is Storybook build output (wiped on every build) — do not rely on files there
 
 ## Token Categories
 - `--color-semantic-*`: USE THESE for components (background, text, border, status)
@@ -58,7 +59,7 @@ NEVER hardcode colors. Always use:
 - Card: Content containers
 - Checkbox: Boolean inputs
 - CommandPrompt: DOS command line aesthetic
-- Icon: 89 icons (Calendar, Star, Check, etc.)
+- Icon: 12 named icons backed by pixelarticons (Info, Warning, Error, Done, Check, Close, Chevron Up/Down, App, Cancel, Fullscreen, Add); tree-shakable per-icon imports via `eidotter/icons`
 - Input: Text fields
 - Modal: Dialog overlays (uses native dialog element)
 - Progress: Loading/completion bars
@@ -70,7 +71,6 @@ NEVER hardcode colors. Always use:
 - TimelineContainer: Multi-zoom timeline (year/month/day/hour views). Supports mode="static" for read-only vertical feed (replaces TimelineList). Shared TimelineEntryData type.
 - TimelineNode: Timeline markers (circle/square/diamond, labels no longer truncated)
 - Footer: Site footer with default legal links (Impressum + Datenschutz). Exports defaultLegalLinks constant.
-- TimelineList: DEPRECATED — use TimelineContainer mode="static" instead
 - FilterBar: Multi-select filter toolbar with keyboard navigation
 - Tag: Interactive labels, filter chips, closeable tags (+ TagGroup wrapper)
 - ChatMessage: Single chat message with role-based DOS styling (user >, assistant C:\>, system italic) and streaming cursor
@@ -81,8 +81,15 @@ NEVER hardcode colors. Always use:
 - Nav: DOS-themed navigation (DesktopNav + MobileNav)
 - Separator: Horizontal/vertical content divider
 - TextScramble: DOS text decode/glitch effect
-- TimelineList: Data-driven timeline list
-- TimelineEntry: Timeline list item
+- Header: Sticky site header (retro/modern variants), composes branding + Nav
+- Notification: Toast popup with layered amber glow, auto-dismiss, progress variant
+- CmdPalette: ⌘K command palette with scored search and keyboard nav
+- DosFigure: Demoscene painted-screen media placeholder with scanline sweep
+- InlineLink: In-flow anchor with dotted underline + ▸ / ↗ glyph
+- Lightbox: Fullscreen image viewer on Modal primitives — prev/next, counter, keyboard nav, swipe
+- AIText: Inline AI-content marker rendering data-provenance="ai-draft" with shimmer gradient
+- LegalPage: Impressum/Datenschutz layout primitive + reusable German DDG/DSGVO clause components
+- Brand: Logo, Wordmark, BrandLockup branding marks
 
 ## Component Origins
 Components originate from different projects. Use `getComponentsByOrigin(projectId)` or `getComponentsByConsumer(projectId)` from the registry.


### PR DESCRIPTION
## What

Documentation drifted behind the v0.24.x releases — README claimed "36 components", CLAUDE.md said v0.21.0/37, and `llms.txt` was stale back to v0.19.4. The library actually ships **40** named components.

- **README.md** — count 36→40; added `Lightbox` (Windowing & shell), `Brand`, `LegalPage` (Content surfaces), `AIText` (Chat & media) to the family tables
- **llms.txt** — corrected component list (was missing Brand, LegalPage, AIText, Lightbox), removed long-deleted `TimelineList`/`TimelineEntry` entries, fixed icon facts (12 names via pixelarticons, not "89 icons"), version claim v0.19.4→v0.24.x, and repointed "Files for AI Agents" away from `docs/*` (Storybook wipes that dir) to `guidelines/`
- **CLAUDE.md** — component status section v0.21.0→v0.24.x with AIText + Lightbox blurbs
- **guidelines/README.md** — count 36→40
- **guidelines/components.md** — new usage sections for Lightbox and AIText

## Verification

- `npm run lint` clean
- `npm test` — 55 suites, 1107 tests pass

Closes DMNC-1008 ([Linear](https://linear.app/lizomorf/issue/DMNC-1008))

🤖 Generated with [Claude Code](https://claude.com/claude-code)