### PR TITLE
fix(header): retro variant opaque background (sticky see-through bug)

### DIFF
--- a/src/components/Header/components/Header.css
+++ b/src/components/Header/components/Header.css
@@ -14,7 +14,12 @@
 }
 
 .eidotter-header--retro {
-  background-color: transparent;
+  /* Opaque, not transparent: Header is sticky by default, and this
+     unlayered rule outranks the sticky bg-dos-bg-primary utility under
+     the Tailwind v4 layer order — a transparent sticky header lets
+     content scroll visibly through it (caught on dmnc.tech). Identical
+     rendering on primary-bg pages. */
+  background-color: var(--color-semantic-background-primary);
   box-shadow: 0 1px 0 0 var(--color-cga-amber-glow);
 }
 


### PR DESCRIPTION
Reported on dmnc.tech: the top nav lets page content scroll visibly through it.

**Root cause:** `Header` is `sticky` by default, which applies `bg-dos-bg-primary` — but `.eidotter-header--retro` explicitly set `background-color: transparent`, and unlayered component CSS outranks layered Tailwind utilities since the v4 migration. Sticky + retro = transparent sticky header.

**Fix:** retro paints `var(--color-semantic-background-primary)`. Identical rendering on primary-bg pages (transparent over primary == primary), opaque when content scrolls underneath. Chromatic will confirm no visual diff on the stories.

17 Header tests green, token lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)