### PR TITLE
fix(css): flatten cascade layers in dist stylesheet for Tailwind v3 consumers, 0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.1] - 2026-06-10
+
+### Fixed
+- **Tailwind v3 consumers broke on the v4-built stylesheet.** Tailwind v4 wraps `dist/eidotter.css` in native `@layer theme/base/utilities` blocks; Tailwind **v3** hijacks the `@layer` at-rule as its own directive grammar, so v3 apps whose bundler pipes vendor CSS through postcss (Next.js) failed with ``"`@layer base` is used but no matching `@tailwind base` directive"``. A post-build step (`scripts/flatten-css-layers.mjs`) now unwraps the layer blocks in document order — restoring exactly the unlayered cascade the v3-built dist always had. Verified against betamorf (Next + Tailwind 3).
+
 ## [0.26.0] - 2026-06-10
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",
@@ -64,7 +64,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "vite build && tsc -p tsconfig.build.json && npm run build-icons",
+    "build": "vite build && node scripts/flatten-css-layers.mjs && tsc -p tsconfig.build.json && npm run build-icons",
     "build-icons": "node scripts/icons/build-barrels.mjs && tsc -p tsconfig.icons.json",
     "fetch-icons": "node scripts/icons/fetch-svgs.mjs",
     "generate-icons": "node scripts/icons/build-tsx.mjs && node scripts/icons/build-barrels.mjs",

--- a/scripts/flatten-css-layers.mjs
+++ b/scripts/flatten-css-layers.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * Flatten CSS cascade layers in dist/eidotter.css (post-build).
+ *
+ * Tailwind v4 wraps its output in native `@layer theme/base/utilities/...`
+ * blocks. Tailwind v3 hijacks the `@layer` at-rule as its own directive
+ * grammar, so any v3 consumer whose bundler pipes node_modules CSS through
+ * postcss (Next.js does) fails with:
+ *   "`@layer base` is used but no matching `@tailwind base` directive"
+ *
+ * Unwrapping the layer blocks in document order restores exactly the
+ * (unlayered) cascade semantics the v3-built dist always had, and keeps the
+ * stylesheet consumable by v3 and v4 apps alike. Re-evaluate once every
+ * portfolio consumer is on Tailwind 4 (or none pipe vendor CSS through v3).
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import postcss from 'postcss';
+
+const FILE = new URL('../dist/eidotter.css', import.meta.url);
+
+const css = readFileSync(FILE, 'utf8');
+const root = postcss.parse(css);
+
+let unwrapped = 0;
+// Repeat until fixpoint in case of nested @layer blocks.
+let found = true;
+while (found) {
+  found = false;
+  root.walkAtRules('layer', (atRule) => {
+    found = true;
+    unwrapped += 1;
+    if (atRule.nodes && atRule.nodes.length > 0) {
+      atRule.replaceWith(atRule.nodes);
+    } else {
+      atRule.remove(); // bare `@layer a, b;` ordering statement
+    }
+  });
+}
+
+const out = root.toString();
+if (/@layer/.test(out)) {
+  console.error('[flatten-css-layers] FAILED — @layer still present after flattening');
+  process.exit(1);
+}
+
+writeFileSync(FILE, out);
+console.log(`[flatten-css-layers] OK — unwrapped ${unwrapped} @layer rule(s) in dist/eidotter.css`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,4 +132,4 @@ export type {
 } from './components/registry';
 
 // Version information
-export const version = '0.26.0';
+export const version = '0.26.1';


### PR DESCRIPTION
The v4-built dist/eidotter.css shipped native @layer blocks; Tailwind
v3 treats @layer as its own directive grammar, so v3 apps that pipe
vendor CSS through postcss (Next.js) failed with '@layer base is used
but no matching @tailwind base directive'. A post-build step now
unwraps the layer blocks in document order — identical cascade to the
v3-era unlayered dist. Verified against betamorf (Next + Tailwind 3)
via packed tarball; eidotter-home (Astro, no Tailwind pipeline)
unaffected either way.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
