### PR TITLE
feat(skeleton): CRT raster hum-bar roll replaces horizontal sweep (DMNC-1018)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The preset auto-registers `tailwindcss-react-aria-components` and `tailwindcss-a
 | `Notification` | Toast popup with layered amber glow, auto-dismiss, progress variant |
 | `Stat` | Key-value display for metrics |
 | `Progress` | DOS-style progress bar with block characters |
-| `Skeleton` | DOS/CGA loading placeholder — ░▒▓ shade rows with amber scanline sweep |
+| `Skeleton` | DOS/CGA loading placeholder — ░▒▓ shade rows with a CRT hum-bar band rolling top→bottom |
 | `Separator` | Horizontal / vertical divider |
 | `Breadcrumb` | Navigation path display |
 | `LegalPage` | Impressum / Datenschutz layout primitive with reusable German DDG/DSGVO clauses |

--- a/llms.txt
+++ b/llms.txt
@@ -88,7 +88,7 @@ NEVER hardcode colors. Always use:
 - InlineLink: In-flow anchor with dotted underline + ▸ / ↗ glyph
 - Lightbox: Fullscreen image viewer on Modal primitives — prev/next, counter, keyboard nav, swipe
 - AIText: Inline AI-content marker rendering data-provenance="ai-draft" with shimmer gradient
-- Skeleton: DOS/CGA loading placeholder — shade-character rows with amber scanline sweep (text/card/figure/timeline variants)
+- Skeleton: DOS/CGA loading placeholder — shade-character rows with a CRT hum-bar band rolling top→bottom (text/card/figure/timeline variants)
 - LegalPage: Impressum/Datenschutz layout primitive + reusable German DDG/DSGVO clause components
 - Brand: Logo, Wordmark, BrandLockup branding marks
 

--- a/src/components/Skeleton/components/Skeleton.css
+++ b/src/components/Skeleton/components/Skeleton.css
@@ -1,6 +1,6 @@
 /* Skeleton — DOS/CGA loading placeholder.
    Shade-character rows (layout via Tailwind utilities in TSX); this file holds
-   only what Tailwind can't express: glyph clipping, the amber scanline sweep,
+   only what Tailwind can't express: glyph clipping, the rolling raster band,
    and the reduced-motion / high-contrast accommodations. */
 
 .eidotter-skeleton {
@@ -59,31 +59,35 @@
 }
 
 /* ==========================================================================
-   Scanline sweep — amber phosphor band passing over the shade field.
-   Compositor-only: the band moves via transform, nothing else animates.
+   Raster animation — CRT hum-bar roll, top → bottom. Compositor-only.
+   A horizontal glow band rolls down the shade field the way the refresh-beat
+   bar rolls down a CGA monitor. The gradient is asymmetric: bright leading
+   edge at the bottom (where the beam is), phosphor-decay tail fading upward.
    ========================================================================== */
 
 .eidotter-skeleton--animated::after {
   content: '';
   position: absolute;
   top: 0;
-  bottom: 0;
   left: 0;
-  width: 50%;
+  right: 0;
+  height: 45%;
   pointer-events: none;
   background: linear-gradient(
-    90deg,
-    transparent,
-    var(--effects-phosphor-glow),
-    transparent
+    180deg,
+    transparent 0%,
+    var(--effects-phosphor-glow) 78%,
+    transparent 100%
   );
-  transform: translateX(-100%);
-  animation: eidotter-skeleton-sweep 2.4s linear infinite;
+  transform: translateY(-100%);
+  /* 1.6s sits in the 1.4-2.0s window where perceived wait is shortest
+     (Stanford JCR 2025: perceived duration is convex in animation speed). */
+  animation: eidotter-skeleton-raster 1.6s linear infinite;
 }
 
-@keyframes eidotter-skeleton-sweep {
+@keyframes eidotter-skeleton-raster {
   to {
-    transform: translateX(300%);
+    transform: translateY(330%);
   }
 }
 
@@ -91,10 +95,27 @@
    Accessibility
    ========================================================================== */
 
+/* Reduced motion: replace the rolling band with a very gentle opacity
+   breathing (Carbon's accessible-skeleton pattern, WCAG C39) — still reads
+   as "loading", no vestibular trigger. */
 @media (prefers-reduced-motion: reduce) {
   .eidotter-skeleton--animated::after {
     animation: none;
     content: none;
+  }
+
+  .eidotter-skeleton--animated .eidotter-skeleton__glyphs {
+    animation: eidotter-skeleton-breathe 3s ease-in-out infinite;
+  }
+}
+
+@keyframes eidotter-skeleton-breathe {
+  0%,
+  100% {
+    opacity: 0.7;
+  }
+  50% {
+    opacity: 1;
   }
 }
 
@@ -102,5 +123,10 @@
   .eidotter-skeleton--animated::after {
     animation: none;
     content: none;
+  }
+
+  .eidotter-skeleton--animated .eidotter-skeleton__glyphs {
+    animation: none;
+    opacity: 1;
   }
 }

--- a/src/components/Skeleton/components/Skeleton.stories.tsx
+++ b/src/components/Skeleton/components/Skeleton.stories.tsx
@@ -9,8 +9,9 @@ import '../../../styles/dos-utilities.css';
  * `<Skeleton>` is eidotter's loading placeholder — DOS/CGA style.
  *
  * No smooth gray shimmer: pending content is a field of shade characters
- * (░ ▒ ▓), character-cell by character-cell, swept by an amber phosphor
- * scanline. Purely presentational — render while real content loads, then
+ * (░ ▒ ▓), character-cell by character-cell, with a CRT hum-bar glow band
+ * rolling top→bottom over it — the way the refresh beat rolls down a CGA
+ * monitor. Purely presentational — render while real content loads, then
  * swap it out.
  */
 const meta = {
@@ -28,7 +29,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'DOS/CGA loading placeholder. Shade-character rows (░ ▒ ▓) with an amber scanline sweep. Variants: `text`, `card`, `figure`, `timeline`. The sweep is compositor-only and disabled under `prefers-reduced-motion`; the wrapper announces `label` via `role="status"` while the glyphs stay `aria-hidden`.',
+          'DOS/CGA loading placeholder. Shade-character rows (░ ▒ ▓) with a CRT hum-bar glow band rolling top→bottom (phosphor-decay tail, 1.6s cycle). Variants: `text`, `card`, `figure`, `timeline`. Compositor-only; under `prefers-reduced-motion` the band becomes a gentle opacity breathing. The wrapper announces `label` via `role="status"` while the glyphs stay `aria-hidden`.',
       },
     },
   },
@@ -44,7 +45,8 @@ const meta = {
     },
     animated: {
       control: 'boolean',
-      description: 'Amber scanline sweep (off under prefers-reduced-motion)',
+      description:
+        'CRT hum-bar band rolling top→bottom; replaced by gentle opacity breathing under prefers-reduced-motion',
     },
     label: {
       control: 'text',
@@ -108,7 +110,7 @@ export const ParagraphSized: Story = {
   args: { lines: 6 },
 };
 
-/** Static — `animated={false}`; also what reduced-motion users see. */
+/** Static — `animated={false}`. (Reduced-motion users get a gentle opacity breathing instead, not this.) */
 export const Static: Story = {
   render: (args) => (
     <div style={demoWidth}>

--- a/src/components/Skeleton/components/Skeleton.tsx
+++ b/src/components/Skeleton/components/Skeleton.tsx
@@ -9,7 +9,12 @@ export interface SkeletonProps {
   variant?: SkeletonVariant;
   /** Number of placeholder lines (text/card/timeline body lines, figure shade rows). Defaults per variant. */
   lines?: number;
-  /** Amber scanline sweep across the placeholder (default true; disabled under prefers-reduced-motion) */
+  /**
+   * Raster animation: a CRT hum-bar glow band rolling top→bottom with a
+   * phosphor-decay tail, like the refresh beat on a CGA monitor. Default true.
+   * Under prefers-reduced-motion the band is replaced by a gentle opacity
+   * breathing; prefers-contrast: high disables all animation.
+   */
   animated?: boolean;
   /** Accessible loading announcement */
   label?: string;
@@ -20,13 +25,14 @@ export interface SkeletonProps {
 /**
  * DOS/CGA loading placeholder. Instead of the modern smooth gray shimmer,
  * placeholder lines are rows of shade characters (░ ▒ ▓) — character-cell
- * by character-cell, like a screenful of unrendered text mode — swept by an
- * amber phosphor scanline.
+ * by character-cell, like a screenful of unrendered text mode — with a CRT
+ * hum-bar glow band rolling top→bottom over them, phosphor-decay tail
+ * trailing upward, the way the refresh beat rolls down a CGA monitor.
  *
  * Purely presentational: render it while real content loads, then swap it
- * out. The sweep is compositor-only (transform) and is disabled under
- * `prefers-reduced-motion` (static placeholder remains); the glow band is
- * removed under `prefers-contrast: high`.
+ * out. The band is compositor-only (transform). Under
+ * `prefers-reduced-motion` it is replaced by a gentle opacity breathing;
+ * `prefers-contrast: high` disables all animation.
  *
  * Glyph rows are `aria-hidden`; the wrapper announces `label` via
  * `role="status"`.

--- a/src/components/registry.ts
+++ b/src/components/registry.ts
@@ -210,7 +210,7 @@ export const componentRegistry: Record<string, ComponentMeta> = {
   Modal:         { origin: 'eidotter', consumers: ['pomodoke-calendar'] },
   Progress:      { origin: 'eidotter', consumers: ['steuerdash'], since: '0.3.0' },
   RetroEffects:  { origin: 'spacewar', consumers: ['spacewar', 'rizomorf'], originNote: 'CRT scanline/glow effects from Spacewar!' },
-  Skeleton:      { origin: 'eidotter', consumers: [], originNote: 'DOS/CGA loading placeholder — shade-character rows (\u2591\u2592\u2593) with amber scanline sweep (DMNC-1018)' },
+  Skeleton:      { origin: 'eidotter', consumers: [], originNote: 'DOS/CGA loading placeholder — shade-character rows (\u2591\u2592\u2593) with CRT hum-bar band rolling top\u2192bottom (DMNC-1018)' },
   Stat:          { origin: 'steuerdash', consumers: ['steuerdash'], originNote: 'Key-value display created for tax dashboard' },
   Switch:        { origin: 'eidotter', consumers: [] },
   FilterBar:     { origin: 'eidotter', consumers: ['lifelines', 'rizomorf'], originNote: 'Multi-select toggle group for faceted filtering' },


### PR DESCRIPTION
Design feedback on the just-merged Skeleton: the left→right glow band read as "progress bar", not CRT. This replaces it with a **raster roll** — a glow band rolling **top→bottom** with an asymmetric gradient (bright leading edge at the bottom where the beam is, phosphor-decay tail fading upward), the way the refresh beat rolls down a CGA monitor.

## Research-grounded

- **Directed motion beats pulsing** — pulsing skeletons tested *worse than spinners* (Viget 2017); shimmer beat pulse (Chung 2018); NN/G discourages pulsing frames. So a band stays — but the L→R evidence is thin (only ever tested vs pulse), and vertical is the CRT-authentic direction.
- **Cycle = 1.6s** — perceived wait is convex in animation speed (Stanford JCR 2025): too slow *and* too fast both feel longer; minimum sits ~1.4–2.0s.
- **Reduced motion ≠ static** — now a gentle 3s opacity breathing (Carbon's accessible-skeleton pattern, WCAG C39); `prefers-contrast: high` still kills all animation.

## Notes

- Still compositor-only: one `transform` on a pseudo-element, or pure `opacity`.
- A prototype `effect` prop (raster/warmup/sweep) was built for side-by-side comparison in Storybook and stripped after the decision — **no API change**: `animated` boolean as before.
- Docs wording updated (stories, README, llms.txt, registry note).

Verified: 12 Skeleton tests green, eslint/tsc/token-lint clean, raster roll + 320px clipping confirmed visually in Storybook dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)