### PR TITLE
fix(accordion): remove 500px expand cap — animate grid-template-rows to natural height

### DIFF
--- a/src/components/Accordion/components/Accordion.test.tsx
+++ b/src/components/Accordion/components/Accordion.test.tsx
@@ -22,6 +22,15 @@ describe('Section', () => {
       expect(content).toHaveAttribute('inert');
     });
 
+    it('wraps children in the grid-row inner element (DMNC-928)', () => {
+      render(<Section title="Title" defaultExpanded>Tall Content</Section>);
+      const inner = document.querySelector(
+        '.eidotter-section__content > .eidotter-section__content-inner',
+      );
+      expect(inner).toBeInTheDocument();
+      expect(inner).toHaveTextContent('Tall Content');
+    });
+
     it('renders header as button', () => {
       render(<Section title="Title">Content</Section>);
       expect(screen.getByRole('button')).toBeInTheDocument();

--- a/src/components/Accordion/components/Section.css
+++ b/src/components/Accordion/components/Section.css
@@ -1,34 +1,46 @@
 /* Section — expand/collapse transitions, hover/active states, phosphor effects */
 /* Layout handled by Tailwind in Section.tsx */
 
-/* Content panel — collapse/expand via CSS transitions */
+/* Content panel — collapse/expand via CSS transitions.
+   grid-template-rows 0fr → 1fr animates to the natural content height with no
+   hard cap (a 500px max-height previously clipped tall content — DMNC-928).
+   Same pattern as TimelineContainer's entry expansion. */
 .eidotter-section__content {
-  max-height: 0;
+  display: grid;
+  grid-template-rows: 0fr;
   opacity: 0;
-  padding: 0 16px;
-  overflow: clip;
   visibility: hidden;
   border-top: 1px solid var(--color-semantic-border-default);
   font-size: var(--typography-font-size-text-sm, 14px);
   line-height: 20px;
   color: var(--color-cga-amber);
   transition:
-    max-height var(--duration-normal, 200ms) ease-in-out,
+    grid-template-rows var(--duration-normal, 200ms) ease-in-out,
     opacity var(--duration-normal, 200ms) ease-in-out,
-    padding var(--duration-normal, 200ms) ease-in-out,
     visibility 0s var(--duration-normal, 200ms);
 }
 
+/* Inner wrapper collapses with the grid row; vertical padding animates to 0
+   so border-box sizing can't hold the row open when collapsed. */
+.eidotter-section__content-inner {
+  min-height: 0;
+  overflow: clip;
+  padding: 0 16px;
+  transition: padding var(--duration-normal, 200ms) ease-in-out;
+}
+
 .eidotter-section--expanded .eidotter-section__content {
-  max-height: 500px;
+  grid-template-rows: 1fr;
   opacity: 1;
-  padding: 16px;
   visibility: visible;
   transition:
-    max-height var(--duration-normal, 200ms) ease-in-out,
+    grid-template-rows var(--duration-normal, 200ms) ease-in-out,
     opacity var(--duration-normal, 200ms) ease-in-out,
-    padding var(--duration-normal, 200ms) ease-in-out,
     visibility 0s 0s;
+}
+
+.eidotter-section--expanded .eidotter-section__content-inner {
+  padding: 16px;
 }
 
 /* Hover/active states */
@@ -89,6 +101,10 @@
   }
 
   .eidotter-section__content {
+    transition: none;
+  }
+
+  .eidotter-section__content-inner {
     transition: none;
   }
 } 

--- a/src/components/Accordion/components/Section.stories.tsx
+++ b/src/components/Accordion/components/Section.stories.tsx
@@ -64,4 +64,26 @@ export const ExpandedActive: Story = {
     defaultExpanded: true,
     isActive: true,
   },
-}; 
+};
+
+/**
+ * Regression story for DMNC-928: content far taller than the old 500px
+ * max-height cap must be fully visible when expanded — nothing clipped,
+ * the section grows to its natural content height.
+ */
+export const ExpandedTallContent: Story = {
+  args: {
+    title: 'Tall content (regression: DMNC-928)',
+    defaultExpanded: true,
+    children: (
+      <div>
+        {Array.from({ length: 12 }, (_, i) => (
+          <p key={i} style={{ marginBottom: 'var(--spacing-4, 16px)' }}>
+            Paragraph {i + 1} of 12 — {defaultContent}
+          </p>
+        ))}
+        <button type="button">Reachable control below 500px</button>
+      </div>
+    ),
+  },
+};

--- a/src/components/Accordion/components/Section.tsx
+++ b/src/components/Accordion/components/Section.tsx
@@ -70,7 +70,7 @@ export const Section: React.FC<SectionProps> = ({
         className="eidotter-section__content"
         inert={!isExpanded ? true : undefined}
       >
-        {children}
+        <div className="eidotter-section__content-inner">{children}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## What

`<Section>` clipped expanded content past a hard `max-height: 500px` with `overflow: clip` — anything below the cap was unreachable with no scrollbar hint (consumers like sticker-sheet were overriding it locally).

This replaces the max-height animation with the **`grid-template-rows: 0fr → 1fr`** pattern (option 2 from the issue — the same pattern TimelineContainer's entry expansion already uses):

- `.eidotter-section__content` becomes the animated grid wrapper (no height cap)
- new `.eidotter-section__content-inner` (`min-height: 0; overflow: clip`) collapses with the row; its vertical padding animates to 0 so border-box sizing can't hold the collapsed row open
- `inert` + `visibility` behavior unchanged; reduced-motion opt-out extended to the inner wrapper

## Verification

- Jest: Accordion suite 26 tests pass (new structural test for the inner wrapper), full lint clean
- Storybook + Playwright on the new `ExpandedTallContent` regression story (12 paragraphs + a button, 965px tall):
  - expanded: full 965px rendered, bottom button visible and inside the content box
  - collapse: animates to 0 height (1px border remainder), `visibility: hidden` + `inert`
  - re-expand: returns to natural height

Closes DMNC-928 ([Linear](https://linear.app/lizomorf/issue/DMNC-928))

🤖 Generated with [Claude Code](https://claude.com/claude-code)