### PR TITLE
ci: axe a11y regression gate + Chromatic workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,3 +69,23 @@ jobs:
       run: npm run build-storybook
       env:
         NODE_ENV: production
+
+    - name: Install Playwright browser (axe gate)
+      run: npx playwright install --with-deps chromium
+
+    - name: Axe a11y regression gate
+      run: |
+        python3 -m http.server 6007 --directory docs --bind 127.0.0.1 &
+        npx wait-on tcp:127.0.0.1:6007
+        npm run test-a11y
+      env:
+        A11Y_FAIL_ON_VIOLATION: '1'
+        A11Y_REPORT_PATH: /tmp/a11y-ci-report.jsonl
+
+    - name: Upload a11y report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: a11y-report
+        path: /tmp/a11y-ci-report.jsonl
+        if-no-files-found: ignore

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,53 @@
+name: Chromatic
+
+# Visual regression via Chromatic (DMNC-1010).
+# Requires the CHROMATIC_PROJECT_TOKEN repo secret — create a project at
+# https://www.chromatic.com, link this repo, and add the token under
+# Settings → Secrets and variables → Actions. Until the secret exists,
+# the job skips itself (it does not fail).
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    env:
+      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+    steps:
+      - name: Check token
+        id: token
+        run: |
+          if [ -n "$CHROMATIC_PROJECT_TOKEN" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "CHROMATIC_PROJECT_TOKEN not configured — skipping visual regression."
+          fi
+
+      - uses: actions/checkout@v6
+        if: steps.token.outputs.present == 'true'
+        with:
+          fetch-depth: 0 # Chromatic needs full git history for baselines
+
+      - uses: actions/setup-node@v6
+        if: steps.token.outputs.present == 'true'
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        if: steps.token.outputs.present == 'true'
+        run: npm ci
+
+      - name: Run Chromatic
+        if: steps.token.outputs.present == 'true'
+        uses: chromaui/action@v13
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          buildScriptName: build-storybook
+          onlyChanged: true # TurboSnap — snapshot only stories affected by the change
+          autoAcceptChanges: main # main is the baseline; review happens on PRs
+          exitOnceUploaded: true

--- a/.storybook/a11y-known-failures.json
+++ b/.storybook/a11y-known-failures.json
@@ -1,0 +1,144 @@
+{
+  "components-timelinecontainer--default": [
+    "color-contrast"
+  ],
+  "components-timelinecontainer--month-view": [
+    "color-contrast"
+  ],
+  "components-timelinecontainer--day-view": [
+    "color-contrast"
+  ],
+  "components-timelinecontainer--hour-view": [
+    "color-contrast"
+  ],
+  "components-timelinecontainer--static-mode": [
+    "color-contrast"
+  ],
+  "components-timelinecontainer--feed-mode": [
+    "color-contrast"
+  ],
+  "components-timelinecontainer--feed-mode-with-on-load-more": [
+    "color-contrast"
+  ],
+  "components-retroeffects--default": [
+    "color-contrast"
+  ],
+  "components-retroeffects--scanlines-only": [
+    "color-contrast"
+  ],
+  "components-retroeffects--glow-only": [
+    "color-contrast"
+  ],
+  "components-timelinecontainer--on-light-backdrop": [
+    "color-contrast"
+  ],
+  "components-retroeffects--subtle-effects": [
+    "color-contrast"
+  ],
+  "components-timelinecontainer--single-entry": [
+    "color-contrast"
+  ],
+  "components-retroeffects--intense-effects": [
+    "color-contrast"
+  ],
+  "components-retroeffects--no-effects": [
+    "color-contrast"
+  ],
+  "components-timelinecontainer--mobile": [
+    "color-contrast"
+  ],
+  "components-retroeffects--with-bloom": [
+    "color-contrast"
+  ],
+  "components-retroeffects--power-cycle": [
+    "color-contrast"
+  ],
+  "components-timelinecontainer--tablet": [
+    "color-contrast"
+  ],
+  "components-retroeffects--powered-off": [
+    "color-contrast"
+  ],
+  "components-timelinecontainer--ultrawide": [
+    "color-contrast"
+  ],
+  "components-retroeffects--with-callbacks": [
+    "color-contrast"
+  ],
+  "components-timelinecontainer--controlled": [
+    "color-contrast"
+  ],
+  "components-timelinecontainer--custom-render-entry": [
+    "color-contrast"
+  ],
+  "components-tag--closeable": [
+    "color-contrast"
+  ],
+  "components-tag--with-colors": [
+    "color-contrast"
+  ],
+  "components-button--destructive": [
+    "color-contrast"
+  ],
+  "components-tag--timeline-entry": [
+    "color-contrast"
+  ],
+  "components-button--all-variants": [
+    "color-contrast"
+  ],
+  "components-button--phosphor-states": [
+    "color-contrast"
+  ],
+  "components-timelinenode--all-shapes-and-sizes": [
+    "color-contrast"
+  ],
+  "components-breadcrumb--all-variants": [
+    "color-contrast"
+  ],
+  "components-switch--all-states": [
+    "color-contrast"
+  ],
+  "components-card--default": [
+    "color-contrast"
+  ],
+  "components-card--elevated": [
+    "color-contrast"
+  ],
+  "components-card--bordered": [
+    "color-contrast"
+  ],
+  "components-card--glow": [
+    "color-contrast"
+  ],
+  "components-card--with-footer": [
+    "color-contrast"
+  ],
+  "components-card--all-variants": [
+    "color-contrast"
+  ],
+  "components-commandprompt--disabled": [
+    "color-contrast"
+  ],
+  "brand-lockup--default": [
+    "color-contrast"
+  ],
+  "brand-lockup--small-lockup": [
+    "color-contrast"
+  ],
+  "brand-lockup--hero-lockup": [
+    "color-contrast"
+  ],
+  "brand-lockup--wordmark-only": [
+    "color-contrast"
+  ],
+  "brand-lockup--no-glow": [
+    "color-contrast"
+  ],
+  "brand-lockup--wordmark-inline": [
+    "aria-prohibited-attr",
+    "color-contrast"
+  ],
+  "components-footer--with-extra-content": [
+    "color-contrast"
+  ]
+}

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -60,14 +60,17 @@ const preview: Preview = {
     (Story, context) => {
       const meta = context.parameters.projectMeta;
       return React.createElement('div', { 'data-theme': 'amber-mono', style: { padding: '1rem' } },
+        // text-primary (not cga-brown): the banner is on every story, and
+        // brown (#AA5500, ~3.7:1) failed the axe color-contrast gate as
+        // chrome noise drowning out real component violations (DMNC-1011).
         meta ? React.createElement('div', {
           style: {
             fontFamily: 'var(--font-dos, monospace)',
             fontSize: '11px',
             padding: '4px 8px',
             marginBottom: '8px',
-            color: 'var(--color-cga-brown, #AA5500)',
-            borderBottom: '1px solid var(--color-cga-brown, #AA5500)',
+            color: 'var(--color-semantic-text-primary, #b87c1a)',
+            borderBottom: '1px solid var(--color-semantic-text-primary, #b87c1a)',
           }
         }, `Origin: ${meta.origin}${meta.originNote ? ` — ${meta.originNote}` : ''} | Used by: ${meta.consumers.join(', ') || 'none'}`) : null,
         React.createElement(Story)

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -1,10 +1,16 @@
 import type { TestRunnerConfig } from '@storybook/test-runner';
 import { getStoryContext } from '@storybook/test-runner';
 import { injectAxe, getViolations, configureAxe } from 'axe-playwright';
-import { writeFileSync, appendFileSync, existsSync, mkdirSync } from 'node:fs';
+import { writeFileSync, appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 const REPORT_PATH = process.env.A11Y_REPORT_PATH ?? 'solutions/best-practices/storybook-a11y-baseline-2026-05-05.json';
+
+// Ratchet for the CI gate — story id → axe rule ids that are known to fail
+// (pre-existing, tracked under DMNC-1012). See the gate block in postVisit.
+const knownFailures: Record<string, string[]> = JSON.parse(
+  readFileSync(new URL('a11y-known-failures.json', import.meta.url), 'utf-8'),
+);
 
 const reportDir = dirname(REPORT_PATH);
 if (!existsSync(reportDir)) mkdirSync(reportDir, { recursive: true });
@@ -50,6 +56,26 @@ const config: TestRunnerConfig = {
         violations: slim,
       }) + '\n',
     );
+
+    // CI gate (DMNC-1011): report-only by default so local baseline runs
+    // keep collecting; with A11Y_FAIL_ON_VIOLATION set, violations fail the
+    // story's test and therefore the CI job — except those in the ratchet
+    // file. a11y-known-failures.json pins the pre-existing violations (the
+    // 2026-05-05 audit's "story-level / amber-aesthetic" backlog, worked off
+    // under DMNC-1012): a known story may keep its known rule ids, but any
+    // NEW story violation or new rule on a known story fails. Shrink the
+    // file as entries get fixed — never grow it without a tracking issue.
+    if (process.env.A11Y_FAIL_ON_VIOLATION && violations.length > 0) {
+      const allowedRules: string[] = knownFailures[context.id] ?? [];
+      const fresh = slim.filter((v: { id: string }) => !allowedRules.includes(v.id));
+      if (fresh.length > 0) {
+        throw new Error(
+          `axe: ${fresh.length} new WCAG violation(s) in "${context.title} › ${context.name}": ` +
+            fresh.map((v: { id: string; impact: string }) => `${v.id} (${v.impact})`).join(', ') +
+            (allowedRules.length ? ` (allowlisted here: ${allowedRules.join(', ')})` : ''),
+        );
+      }
+    }
   },
 };
 

--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -92,7 +92,24 @@ A11Y_REPORT_PATH=solutions/best-practices/storybook-a11y-baseline-2026-05-05.ndj
   npx test-storybook --url http://127.0.0.1:6007 --maxWorkers 2 --no-cache
 ```
 
-Both scripts are reporting tools — exit code is always 0 in this audit cycle. A future plan will gate CI on regressions.
+Both commands above are reporting tools — exit code is always 0.
+
+## CI regression gate (since 2026-06-10, DMNC-1011)
+
+`build.yml` runs the same axe scan against the built Storybook on every PR with
+`A11Y_FAIL_ON_VIOLATION=1`. In that mode, `.storybook/test-runner.ts` fails any
+story with a violation **not** pinned in `.storybook/a11y-known-failures.json`
+— the ratchet of pre-existing violations (47 stories, mostly amber-aesthetic
+`color-contrast` tensions) being worked off under DMNC-1012. Shrink that file
+as entries get fixed; never grow it without a tracking issue.
+
+Run the gate locally:
+
+```bash
+npm run build-storybook
+( cd docs && python3 -m http.server 6007 ) &
+A11Y_FAIL_ON_VIOLATION=1 A11Y_REPORT_PATH=/tmp/a11y-gate.jsonl npm run test-a11y
+```
 
 ---
 

--- a/src/components/Input/components/Input.stories.tsx
+++ b/src/components/Input/components/Input.stories.tsx
@@ -69,6 +69,7 @@ export const Disabled: Story = {
 export const WithValue: Story = {
   args: {
     defaultValue: 'C:\\DOS\\COMMAND.COM',
+    'aria-label': 'Command path',
   },
 };
 

--- a/src/components/Tokens/DosUtilities.stories.tsx
+++ b/src/components/Tokens/DosUtilities.stories.tsx
@@ -7,6 +7,8 @@ const meta = {
   title: 'Design System/DOS Utilities',
   parameters: {
     layout: 'fullscreen',
+    // Deliberately renders the full palette incl. low-contrast entries — excluded from the axe CI gate (DMNC-1011, per the 2026-05-05 baseline's noise filter).
+    a11y: { disable: true },
     docs: {
       description: {
         component:

--- a/src/components/Tokens/TokenPlayground.stories.tsx
+++ b/src/components/Tokens/TokenPlayground.stories.tsx
@@ -16,6 +16,8 @@ const meta = {
   title: 'Design System/Token Playground',
   parameters: {
     layout: 'fullscreen',
+    // Deliberately renders the full palette incl. low-contrast entries — excluded from the axe CI gate (DMNC-1011, per the 2026-05-05 baseline's noise filter).
+    a11y: { disable: true },
     backgrounds: {
       default: 'dos',
       values: [{ name: 'dos', value: '#020003' }],

--- a/src/components/Tokens/Tokens.stories.tsx
+++ b/src/components/Tokens/Tokens.stories.tsx
@@ -6,6 +6,8 @@ const meta = {
   title: 'Design System/Color Tokens',
   parameters: {
     layout: 'fullscreen',
+    // Deliberately renders the full palette incl. low-contrast entries — excluded from the axe CI gate (DMNC-1011, per the 2026-05-05 baseline's noise filter).
+    a11y: { disable: true },
     backgrounds: {
       default: 'dos',
       values: [


### PR DESCRIPTION
## What

**Axe gate (DMNC-1011):** `build.yml` now runs the Storybook axe scan (wcag2a/wcag2aa/wcag21aa) on every PR with `A11Y_FAIL_ON_VIOLATION=1`. The test-runner gains a **ratchet**: violations pinned in `.storybook/a11y-known-failures.json` stay allowed; any new story violation — or a new rule on a known story — fails CI. The 47-entry allowlist is the 2026-05-05 baseline's pre-existing story-level/amber-aesthetic backlog, worked off under DMNC-1012 (shrink-only).

**Noise cleanup** (prescribed by the baseline doc, never executed until now):
- Registry-origin decorator banner: `cga-brown` (3.7:1, failed on ~every story) → `text-primary`
- Palette-display stories (Color Tokens, Token Playground, DOS Utilities): `parameters.a11y.disable` — they deliberately render low-contrast palette entries
- Raw failing stories: **276 → 47**
- Plus one real critical fix: `Input › WithValue` story had no accessible name

**Chromatic (DMNC-1010):** new `chromatic.yml` using `chromaui/action@v13` with TurboSnap (`onlyChanged`), auto-accept on main, review on PRs. **It skips itself until the `CHROMATIC_PROJECT_TOKEN` secret exists** — @CinimoDY: create a project at chromatic.com, link the repo, add the token under Settings → Secrets to activate.

ACCESSIBILITY.md documents the gate + local re-run.

## Verification

- Full gate run against Storybook: **332/332 stories pass** with enforcement on
- Negative test: before the Input story fix landed in the served build, the gate correctly failed that story with `label (critical)` — it demonstrably catches new violations
- `npm run lint` clean

Closes DMNC-1011 ([Linear](https://linear.app/lizomorf/issue/DMNC-1011)) · Refs DMNC-1010, DMNC-1012

🤖 Generated with [Claude Code](https://claude.com/claude-code)