### PR TITLE
chore(release): 0.27.0 — Skeleton loading placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.0] - 2026-06-11
+
+### Added
+- **`<Skeleton>` — DOS/CGA loading placeholder (DMNC-1018).** Pending content renders as rows of shade characters (░ ▒ ▓) instead of a smooth gray shimmer, with a CRT hum-bar glow band rolling top→bottom over the field (asymmetric gradient: bright leading edge where the beam is, phosphor-decay tail fading upward — the refresh beat rolling down a CGA monitor). Variants: `text` (lines, last shortened), `card` (bordered surface + dense heading line), `figure` (contiguous dense shade field, pairs with `DosFigure`), `timeline` (marker square + entry column). Props: `variant`, `lines` (per-variant defaults), `animated`, `label`, `className`. Compositor-only animation at a research-backed 1.6s cycle; under `prefers-reduced-motion` the band becomes a gentle opacity breathing (Carbon's accessible-skeleton pattern); `prefers-contrast: high` disables all animation. Wrapper announces via `role="status"`; glyph rows stay `aria-hidden`.
+
+### Changed
+- Dependency batch (#374): storybook 10.4.3, chromatic CLI 17.4.0 + chromaui/action v17, actions/upload-artifact v7, react-aria 3.49 family, vite 8.0.16, style-dictionary 5.4.4 (zero-valued dimension tokens now emit `0px` — semantically identical; preset gains `dos-0`/`dos-none` keys, Swift tokens gain `sp0`), qs 6.15.2, and the rest of the minor-and-patch group.
+
 ## [0.26.1] - 2026-06-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,11 +289,13 @@ eiDotter uses Untitled UI as a **pattern reference**, not a dependency. **No UTI
 - **Figma:** UTI Figma library is set up with eiDotter's DOS tokens. eiDotter's Figma file is the source of truth for component design.
 - **License rationale:** eidotter is published under CC-BY-NC-4.0. UTI Pro is a paid commercial license that does not permit sublicensing/redistribution. Bundling UTI Pro assets into `dist/eidotter.css` / `dist/index.es.js` would have been a license violation. Pixelarticons (MIT) avoids this entirely.
 
-## Current Component Status (v0.24.x, June 2026)
+## Current Component Status (v0.27.x, June 2026)
 
 **Components** (41): Accordion, AIText, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Lightbox, Modal, Nav, Notification, Progress, RetroEffects, Separator, Skeleton, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
 
 **AIText (v0.24.x, DMNC-946):** Inline marker for AI-drafted prose — renders a `<span data-provenance="ai-draft">` with the magenta→white→cyan shimmer gradient from `src/styles/provenance.css` (shared with the per-paragraph diff pipeline, DMNC-884). Use for marking a phrase inside otherwise-human prose; for whole paragraphs in MDX prefer the raw `data-provenance` attribute.
+
+**Skeleton (v0.27.0, DMNC-1018):** DOS/CGA loading placeholder — rows of shade characters (░ ▒ ▓) with a CRT hum-bar glow band rolling top→bottom (1.6s, compositor-only; gentle opacity breathing under reduced motion, all animation off in high contrast). Variants: text/card/figure/timeline. Purely presentational — render while content loads, then swap out.
 
 **Lightbox (v0.21.x+, DMNC-877):** Fullscreen image viewer built on Modal's React Aria primitives — prev/next navigation, counter, caption, keyboard nav, touch swipe. Used by TimelineContainer's image/gallery entry variants.
 

--- a/guidelines/components.md
+++ b/guidelines/components.md
@@ -407,6 +407,43 @@ Visual indicator for completion or loading.
 
 ---
 
+## Skeleton
+
+DOS/CGA loading placeholder — shade-character rows (░ ▒ ▓) with a CRT hum-bar glow band rolling top→bottom.
+
+### When to Use
+
+- Content placeholder while data loads (use `Progress` when completion is measurable)
+- Pending timeline entries, cards, or media blocks
+- Anywhere a modern app would show a gray shimmer skeleton
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| variant | `'text' \| 'card' \| 'figure' \| 'timeline'` | `'text'` | Placeholder shape |
+| lines | `number` | per variant | Line/row count (text 3, card 3, figure 4, timeline 2) |
+| animated | `boolean` | `true` | Raster band; gentle opacity breathing under `prefers-reduced-motion` |
+| label | `string` | `'Loading'` | Screen-reader announcement (`role="status"`) |
+
+### Examples
+
+```tsx
+// Pending paragraph
+<Skeleton lines={4} />
+
+// Pending card with heading line
+<Skeleton variant="card" />
+
+// Pending media block (pairs with DosFigure)
+<Skeleton variant="figure" lines={6} />
+
+// Pending timeline entry
+<Skeleton variant="timeline" label="Loading entries" />
+```
+
+---
+
 ## Breadcrumb
 
 Navigation path showing location hierarchy.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,4 +134,4 @@ export type {
 } from './components/registry';
 
 // Version information
-export const version = '0.26.1';
+export const version = '0.27.0';


### PR DESCRIPTION
Release prep for 0.27.0 — ships `<Skeleton>` (DMNC-1018, #373 + #375) and the dependency batch (#374).

- CHANGELOG `[0.27.0]` entry (Added: Skeleton; Changed: dep batch incl. style-dictionary 5.4.4 token output change)
- Version bump: `package.json` + `src/index.ts` → 0.27.0
- CLAUDE.md component status → v0.27.x with Skeleton note
- `guidelines/components.md` gains a Skeleton section (when-to-use vs Progress, props, examples)

After merge: `gh release create v0.27.0` → `publish.yml` publishes to npm via OIDC trusted publishing; Storybook redeploys from main automatically.

Verified: 1115 tests + build green on the bumped tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)