### PR TITLE
feat(retro-effects): CGA boot sequence — monitor turn-on launch pattern (DMNC-1047)

### DIFF
--- a/src/components/RetroEffects/components/RetroEffects.css
+++ b/src/components/RetroEffects/components/RetroEffects.css
@@ -137,3 +137,102 @@
     display: none;
   }
 }
+
+/* ==========================================================================
+   Boot sequence — CGA monitor turn-on (DMNC-1047). ~650ms, plays once on
+   mount when `boot` is set. Ignition line → raster opens → warm glow settles.
+   All transform/opacity (compositor-only).
+   ========================================================================== */
+
+.eidotter-retro-effects__boot {
+  position: absolute;
+  inset: 0;
+}
+
+.eidotter-retro-effects__boot-panel {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 50%;
+  background: var(--color-cga-black);
+  animation: eidotter-retro-boot-panel 300ms cubic-bezier(0.22, 1, 0.36, 1) 140ms forwards;
+}
+
+.eidotter-retro-effects__boot-panel--top {
+  top: 0;
+  transform-origin: top;
+}
+
+.eidotter-retro-effects__boot-panel--bottom {
+  bottom: 0;
+  transform-origin: bottom;
+}
+
+@keyframes eidotter-retro-boot-panel {
+  to {
+    transform: scaleY(0);
+  }
+}
+
+/* The beam igniting: a bright line stretches across the center, then hands
+   off to the picture as the raster opens. */
+.eidotter-retro-effects__boot-line {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 2px;
+  margin-top: -1px;
+  background: var(--color-cga-amber);
+  box-shadow:
+    0 0 8px 2px var(--color-cga-amber-glow),
+    0 0 28px 8px var(--effects-phosphor-glow);
+  transform: scaleX(0);
+  animation: eidotter-retro-boot-line 420ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+@keyframes eidotter-retro-boot-line {
+  0% {
+    transform: scaleX(0);
+    opacity: 1;
+  }
+  34% {
+    transform: scaleX(1);
+    opacity: 1;
+  }
+  100% {
+    transform: scaleX(1);
+    opacity: 0;
+  }
+}
+
+/* Warm phosphor wash — the satisfying part. Peaks early, fades out. */
+.eidotter-retro-effects__boot-glow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 80% 60% at center,
+    var(--color-cga-amber-glow) 0%,
+    transparent 70%
+  );
+  opacity: 0;
+  animation: eidotter-retro-boot-glow 650ms ease-out forwards;
+}
+
+@keyframes eidotter-retro-boot-glow {
+  0% {
+    opacity: 0;
+  }
+  30% {
+    opacity: calc(0.55 * var(--retro-intensity));
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .eidotter-retro-effects__boot {
+    display: none;
+  }
+}

--- a/src/components/RetroEffects/components/RetroEffects.stories.tsx
+++ b/src/components/RetroEffects/components/RetroEffects.stories.tsx
@@ -358,3 +358,54 @@ export const WithCallbacks: Story = {
     },
   },
 };
+
+const BootDemo: React.FC = () => {
+  const [generation, setGeneration] = React.useState(0);
+
+  return (
+    <>
+      <div
+        style={{
+          fontFamily: 'var(--typography-font-family-primary, monospace)',
+          color: 'var(--color-cga-amber)',
+          padding: 32,
+          minHeight: 320,
+        }}
+      >
+        <h1 style={{ fontSize: 28, marginBottom: 12 }}>C:\&gt; SYSTEM READY</h1>
+        <p style={{ maxWidth: '52ch', lineHeight: 1.4 }}>
+          The monitor just turned on: an amber line ignited across the center, the raster opened
+          from it, and a warm phosphor glow settled — about 650ms, then out of the way.
+        </p>
+        <button
+          type="button"
+          onClick={() => setGeneration((g) => g + 1)}
+          style={{
+            marginTop: 16,
+            background: 'none',
+            border: '1px solid var(--color-cga-amber)',
+            color: 'var(--color-cga-amber)',
+            fontFamily: 'inherit',
+            padding: '6px 12px',
+            cursor: 'pointer',
+          }}
+        >
+          [ REBOOT ]
+        </button>
+      </div>
+      <RetroEffects key={generation} boot scanlines glow flicker={false} />
+    </>
+  );
+};
+
+export const BootSequence: Story = {
+  render: () => <BootDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The CGA monitor turn-on (DMNC-1047): pass `boot` to play a ~650ms launch sequence once on mount — ignition line → raster opens → warm glow settles. Skipped entirely under prefers-reduced-motion. Intended as the portfolio-wide first-load pattern: consumers already mounting RetroEffects in their layout add the one prop.',
+      },
+    },
+  },
+};

--- a/src/components/RetroEffects/components/RetroEffects.test.tsx
+++ b/src/components/RetroEffects/components/RetroEffects.test.tsx
@@ -420,4 +420,47 @@ describe('RetroEffects', () => {
       expect(onPowerStateChange).not.toHaveBeenCalled();
     });
   });
