### PR TITLE
feat(skeleton): DOS/CGA loading placeholder component (DMNC-1018)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,8 @@ border-color: rgba(255, 255, 255, 0.1);
 | Navigation tabs | `<Tabs>` |
 | Status indicator | `<Badge>` |
 | Text input | `<Input>` |
-| Loading state | `<Progress>` |
+| Loading state (known progress) | `<Progress>` |
+| Loading placeholder (pending content) | `<Skeleton>` |
 | Collapsible section | `<Section>` (Accordion) |
 | Navigation path | `<Breadcrumb>` |
 | Site header | `<Header>` |
@@ -290,7 +291,7 @@ eiDotter uses Untitled UI as a **pattern reference**, not a dependency. **No UTI
 
 ## Current Component Status (v0.24.x, June 2026)
 
-**Components** (40): Accordion, AIText, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Lightbox, Modal, Nav, Notification, Progress, RetroEffects, Separator, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
+**Components** (41): Accordion, AIText, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Lightbox, Modal, Nav, Notification, Progress, RetroEffects, Separator, Skeleton, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
 
 **AIText (v0.24.x, DMNC-946):** Inline marker for AI-drafted prose — renders a `<span data-provenance="ai-draft">` with the magenta→white→cyan shimmer gradient from `src/styles/provenance.css` (shared with the per-paragraph diff pipeline, DMNC-884). Use for marking a phrase inside otherwise-human prose; for whole paragraphs in MDX prefer the raw `data-provenance` attribute.
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The preset auto-registers `tailwindcss-react-aria-components` and `tailwindcss-a
 </details>
 
 <details>
-<summary><strong>Content surfaces</strong> — Card, Accordion, Alert, Badge, Tag, Notification, Stat, Progress, Separator, Breadcrumb, LegalPage</summary>
+<summary><strong>Content surfaces</strong> — Card, Accordion, Alert, Badge, Tag, Notification, Stat, Progress, Skeleton, Separator, Breadcrumb, LegalPage</summary>
 
 | Component | Purpose |
 |---|---|
@@ -124,6 +124,7 @@ The preset auto-registers `tailwindcss-react-aria-components` and `tailwindcss-a
 | `Notification` | Toast popup with layered amber glow, auto-dismiss, progress variant |
 | `Stat` | Key-value display for metrics |
 | `Progress` | DOS-style progress bar with block characters |
+| `Skeleton` | DOS/CGA loading placeholder — ░▒▓ shade rows with amber scanline sweep |
 | `Separator` | Horizontal / vertical divider |
 | `Breadcrumb` | Navigation path display |
 | `LegalPage` | Impressum / Datenschutz layout primitive with reusable German DDG/DSGVO clauses |

--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,7 @@
 > DOS-themed React component library with authentic CGA/amber phosphor aesthetics.
 
 ## Quick Facts
-- 40 components (Accordion, AIText, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Lightbox, Modal, Nav, Notification, Progress, RetroEffects, Separator, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens)
+- 41 components (Accordion, AIText, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Lightbox, Modal, Nav, Notification, Progress, RetroEffects, Separator, Skeleton, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens)
 - Dark theme only (amber-on-black phosphor CRT aesthetic)
 - CSS custom properties + Tailwind preset
 - React 18/19, Tailwind 3/4 compatible
@@ -88,6 +88,7 @@ NEVER hardcode colors. Always use:
 - InlineLink: In-flow anchor with dotted underline + ▸ / ↗ glyph
 - Lightbox: Fullscreen image viewer on Modal primitives — prev/next, counter, keyboard nav, swipe
 - AIText: Inline AI-content marker rendering data-provenance="ai-draft" with shimmer gradient
+- Skeleton: DOS/CGA loading placeholder — shade-character rows with amber scanline sweep (text/card/figure/timeline variants)
 - LegalPage: Impressum/Datenschutz layout primitive + reusable German DDG/DSGVO clause components
 - Brand: Logo, Wordmark, BrandLockup branding marks
 

