### PR TITLE
chore(release): 0.27.1 — header fix + Foundation Logomark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.1] - 2026-06-11
+
+### Fixed
+- **Sticky retro Header let content scroll through it.** `.eidotter-header--retro` set `background-color: transparent`, which outranks the sticky default's `bg-dos-bg-primary` utility under the Tailwind v4 layer order. Retro now paints `--color-semantic-background-primary` — identical on primary-bg pages, opaque when sticky. (#378, caught on dmnc.tech)
+
+### Changed
+- **`<Logo>` is now the Foundation Logomark** (Figma node 16-610, DMNC-1031): the amber yolk wrapped in a pixel-dotted ring — the "dotter" — with pixel specular highlights and a radial phosphor halo. Replaces the smooth "V2 yolk". Mark-only on transparent (the app-icon squircle in the Figma component is an app-icon artifact). API unchanged; gradient ids namespaced via `useId`. (#379)
+
 ## [0.27.0] - 2026-06-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",

--- a/src/components/registry.ts
+++ b/src/components/registry.ts
@@ -210,7 +210,7 @@ export const componentRegistry: Record<string, ComponentMeta> = {
   Modal:         { origin: 'eidotter', consumers: ['pomodoke-calendar'] },
   Progress:      { origin: 'eidotter', consumers: ['steuerdash'], since: '0.3.0' },
   RetroEffects:  { origin: 'spacewar', consumers: ['spacewar', 'rizomorf'], originNote: 'CRT scanline/glow effects from Spacewar!' },
-  Skeleton:      { origin: 'eidotter', consumers: [], originNote: 'DOS/CGA loading placeholder — shade-character rows (\u2591\u2592\u2593) with CRT hum-bar band rolling top\u2192bottom (DMNC-1018)' },
+  Skeleton:      { origin: 'eidotter', consumers: ['dmnctech'], originNote: 'DOS/CGA loading placeholder — shade-character rows (\u2591\u2592\u2593) with CRT hum-bar band rolling top\u2192bottom (DMNC-1018)' },
   Stat:          { origin: 'steuerdash', consumers: ['steuerdash'], originNote: 'Key-value display created for tax dashboard' },
   Switch:        { origin: 'eidotter', consumers: [] },
   FilterBar:     { origin: 'eidotter', consumers: ['lifelines', 'rizomorf'], originNote: 'Multi-select toggle group for faceted filtering' },

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,4 +134,4 @@ export type {
 } from './components/registry';
 
 // Version information
-export const version = '0.27.0';
+export const version = '0.27.1';


### PR DESCRIPTION
Patch release: #378 (sticky retro header paints opaque background) + #379 (Logo = Foundation Logomark with pixel-dotted ring). Also records dmnctech as Skeleton's first registry consumer (dmnctech#26).

After merge: `gh release create v0.27.1` → OIDC npm publish; then dmnctech#26 gets a lockfile refresh so dmnc.tech ships skeleton + header + logo together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)