### PR TITLE
chore(release): 0.28.0 — CGA boot sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.0] - 2026-06-12
+
+### Added
+- **CGA boot sequence (DMNC-1047).** New `boot` prop on `<RetroEffects>` plays a ~650ms monitor turn-on once on mount: a bright amber ignition line stretches across the center over black, the raster opens from it (panels retract to the edges), and a warm radial phosphor wash peaks and settles. The portfolio-wide first-load signature — consumers already mounting RetroEffects add one prop. Server-rendered panels make the first paint black (no content flash); compositor-only; skipped entirely under `prefers-reduced-motion`; `onBootComplete` callback for sequencing boot text after the turn-on.
+
 ## [0.27.1] - 2026-06-11
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,11 +289,13 @@ eiDotter uses Untitled UI as a **pattern reference**, not a dependency. **No UTI
 - **Figma:** UTI Figma library is set up with eiDotter's DOS tokens. eiDotter's Figma file is the source of truth for component design.
 - **License rationale:** eidotter is published under CC-BY-NC-4.0. UTI Pro is a paid commercial license that does not permit sublicensing/redistribution. Bundling UTI Pro assets into `dist/eidotter.css` / `dist/index.es.js` would have been a license violation. Pixelarticons (MIT) avoids this entirely.
 
-## Current Component Status (v0.27.x, June 2026)
+## Current Component Status (v0.28.x, June 2026)
 
 **Components** (41): Accordion, AIText, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Lightbox, Modal, Nav, Notification, Progress, RetroEffects, Separator, Skeleton, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
 
 **AIText (v0.24.x, DMNC-946):** Inline marker for AI-drafted prose — renders a `<span data-provenance="ai-draft">` with the magenta→white→cyan shimmer gradient from `src/styles/provenance.css` (shared with the per-paragraph diff pipeline, DMNC-884). Use for marking a phrase inside otherwise-human prose; for whole paragraphs in MDX prefer the raw `data-provenance` attribute.
+
+**RetroEffects `boot` (v0.28.0, DMNC-1047):** CGA monitor turn-on played once on mount (~650ms: ignition line → raster opens → warm phosphor wash). The portfolio-wide first-load signature — consumers add the one prop. Compositor-only; skipped under reduced motion; `onBootComplete` for sequencing boot text.
 
 **Skeleton (v0.27.0, DMNC-1018):** DOS/CGA loading placeholder — rows of shade characters (░ ▒ ▓) with a CRT hum-bar glow band rolling top→bottom (1.6s, compositor-only; gentle opacity breathing under reduced motion, all animation off in high contrast). Variants: text/card/figure/timeline. Purely presentational — render while content loads, then swap out.
 

--- a/guidelines/components.md
+++ b/guidelines/components.md
@@ -673,6 +673,7 @@ CRT monitor visual effects overlay.
 | scanlines | `boolean` | `true` | Show horizontal scanlines |
 | glow | `boolean` | `true` | Show edge vignette glow |
 | flicker | `boolean` | `true` | Subtle CRT flicker animation |
+| boot | `boolean` | `false` | Play the ~650ms CGA monitor turn-on once on mount (ignition line → raster opens → warm glow). Skipped under reduced motion |
 | intensity | `number` | `1` | Effect intensity (0-1) |
 
 ### Examples
@@ -689,6 +690,9 @@ CRT monitor visual effects overlay.
 
 // Subtle effects
 <RetroEffects intensity={0.5} />
+
+// Site launch: the monitor turns on (portfolio-wide pattern)
+<RetroEffects boot onBootComplete={() => startBootText()} />
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,4 +134,4 @@ export type {
 } from './components/registry';
 
 // Version information
-export const version = '0.27.1';
+export const version = '0.28.0';


### PR DESCRIPTION
Release prep for 0.28.0 — ships the RetroEffects `boot` prop (#381, DMNC-1047). CHANGELOG, version bumps, CLAUDE.md status, guidelines RetroEffects section. 1120 tests + build green.

After merge: `gh release create v0.28.0` → OIDC npm publish → consumer rollout (dmnctech, eidotter-home, betamorf, rizomorf, dmnc-online).

🤖 Generated with [Claude Code](https://claude.com/claude-code)