--- a/src/components/Skeleton/components/Skeleton.css
+++ b/src/components/Skeleton/components/Skeleton.css
@@ -1,0 +1,106 @@
+/* Skeleton — DOS/CGA loading placeholder.
+   Shade-character rows (layout via Tailwind utilities in TSX); this file holds
+   only what Tailwind can't express: glyph clipping, the amber scanline sweep,
+   and the reduced-motion / high-contrast accommodations. */
+
+.eidotter-skeleton {
+  position: relative;
+  overflow: hidden;
+}
+
+.eidotter-skeleton__glyphs {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2, 8px);
+}
+
+/* Each line is one row of ░▒▓ cells, clipped to the container width.
+   Long deterministic texture string inside — no layout-affecting animation. */
+.eidotter-skeleton__line {
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.eidotter-skeleton__line--short {
+  width: 60%;
+}
+
+.eidotter-skeleton__line--meta {
+  width: 35%;
+}
+
+/* Figure: contiguous shade field — no row gaps, padding-less media block */
+.eidotter-skeleton--figure .eidotter-skeleton__glyphs {
+  gap: 0;
+}
+
+/* Timeline entry: marker square + indented line column */
+.eidotter-skeleton--timeline .eidotter-skeleton__glyphs {
+  flex-direction: row;
+  align-items: flex-start;
+  gap: var(--spacing-3, 12px);
+}
+
+.eidotter-skeleton__marker {
+  flex-shrink: 0;
+  width: var(--spacing-3, 12px);
+  height: var(--spacing-3, 12px);
+  margin-top: var(--spacing-1, 4px);
+}
+
+.eidotter-skeleton__entry {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2, 8px);
+  flex: 1;
+  min-width: 0;
+}
+
+/* ==========================================================================
+   Scanline sweep — amber phosphor band passing over the shade field.
+   Compositor-only: the band moves via transform, nothing else animates.
+   ========================================================================== */
+
+.eidotter-skeleton--animated::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 50%;
+  pointer-events: none;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--effects-phosphor-glow),
+    transparent
+  );
+  transform: translateX(-100%);
+  animation: eidotter-skeleton-sweep 2.4s linear infinite;
+}
+
+@keyframes eidotter-skeleton-sweep {
+  to {
+    transform: translateX(300%);
+  }
+}
+
+/* ==========================================================================
+   Accessibility
+   ========================================================================== */
+
+@media (prefers-reduced-motion: reduce) {
+  .eidotter-skeleton--animated::after {
+    animation: none;
+    content: none;
+  }
+}
+
+@media (prefers-contrast: high) {
+  .eidotter-skeleton--animated::after {
+    animation: none;
+    content: none;
+  }
+}

