### PR TITLE
fix(icon): inherit color from context instead of hardcoding amber

### DIFF
--- a/src/components/Icon/components/Icon.css
+++ b/src/components/Icon/components/Icon.css
@@ -1,9 +1,13 @@
+/* Icons follow the surrounding text color (pixelarticons use fill="currentColor").
+   Hardcoding amber here broke themed surfaces — e.g. the Section chevron stayed
+   amber on the amber hover/expanded header fill (DMNC-929). Amber-by-default in
+   neutral contexts comes from inheritance; use the `color` prop to override. */
 .icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   vertical-align: middle;
-  color: var(--color-cga-amber, #ffb000);
+  color: inherit;
 }
 
 .icon__svg {

--- a/src/components/Icon/components/Icon.stories.tsx
+++ b/src/components/Icon/components/Icon.stories.tsx
@@ -106,3 +106,28 @@ export const Colors: Story = {
     </div>
   ),
 };
+
+/**
+ * Regression story for DMNC-929: Icon must inherit the surrounding text color.
+ * On an amber surface with dark text (like the Section header in hover/expanded
+ * state), the icon has to render dark — a hardcoded amber would vanish into
+ * the fill.
+ */
+export const InheritsSurfaceColor: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '8px',
+        alignItems: 'center',
+        background: 'var(--color-semantic-background-accent)',
+        color: 'var(--color-semantic-text-secondary)',
+        padding: '8px 16px',
+        fontFamily: 'var(--typography-font-family-primary)',
+      }}
+    >
+      Dark text on amber fill
+      <Icon name="Chevron Down" size="S" />
+    </div>
+  ),
+};

--- a/src/components/Terminal/components/Terminal.css
+++ b/src/components/Terminal/components/Terminal.css
@@ -158,6 +158,8 @@
     padding: 2px 8px;
     cursor: default;
     user-select: none;
+    /* Dark symbol + icon on the amber chip — Icon inherits this (DMNC-929) */
+    color: var(--color-semantic-background-primary);
 }
 .terminal__taskbar-title {
     margin-left: 4px;


### PR DESCRIPTION
## What

`.icon` hardstamped `color: var(--color-cga-amber)` over every surrounding color. pixelarticons render with `fill="currentColor"`, so the wrapper silently overrode parent intent everywhere:

| Surface | Before | After |
|---|---|---|
| Section chevron on amber hover/expanded header | amber on amber — invisible | follows dark header text |
| Alert error/success/gray featured icon + close | amber while the outline rings followed the variant color | matches variant color |
| Notification variant icons | same mismatch | matches variant |
| Terminal window controls | amber glyphs on amber chips — invisible | dark glyphs (the intended DOS look) |
| Modal / Lightbox close hover colors | blocked by the hardstamp | apply again |

One spot relied on the hardstamp's side effect: the minimized Terminal taskbar chip now sets its own dark `color` so the App icon + title render dark on the amber chip.

Explicit amber in a neutral context is still available via the existing `color` prop.

## Verification

- Full `npm test` (54 suites, 1102 tests) + lint clean
- Storybook + Playwright computed-style checks per surface:
  - Section expanded+hover: icon `rgb(2,0,3)` == header color ✓
  - Alert error: icon == variant color ✓
  - Terminal controls (args-override story): glyph `rgb(2,0,3)` on `rgb(255,176,0)` chip ✓
  - Minimized taskbar chip: icon dark on amber ✓
- New regression story: `Icon → InheritsSurfaceColor` (dark-on-amber surface)

Closes DMNC-929 ([Linear](https://linear.app/lizomorf/issue/DMNC-929))

🤖 Generated with [Claude Code](https://claude.com/claude-code)