+
+  describe('boot sequence', () => {
+    it('does not render the boot layer by default', () => {
+      render(<RetroEffects />);
+      expect(document.querySelector('.eidotter-retro-effects__boot')).toBeNull();
+    });
+
+    it('renders ignition line, panels, and glow when boot is set', () => {
+      render(<RetroEffects boot />);
+      expect(document.querySelector('.eidotter-retro-effects__boot')).not.toBeNull();
+      expect(document.querySelectorAll('.eidotter-retro-effects__boot-panel')).toHaveLength(2);
+      expect(document.querySelector('.eidotter-retro-effects__boot-line')).not.toBeNull();
+      expect(document.querySelector('.eidotter-retro-effects__boot-glow')).not.toBeNull();
+    });
+
+    it('removes the boot layer and fires onBootComplete when the glow animation ends', () => {
+      const onBootComplete = jest.fn();
+      render(<RetroEffects boot onBootComplete={onBootComplete} />);
+      const layer = document.querySelector('.eidotter-retro-effects__boot') as HTMLElement;
+      fireAnimationEnd(layer, 'eidotter-retro-boot-glow');
+      expect(document.querySelector('.eidotter-retro-effects__boot')).toBeNull();
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores animationend from other boot animations', () => {
+      render(<RetroEffects boot />);
+      const layer = document.querySelector('.eidotter-retro-effects__boot') as HTMLElement;
+      fireAnimationEnd(layer, 'eidotter-retro-boot-line');
+      expect(document.querySelector('.eidotter-retro-effects__boot')).not.toBeNull();
+    });
+
+    it('settles via the safety timeout if no animation event arrives', () => {
+      jest.useFakeTimers();
+      const onBootComplete = jest.fn();
+      render(<RetroEffects boot onBootComplete={onBootComplete} />);
+      act(() => {
+        jest.advanceTimersByTime(1300);
+      });
+      expect(document.querySelector('.eidotter-retro-effects__boot')).toBeNull();
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+      jest.useRealTimers();
+    });
+  });
 });

--- a/src/components/RetroEffects/components/RetroEffects.tsx
+++ b/src/components/RetroEffects/components/RetroEffects.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { cn } from '../../../utils/cn';
+import { prefersReducedMotion } from '../../../utils/prefersReducedMotion';
 import './RetroEffects.css';
 
 export type PowerState = 'on' | 'powering-on' | 'powering-off' | 'off';
@@ -27,6 +28,14 @@ export interface RetroEffectsProps {
    */
   powered?: boolean;
   /**
+   * Play the CGA monitor boot sequence once on mount (~650ms): an amber
+   * ignition line stretches across the center, the black raster opens from
+   * it, and a warm phosphor glow settles. Skipped entirely under
+   * prefers-reduced-motion. Opt-in; intended as the portfolio-wide launch
+   * pattern (DMNC-1047).
+   */
+  boot?: boolean;
+  /**
    * Intensity of the effects (0-1)
    */
   intensity?: number;
@@ -46,6 +55,10 @@ export interface RetroEffectsProps {
    * Callback when power-off animation completes
    */
   onPowerOff?: () => void;
+  /**
+   * Callback when the boot sequence completes (or is skipped)
+   */
+  onBootComplete?: () => void;
 }
 
 /**
@@ -66,14 +79,41 @@ export const RetroEffects: React.FC<RetroEffectsProps> = ({
   flicker = true,
   bloom = false,
   powered = true,
+  boot = false,
   intensity = 1,
   className,
   onPowerStateChange,
   onPowerOn,
   onPowerOff,
+  onBootComplete,
 }) => {
   const prevPoweredRef = useRef(powered);
   const [powerState, setPowerState] = useState<PowerState>(powered ? 'on' : 'off');
+  const [booting, setBooting] = useState(boot);
+
+  // Boot settles via the glow's animationend; reduced-motion (where the boot
+  // layer is display:none and never animates) and any missed event settle via
+  // this effect instead.
+  useEffect(() => {
+    if (!booting) return;
+    if (prefersReducedMotion()) {
+      setBooting(false);
+      onBootComplete?.();
+      return;
+    }
+    const safety = window.setTimeout(() => {
+      setBooting(false);
+      onBootComplete?.();
+    }, 1200);
+    return () => window.clearTimeout(safety);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [booting]);
+
+  const handleBootAnimationEnd = (event: React.AnimationEvent) => {
+    if (event.animationName !== 'eidotter-retro-boot-glow') return;
+    setBooting(false);
+    onBootComplete?.();
+  };
 
   // Track power state transitions (intentional: animation state machine requires
   // syncing prop changes to transitional states, settled by onAnimationEnd)
@@ -145,6 +185,14 @@ export const RetroEffects: React.FC<RetroEffectsProps> = ({
           {flicker && <div className="eidotter-retro-effects__flicker" />}
           {bloom && <div className="eidotter-retro-effects__bloom" />}
         </>
+      )}
+      {booting && (
+        <div className="eidotter-retro-effects__boot" onAnimationEnd={handleBootAnimationEnd}>
+          <div className="eidotter-retro-effects__boot-panel eidotter-retro-effects__boot-panel--top" />
+          <div className="eidotter-retro-effects__boot-panel eidotter-retro-effects__boot-panel--bottom" />
+          <div className="eidotter-retro-effects__boot-line" />
+          <div className="eidotter-retro-effects__boot-glow" />
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
Implements [DMNC-1047](https://linear.app/lizomorf/issue/DMNC-1047): the portfolio-wide "monitor turns on" launch pattern.

\`<RetroEffects boot />\` plays once on mount (~650ms):

1. **Ignition** — bright amber line stretches across the center over black (140ms)
2. **Raster opens** — top/bottom panels retract from the line to the edges (300ms, easeOutExpo)
3. **Warm glow settles** — radial phosphor wash peaks (~0.55 × intensity) and fades (650ms)

- SSR-friendly: panels render server-side → first paint is black, then the open (authentic, no content flash)
- Compositor-only (transform/opacity); settles on the glow's \`animationend\` + safety timeout
- \`prefers-reduced-motion\`: skipped entirely (CSS \`display:none\` + JS bypass)
- \`onBootComplete\` for sequencing boot text after the turn-on
- Distinct from \`powered\` (effects-overlay power transitions)

5 new tests (55 total), \`BootSequence\` story with REBOOT replay, token lint clean, verified frame-by-frame (screenshots in Linear/chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)