### PR TITLE
ci: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  # Manual re-run for releases whose automatic publish failed
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -21,13 +23,19 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
         cache: 'npm'
 
+    # npm trusted publishing (OIDC) needs npm >= 11.5; Node 22 ships npm 10.
+    - name: Upgrade npm for trusted publishing
+      run: npm install -g npm@latest
+
     - name: Install dependencies
       run: npm ci
 
     - name: Build
       run: npm run build
 
+    # No NODE_AUTH_TOKEN: the npm CLI exchanges the GitHub OIDC token with the
+    # registry (trusted publisher configured on npmjs.com for this repo +
+    # workflow). The previous NPM_TOKEN secret had gone stale — npm masks bad
+    # publish auth as a 404 on PUT.
     - name: Publish
       run: npm publish --provenance --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The v0.26.0 release publish failed with npm's 404-on-PUT (stale
NPM_TOKEN — npm masks bad publish auth as 404). Trusted publishing is
configured on npmjs.com for this repo, so drop the token entirely:
npm >= 11.5 exchanges the GitHub OIDC token itself. Adds
workflow_dispatch so failed release publishes can be re-run manually.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