--- a/src/components/Skeleton/components/Skeleton.stories.tsx
+++ b/src/components/Skeleton/components/Skeleton.stories.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Skeleton } from './Skeleton';
+import '../../../styles/tokens.css';
+import '../../../styles/fonts.css';
+import '../../../styles/dos-utilities.css';
+
+/**
+ * `<Skeleton>` is eidotter's loading placeholder — DOS/CGA style.
+ *
+ * No smooth gray shimmer: pending content is a field of shade characters
+ * (░ ▒ ▓), character-cell by character-cell, swept by an amber phosphor
+ * scanline. Purely presentational — render while real content loads, then
+ * swap it out.
+ */
+const meta = {
+  title: 'Design System/Skeleton',
+  component: Skeleton,
+  parameters: {
+    layout: 'padded',
+    backgrounds: {
+      default: 'dos',
+      values: [
+        { name: 'dos', value: '#020003' },
+        { name: 'light', value: '#FFE8A8' },
+      ],
+    },
+    docs: {
+      description: {
+        component:
+          'DOS/CGA loading placeholder. Shade-character rows (░ ▒ ▓) with an amber scanline sweep. Variants: `text`, `card`, `figure`, `timeline`. The sweep is compositor-only and disabled under `prefers-reduced-motion`; the wrapper announces `label` via `role="status"` while the glyphs stay `aria-hidden`.',
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['text', 'card', 'figure', 'timeline'],
+      description: 'Placeholder shape',
+    },
+    lines: {
+      control: { type: 'number', min: 1, max: 12 },
+      description: 'Line / row count (defaults per variant: text 3, card 3, figure 4, timeline 2)',
+    },
+    animated: {
+      control: 'boolean',
+      description: 'Amber scanline sweep (off under prefers-reduced-motion)',
+    },
+    label: {
+      control: 'text',
+      description: 'Screen-reader announcement, default "Loading"',
+    },
+  },
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+type Story = StoryObj<typeof Skeleton>;
+
+const demoWidth: React.CSSProperties = { maxWidth: '48ch' };
+
+/** Default — three pending text lines, last one shortened. */
+export const Text: Story = {
+  render: (args) => (
+    <div style={demoWidth}>
+      <Skeleton {...args} />
+    </div>
+  ),
+  args: {},
+};
+
+/** Card — bordered surface with a denser heading line above the body. */
+export const Card: Story = {
+  render: (args) => (
+    <div style={demoWidth}>
+      <Skeleton {...args} />
+    </div>
+  ),
+  args: { variant: 'card' },
+};
+
+/** Figure — contiguous dense shade field for pending media (pairs with `DosFigure`). */
+export const Figure: Story = {
+  render: (args) => (
+    <div style={demoWidth}>
+      <Skeleton {...args} />
+    </div>
+  ),
+  args: { variant: 'figure', lines: 6 },
+};
+
+/** Timeline — marker square + entry column, for pending timeline entries. */
+export const Timeline: Story = {
+  render: (args) => (
+    <div style={demoWidth}>
+      <Skeleton {...args} />
+    </div>
+  ),
+  args: { variant: 'timeline' },
+};
+
+/** More lines — paragraph-sized placeholder. */
+export const ParagraphSized: Story = {
+  render: (args) => (
+    <div style={demoWidth}>
+      <Skeleton {...args} />
+    </div>
+  ),
+  args: { lines: 6 },
+};
+
+/** Static — `animated={false}`; also what reduced-motion users see. */
+export const Static: Story = {
+  render: (args) => (
+    <div style={demoWidth}>
+      <Skeleton {...args} />
+    </div>
+  ),
+  args: { animated: false },
+};
+
+/** A pending feed: several entry skeletons stacked, as in `mode="feed"` timelines. */
+export const PendingFeed: Story = {
+  render: () => (
+    <div style={{ ...demoWidth, display: 'flex', flexDirection: 'column', gap: '24px' }}>
+      <Skeleton variant="timeline" label="Loading entry 1 of 3" />
+      <Skeleton variant="timeline" label="Loading entry 2 of 3" />
+      <Skeleton variant="timeline" label="Loading entry 3 of 3" />
+    </div>
+  ),
+};

--- a/src/components/Skeleton/components/Skeleton.test.tsx
+++ b/src/components/Skeleton/components/Skeleton.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Skeleton } from './Skeleton';
+
+describe('Skeleton', () => {
+  it('renders a status element with the default label', () => {
+    render(<Skeleton />);
+    expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
+  });
+
+  it('accepts a custom label', () => {
+    render(<Skeleton label="Loading timeline entries" />);
+    expect(
+      screen.getByRole('status', { name: 'Loading timeline entries' }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the glyph rows from assistive tech', () => {
+    const { container } = render(<Skeleton />);
+    const glyphs = container.querySelector('.eidotter-skeleton__glyphs');
+    expect(glyphs).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('defaults to the text variant with 3 lines, last line shortened', () => {
+    const { container } = render(<Skeleton />);
+    expect(container.querySelector('.eidotter-skeleton--text')).not.toBeNull();
+    const lines = container.querySelectorAll('.eidotter-skeleton__line');
+    expect(lines).toHaveLength(3);
+    expect(lines[2]).toHaveClass('eidotter-skeleton__line--short');
+    expect(lines[0]).not.toHaveClass('eidotter-skeleton__line--short');
+  });
+
+  it('renders the requested number of lines', () => {
+    const { container } = render(<Skeleton lines={5} />);
+    expect(container.querySelectorAll('.eidotter-skeleton__line')).toHaveLength(5);
+  });
+
+  it('clamps lines to a minimum of 1 and does not shorten a single line', () => {
+    const { container } = render(<Skeleton lines={0} />);
+    const lines = container.querySelectorAll('.eidotter-skeleton__line');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).not.toHaveClass('eidotter-skeleton__line--short');
+  });
+
+  it('card variant adds a heading meta line above the body lines', () => {
+    const { container } = render(<Skeleton variant="card" />);
+    expect(container.querySelector('.eidotter-skeleton--card')).not.toBeNull();
+    const lines = container.querySelectorAll('.eidotter-skeleton__line');
+    expect(lines).toHaveLength(4); // 1 meta + 3 body
+    expect(lines[0]).toHaveClass('eidotter-skeleton__line--meta');
+  });
+
+  it('figure variant renders dense full-width rows with no shortened line', () => {
+    const { container } = render(<Skeleton variant="figure" />);
+    expect(container.querySelector('.eidotter-skeleton--figure')).not.toBeNull();
+    const lines = container.querySelectorAll('.eidotter-skeleton__line');
+    expect(lines).toHaveLength(4);
+    lines.forEach((line) => {
+      expect(line).not.toHaveClass('eidotter-skeleton__line--short');
+      expect(line.textContent).toContain('▓');
+    });
+  });
+
+  it('timeline variant renders a marker and an entry column', () => {
+    const { container } = render(<Skeleton variant="timeline" />);
+    expect(container.querySelector('.eidotter-skeleton--timeline')).not.toBeNull();
+    expect(container.querySelector('.eidotter-skeleton__marker')).not.toBeNull();
+    const entry = container.querySelector('.eidotter-skeleton__entry');
+    expect(entry).not.toBeNull();
+    // 1 meta line + 2 default body lines
+    expect(entry!.querySelectorAll('.eidotter-skeleton__line')).toHaveLength(3);
+  });
+
+  it('animates by default and can be disabled', () => {
+    const { container, rerender } = render(<Skeleton />);
+    expect(container.querySelector('.eidotter-skeleton--animated')).not.toBeNull();
+    rerender(<Skeleton animated={false} />);
+    expect(container.querySelector('.eidotter-skeleton--animated')).toBeNull();
+  });
+
+  it('uses shade characters for the placeholder texture', () => {
+    const { container } = render(<Skeleton />);
+    const line = container.querySelector('.eidotter-skeleton__line');
+    expect(line?.textContent).toMatch(/[░▒]/);
+  });
+
+  it('merges a custom className onto the root', () => {
+    const { container } = render(<Skeleton className="custom-class" />);
+    const root = container.querySelector('.eidotter-skeleton');
+    expect(root).toHaveClass('custom-class');
+  });
+});

--- a/src/components/Skeleton/components/Skeleton.tsx
+++ b/src/components/Skeleton/components/Skeleton.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { cn } from '../../../utils/cn';
+import './Skeleton.css';
+
+export type SkeletonVariant = 'text' | 'card' | 'figure' | 'timeline';
+
+export interface SkeletonProps {
+  /** Placeholder shape */
+  variant?: SkeletonVariant;
+  /** Number of placeholder lines (text/card/timeline body lines, figure shade rows). Defaults per variant. */
+  lines?: number;
+  /** Amber scanline sweep across the placeholder (default true; disabled under prefers-reduced-motion) */
+  animated?: boolean;
+  /** Accessible loading announcement */
+  label?: string;
+  /** Additional CSS class name */
+  className?: string;
+}
+
+/**
+ * DOS/CGA loading placeholder. Instead of the modern smooth gray shimmer,
+ * placeholder lines are rows of shade characters (░ ▒ ▓) — character-cell
+ * by character-cell, like a screenful of unrendered text mode — swept by an
+ * amber phosphor scanline.
+ *
+ * Purely presentational: render it while real content loads, then swap it
+ * out. The sweep is compositor-only (transform) and is disabled under
+ * `prefers-reduced-motion` (static placeholder remains); the glow band is
+ * removed under `prefers-contrast: high`.
+ *
+ * Glyph rows are `aria-hidden`; the wrapper announces `label` via
+ * `role="status"`.
+ */
+
+// Deterministic shade textures — stable across renders/SSR, clipped by the
+// container so any width works. Light texture reads as pending body text;
+// the dense one as a pending heading / media area.
+const TEXTURE_LIGHT = '░░░░▒░░░░░░░▒░░░▒▒░░░░░░▒░░░░░░░▒░░░░▒░░';
+const TEXTURE_DENSE = '▒▒▓▒▒▒▒▓▒▒▒▒▒▓▒▒▒▒▒▒▓▒▒▒▒▓▒▒▒▒▒▓▒▒▒▒▒▓▒';
+const REPEAT = 6; // 240 cells — wider than any realistic container
+
+const DEFAULT_LINES: Record<SkeletonVariant, number> = {
+  text: 3,
+  card: 3,
+  figure: 4,
+  timeline: 2,
+};
+
+interface LineProps {
+  dense?: boolean;
+  width?: 'full' | 'short' | 'meta';
+}
+
+const Line: React.FC<LineProps> = ({ dense = false, width = 'full' }) => (
+  <span
+    className={cn(
+      'eidotter-skeleton__line',
+      width === 'short' && 'eidotter-skeleton__line--short',
+      width === 'meta' && 'eidotter-skeleton__line--meta',
+    )}
+  >
+    {(dense ? TEXTURE_DENSE : TEXTURE_LIGHT).repeat(REPEAT)}
+  </span>
+);
+
+function renderLines(count: number, dense = false, shortenLast = true): React.ReactNode[] {
+  return Array.from({ length: count }, (_, i) => (
+    <Line
+      key={i}
+      dense={dense}
+      width={shortenLast && i === count - 1 && count > 1 ? 'short' : 'full'}
+    />
+  ));
+}
+
+export const Skeleton: React.FC<SkeletonProps> = ({
+  variant = 'text',
+  lines,
+  animated = true,
+  label = 'Loading',
+  className,
+}) => {
+  const lineCount = Math.max(1, lines ?? DEFAULT_LINES[variant]);
+
+  let glyphs: React.ReactNode;
+  switch (variant) {
+    case 'card':
+      glyphs = (
+        <>
+          <Line dense width="meta" />
+          {renderLines(lineCount)}
+        </>
+      );
+      break;
+    case 'figure':
+      glyphs = renderLines(lineCount, true, false);
+      break;
+    case 'timeline':
+      glyphs = (
+        <>
+          <span className="eidotter-skeleton__marker border-2 border-dos-border-default" />
+          <span className="eidotter-skeleton__entry">
+            <Line width="meta" />
+            {renderLines(lineCount)}
+          </span>
+        </>
+      );
+      break;
+    default:
+      glyphs = renderLines(lineCount);
+  }
+
+  return (
+    <div
+      role="status"
+      aria-label={label}
+      className={cn(
+        'eidotter-skeleton font-dos text-dos-text-muted',
+        `eidotter-skeleton--${variant}`,
+        animated && 'eidotter-skeleton--animated',
+        variant === 'card' && 'border-2 border-dos-border-default bg-dos-bg-secondary p-4',
+        variant === 'figure' && 'border-2 border-dos-border-default bg-dos-bg-secondary',
+        className,
+      )}
+    >
+      <div aria-hidden="true" className="eidotter-skeleton__glyphs">
+        {glyphs}
+      </div>
+    </div>
+  );
+};
+
+Skeleton.displayName = 'Skeleton';

--- a/src/components/Skeleton/components/index.ts
+++ b/src/components/Skeleton/components/index.ts
@@ -1,0 +1,2 @@
+export { Skeleton } from './Skeleton';
+export type { SkeletonProps, SkeletonVariant } from './Skeleton';

--- a/src/components/Skeleton/index.ts
+++ b/src/components/Skeleton/index.ts
@@ -1,0 +1,2 @@
+export { Skeleton } from './components';
+export type { SkeletonProps, SkeletonVariant } from './components';

--- a/src/components/registry.ts
+++ b/src/components/registry.ts
@@ -210,6 +210,7 @@ export const componentRegistry: Record<string, ComponentMeta> = {
   Modal:         { origin: 'eidotter', consumers: ['pomodoke-calendar'] },
   Progress:      { origin: 'eidotter', consumers: ['steuerdash'], since: '0.3.0' },
   RetroEffects:  { origin: 'spacewar', consumers: ['spacewar', 'rizomorf'], originNote: 'CRT scanline/glow effects from Spacewar!' },
+  Skeleton:      { origin: 'eidotter', consumers: [], originNote: 'DOS/CGA loading placeholder — shade-character rows (\u2591\u2592\u2593) with amber scanline sweep (DMNC-1018)' },
   Stat:          { origin: 'steuerdash', consumers: ['steuerdash'], originNote: 'Key-value display created for tax dashboard' },
   Switch:        { origin: 'eidotter', consumers: [] },
   FilterBar:     { origin: 'eidotter', consumers: ['lifelines', 'rizomorf'], originNote: 'Multi-select toggle group for faceted filtering' },

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export { DosFigure } from './components/DosFigure';
 export { CmdPalette } from './components/CmdPalette';
 export { Logo, Wordmark, BrandLockup } from './components/Brand';
 export { AIText } from './components/AIText';
+export { Skeleton } from './components/Skeleton';
 export {
   LegalPage,
   AddressBlock,
@@ -104,6 +105,7 @@ export type { DosFigureProps, DosFigurePin } from './components/DosFigure';
 export type { CmdPaletteProps, CmdPaletteItem } from './components/CmdPalette';
 export type { LogoProps, WordmarkProps, BrandLockupProps } from './components/Brand';
 export type { AITextProps } from './components/AIText';
+export type { SkeletonProps, SkeletonVariant } from './components/Skeleton';
 export type {
   LegalPageProps,
   AddressBlockProps,


### PR DESCRIPTION
Implements [DMNC-1018](https://linear.app/lizomorf/issue/DMNC-1018/skeleton-loading-component-doscga-style) — skeleton loading as a fixture, DOS-authentic.

## What

`<Skeleton variant="text|card|figure|timeline" lines={n} animated label />` — purely presentational loading placeholder. No smooth gray shimmer: pending content is rows of shade characters (░ ▒ ▓), character-cell by character-cell, swept by an amber phosphor scanline (`--effects-phosphor-glow` gradient band).

| Variant | Shape |
|---|---|
| `text` (default) | N lines, last one shortened |
| `card` | Bordered `bg-dos-bg-secondary` surface, dense ▒▓ heading line + body lines |
| `figure` | Contiguous dense shade field for pending media (pairs with `DosFigure`) |
| `timeline` | Marker square + meta line + entry lines |

## Constraints honored

- **Compositor-only**: the sweep animates `transform: translateX` on an overlay; nothing else moves
- **`prefers-reduced-motion` / `prefers-contrast: high`**: overlay removed entirely (`content: none`) — static shade field remains
- **Tokens only**: `text-dos-text-muted`, `border-dos-border-default`, `bg-dos-bg-secondary`, `--spacing-*`, `--effects-phosphor-glow`; token lint green
- **A11y**: wrapper is `role="status"` with `aria-label` (default "Loading"); glyph rows `aria-hidden`. Textures are deterministic strings — SSR-stable, no render randomness
- **V.37 pattern**: Tailwind + `cn()`; CSS file only for glyph clipping, sweep keyframes, and the media-query accommodations

No container queries needed — the component is intrinsically fluid (rows clip to container width; short/meta widths are percentages).

## Verification

- 12 unit tests (full suite: 1115 green)
- `lint`, `lint-tokens`, `tsc -p tsconfig.build.json`, `npm run build`, `build-storybook` all clean
- All four variants verified visually in the built Storybook (screenshots in Linear/chat)
- `docs/` deliberately not rebuilt (release-time convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)