### PR TITLE
feat(retro-effects): bootOnce — play CGA turn-on once per visit (DMNC-1047)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.29.0] - 2026-06-15
 
 ### Added
-- **`bootOnce` on `<RetroEffects>`.** Gates the `boot` turn-on to once per browser tab/session via `sessionStorage`. The sequence plays on the first load of a tab and is suppressed on every later mount within the same tab — both SPA route changes and MPA full-reload navigation — so opening a blog post or switching pages within a site no longer replays it. A new tab/visit replays it; a hard refresh does not. Optional `bootStorageKey` (default `'eidotter:retro-boot'`) scopes the flag or forces a replay. The gated path is effect-driven (SSR-safe; no hydration mismatch on reload) and falls back to playing normally if storage is unavailable. `boot` alone is unchanged (plays on every mount).
+- **`bootOnce` on `<RetroEffects>` (DMNC-1047).** Gates the `boot` turn-on to once per browser tab/session via `sessionStorage`. The sequence plays on the first load of a tab and is suppressed on every later mount within the same tab — both SPA route changes and MPA full-reload navigation — so opening a blog post or switching pages within a site no longer replays it. A new tab/visit replays it; a hard refresh does not. Optional `bootStorageKey` (default `'eidotter:retro-boot'`) scopes the flag or forces a replay. The gated path is effect-driven (SSR-safe; no hydration mismatch on reload) and falls back to playing normally if storage is unavailable. `boot` alone is unchanged (plays on every mount).
 
 ## [0.28.0] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.0] - 2026-06-15
+
+### Added
+- **`bootOnce` on `<RetroEffects>`.** Gates the `boot` turn-on to once per browser tab/session via `sessionStorage`. The sequence plays on the first load of a tab and is suppressed on every later mount within the same tab — both SPA route changes and MPA full-reload navigation — so opening a blog post or switching pages within a site no longer replays it. A new tab/visit replays it; a hard refresh does not. Optional `bootStorageKey` (default `'eidotter:retro-boot'`) scopes the flag or forces a replay. The gated path is effect-driven (SSR-safe; no hydration mismatch on reload) and falls back to playing normally if storage is unavailable. `boot` alone is unchanged (plays on every mount).
+
 ## [0.28.0] - 2026-06-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,13 +289,13 @@ eiDotter uses Untitled UI as a **pattern reference**, not a dependency. **No UTI
 - **Figma:** UTI Figma library is set up with eiDotter's DOS tokens. eiDotter's Figma file is the source of truth for component design.
 - **License rationale:** eidotter is published under CC-BY-NC-4.0. UTI Pro is a paid commercial license that does not permit sublicensing/redistribution. Bundling UTI Pro assets into `dist/eidotter.css` / `dist/index.es.js` would have been a license violation. Pixelarticons (MIT) avoids this entirely.
 
-## Current Component Status (v0.28.x, June 2026)
+## Current Component Status (v0.29.x, June 2026)
 
 **Components** (41): Accordion, AIText, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Lightbox, Modal, Nav, Notification, Progress, RetroEffects, Separator, Skeleton, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
 
 **AIText (v0.24.x, DMNC-946):** Inline marker for AI-drafted prose — renders a `<span data-provenance="ai-draft">` with the magenta→white→cyan shimmer gradient from `src/styles/provenance.css` (shared with the per-paragraph diff pipeline, DMNC-884). Use for marking a phrase inside otherwise-human prose; for whole paragraphs in MDX prefer the raw `data-provenance` attribute.
 
-**RetroEffects `boot` (v0.28.0, DMNC-1047):** CGA monitor turn-on played once on mount (~650ms: ignition line → raster opens → warm phosphor wash). The portfolio-wide first-load signature — consumers add the one prop. Compositor-only; skipped under reduced motion; `onBootComplete` for sequencing boot text.
+**RetroEffects `boot` (v0.28.0, DMNC-1047):** CGA monitor turn-on played once on mount (~650ms: ignition line → raster opens → warm phosphor wash). The portfolio-wide first-load signature — consumers add the one prop. Compositor-only; skipped under reduced motion; `onBootComplete` for sequencing boot text. Add `bootOnce` to gate it to once per browser tab/session (sessionStorage, key `bootStorageKey`, default `'eidotter:retro-boot'`): plays on first load, suppressed on all in-site navigation — SPA route changes AND MPA full-reload navigation — so opening a blog post / switching pages does not replay it; a new tab/visit replays, a hard refresh does not. The gated path is effect-driven (SSR-safe) and falls back to playing if storage is blocked.
 
 **Skeleton (v0.27.0, DMNC-1018):** DOS/CGA loading placeholder — rows of shade characters (░ ▒ ▓) with a CRT hum-bar glow band rolling top→bottom (1.6s, compositor-only; gentle opacity breathing under reduced motion, all animation off in high contrast). Variants: text/card/figure/timeline. Purely presentational — render while content loads, then swap out.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",

--- a/src/components/RetroEffects/components/RetroEffects.stories.tsx
+++ b/src/components/RetroEffects/components/RetroEffects.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { RetroEffects } from './RetroEffects';
 import React from 'react';
+import { Button } from '@/components/Button';
 import { componentRegistry } from '@/components/registry';
 
 const meta: Meta<typeof RetroEffects> = {
@@ -435,28 +436,16 @@ const SessionGatedBootDemo: React.FC = () => {
           minHeight: 320,
         }}
       >
-        <h1 style={{ fontSize: 28, marginBottom: 12 }}>C:\&gt; ONCE PER VISIT</h1>
-        <p style={{ maxWidth: '52ch', lineHeight: 1.4 }}>
+        <h1 style={{ fontSize: 32, marginBottom: 16 }}>C:\&gt; ONCE PER VISIT</h1>
+        <p style={{ maxWidth: '52ch', lineHeight: 1.4, marginBottom: 24 }}>
           With <code>boot bootOnce</code> the turn-on plays on the first load of a tab and is
           suppressed on every later mount — SPA route changes and full-reload navigation alike.
           Remounting the canvas will <em>not</em> replay it. Use the button to clear the session
           flag and simulate a brand-new visit.
         </p>
-        <button
-          type="button"
-          onClick={clearAndReplay}
-          style={{
-            marginTop: 16,
-            background: 'none',
-            border: '1px solid var(--color-cga-amber)',
-            color: 'var(--color-cga-amber)',
-            fontFamily: 'inherit',
-            padding: '6px 12px',
-            cursor: 'pointer',
-          }}
-        >
+        <Button variant="secondary" onPress={clearAndReplay}>
           [ CLEAR + REMOUNT ]
-        </button>
+        </Button>
       </div>
       <RetroEffects
         key={generation}

--- a/src/components/RetroEffects/components/RetroEffects.stories.tsx
+++ b/src/components/RetroEffects/components/RetroEffects.stories.tsx
@@ -409,3 +409,76 @@ export const BootSequence: Story = {
     },
   },
 };
+
+const SessionGatedBootDemo: React.FC = () => {
+  // A stable per-session key so remounting the canvas (HMR, story switch) does
+  // not replay. The CLEAR + REMOUNT button wipes the flag to demo a fresh visit.
+  const STORAGE_KEY = 'eidotter:retro-boot-story';
+  const [generation, setGeneration] = React.useState(0);
+
+  const clearAndReplay = () => {
+    try {
+      window.sessionStorage.removeItem(STORAGE_KEY);
+    } catch {
+      /* ignore */
+    }
+    setGeneration((g) => g + 1);
+  };
+
+  return (
+    <>
+      <div
+        style={{
+          fontFamily: 'var(--typography-font-family-primary, monospace)',
+          color: 'var(--color-cga-amber)',
+          padding: 32,
+          minHeight: 320,
+        }}
+      >
+        <h1 style={{ fontSize: 28, marginBottom: 12 }}>C:\&gt; ONCE PER VISIT</h1>
+        <p style={{ maxWidth: '52ch', lineHeight: 1.4 }}>
+          With <code>boot bootOnce</code> the turn-on plays on the first load of a tab and is
+          suppressed on every later mount — SPA route changes and full-reload navigation alike.
+          Remounting the canvas will <em>not</em> replay it. Use the button to clear the session
+          flag and simulate a brand-new visit.
+        </p>
+        <button
+          type="button"
+          onClick={clearAndReplay}
+          style={{
+            marginTop: 16,
+            background: 'none',
+            border: '1px solid var(--color-cga-amber)',
+            color: 'var(--color-cga-amber)',
+            fontFamily: 'inherit',
+            padding: '6px 12px',
+            cursor: 'pointer',
+          }}
+        >
+          [ CLEAR + REMOUNT ]
+        </button>
+      </div>
+      <RetroEffects
+        key={generation}
+        boot
+        bootOnce
+        bootStorageKey={STORAGE_KEY}
+        scanlines
+        glow
+        flicker={false}
+      />
+    </>
+  );
+};
+
+export const SessionGatedBoot: Story = {
+  render: () => <SessionGatedBootDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Add `bootOnce` to gate the boot sequence to once per browser tab/session (sessionStorage). It plays on the first load and is suppressed on all in-site navigation — SPA route changes AND MPA full-reload navigation — so opening a blog post or switching pages within a site does not replay it. A new tab/visit replays it; a hard refresh does not. `bootStorageKey` overrides the flag key (e.g. to force a replay). Falls back to playing if storage is unavailable.',
+      },
+    },
+  },
+};

--- a/src/components/RetroEffects/components/RetroEffects.test.tsx
+++ b/src/components/RetroEffects/components/RetroEffects.test.tsx
@@ -594,10 +594,63 @@ describe('RetroEffects', () => {
       expect(onBootComplete).toHaveBeenCalledTimes(1);
     });
 
+    it('plays and records the flag exactly once under StrictMode on a fresh session', () => {
+      // The headline scenario: a discarded StrictMode mount must not pre-write
+      // the flag and suppress the real boot.
+      const onBootComplete = jest.fn();
+      render(
+        <React.StrictMode>
+          <RetroEffects boot bootOnce onBootComplete={onBootComplete} />
+        </React.StrictMode>,
+      );
+      const layer = document.querySelector('.eidotter-retro-effects__boot');
+      expect(layer).not.toBeNull();
+      expect(window.sessionStorage.getItem(DEFAULT_KEY)).toBeNull();
+      fireAnimationEnd(layer as HTMLElement, 'eidotter-retro-boot-glow');
+      expect(window.sessionStorage.getItem(DEFAULT_KEY)).toBe('1');
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the safety timeout and records nothing if unmounted mid-boot', () => {
+      jest.useFakeTimers();
+      const onBootComplete = jest.fn();
+      const { unmount } = render(
+        <RetroEffects boot bootOnce onBootComplete={onBootComplete} />,
+      );
+      expect(document.querySelector('.eidotter-retro-effects__boot')).not.toBeNull();
+      unmount();
+      act(() => {
+        jest.advanceTimersByTime(1300);
+      });
+      expect(onBootComplete).not.toHaveBeenCalled();
+      expect(window.sessionStorage.getItem(DEFAULT_KEY)).toBeNull();
+    });
+
+    it('records the mount-time key even if bootStorageKey changes before completion', () => {
+      const { rerender } = render(<RetroEffects boot bootOnce bootStorageKey="key-a" />);
+      rerender(<RetroEffects boot bootOnce bootStorageKey="key-b" />);
+      const layer = document.querySelector('.eidotter-retro-effects__boot') as HTMLElement;
+      fireAnimationEnd(layer, 'eidotter-retro-boot-glow');
+      // The key checked at mount (key-a) is the key written — not the later key-b.
+      expect(window.sessionStorage.getItem('key-a')).toBe('1');
+      expect(window.sessionStorage.getItem('key-b')).toBeNull();
+    });
+
+    it('non-gated boot still plays on every fresh mount and writes no flag', () => {
+      const { unmount } = render(<RetroEffects boot />);
+      expect(document.querySelector('.eidotter-retro-effects__boot')).not.toBeNull();
+      unmount();
+      render(<RetroEffects boot />);
+      expect(document.querySelector('.eidotter-retro-effects__boot')).not.toBeNull();
+      expect(window.sessionStorage.getItem(DEFAULT_KEY)).toBeNull();
+    });
+
     it('is a no-op without boot', () => {
-      render(<RetroEffects bootOnce />);
+      const onBootComplete = jest.fn();
+      render(<RetroEffects bootOnce onBootComplete={onBootComplete} />);
       expect(document.querySelector('.eidotter-retro-effects__boot')).toBeNull();
       expect(window.sessionStorage.getItem(DEFAULT_KEY)).toBeNull();
+      expect(onBootComplete).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/RetroEffects/components/RetroEffects.test.tsx
+++ b/src/components/RetroEffects/components/RetroEffects.test.tsx
@@ -463,4 +463,82 @@ describe('RetroEffects', () => {
       jest.useRealTimers();
     });
   });
+
+  describe('boot once per session (bootOnce)', () => {
+    const DEFAULT_KEY = 'eidotter:retro-boot';
+
+    afterEach(() => {
+      window.sessionStorage.clear();
+    });
+
+    it('plays on first mount with empty storage and records the flag on completion', () => {
+      const onBootComplete = jest.fn();
+      render(<RetroEffects boot bootOnce onBootComplete={onBootComplete} />);
+      expect(document.querySelector('.eidotter-retro-effects__boot')).not.toBeNull();
+      // Flag is written on completion (not at play-start) so a discarded
+      // StrictMode double-mount can't pre-suppress the real boot.
+      expect(window.sessionStorage.getItem(DEFAULT_KEY)).toBeNull();
+      const layer = document.querySelector('.eidotter-retro-effects__boot') as HTMLElement;
+      fireAnimationEnd(layer, 'eidotter-retro-boot-glow');
+      expect(window.sessionStorage.getItem(DEFAULT_KEY)).toBe('1');
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not replay on a later mount when the flag is already set', () => {
+      window.sessionStorage.setItem(DEFAULT_KEY, '1');
+      const onBootComplete = jest.fn();
+      render(<RetroEffects boot bootOnce onBootComplete={onBootComplete} />);
+      expect(document.querySelector('.eidotter-retro-effects__boot')).toBeNull();
+      // Completion still signalled so consumers sequencing on it don't stall.
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('respects a custom bootStorageKey', () => {
+      window.sessionStorage.setItem(DEFAULT_KEY, '1');
+      render(<RetroEffects boot bootOnce bootStorageKey="custom:key" />);
+      // Default key is set but the custom key is empty, so it still plays.
+      const layer = document.querySelector('.eidotter-retro-effects__boot');
+      expect(layer).not.toBeNull();
+      fireAnimationEnd(layer as HTMLElement, 'eidotter-retro-boot-glow');
+      // Completion records the custom key, not the default one.
+      expect(window.sessionStorage.getItem('custom:key')).toBe('1');
+    });
+
+    it('falls back to playing when sessionStorage access throws', () => {
+      const getItemSpy = jest
+        .spyOn(window.sessionStorage.__proto__, 'getItem')
+        .mockImplementation(() => {
+          throw new Error('blocked');
+        });
+      render(<RetroEffects boot bootOnce />);
+      expect(document.querySelector('.eidotter-retro-effects__boot')).not.toBeNull();
+      getItemSpy.mockRestore();
+    });
+
+    it('settles and records the flag under reduced motion', () => {
+      const original = window.matchMedia;
+      window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+        matches: query.includes('reduced-motion'),
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
+      const onBootComplete = jest.fn();
+      render(<RetroEffects boot bootOnce onBootComplete={onBootComplete} />);
+      expect(document.querySelector('.eidotter-retro-effects__boot')).toBeNull();
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+      expect(window.sessionStorage.getItem(DEFAULT_KEY)).toBe('1');
+      window.matchMedia = original;
+    });
+
+    it('is a no-op without boot', () => {
+      render(<RetroEffects bootOnce />);
+      expect(document.querySelector('.eidotter-retro-effects__boot')).toBeNull();
+      expect(window.sessionStorage.getItem(DEFAULT_KEY)).toBeNull();
+    });
+  });
 });

--- a/src/components/RetroEffects/components/RetroEffects.test.tsx
+++ b/src/components/RetroEffects/components/RetroEffects.test.tsx
@@ -466,9 +466,26 @@ describe('RetroEffects', () => {
 
   describe('boot once per session (bootOnce)', () => {
     const DEFAULT_KEY = 'eidotter:retro-boot';
+    const originalMatchMedia = window.matchMedia;
+
+    // Replace matchMedia so prefersReducedMotion() reports `on`; restored in afterEach.
+    const setReducedMotion = (on: boolean) => {
+      window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+        matches: on && query.includes('reduced-motion'),
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
+    };
 
     afterEach(() => {
       window.sessionStorage.clear();
+      window.matchMedia = originalMatchMedia;
+      jest.useRealTimers();
     });
 
     it('plays on first mount with empty storage and records the flag on completion', () => {
@@ -491,6 +508,8 @@ describe('RetroEffects', () => {
       expect(document.querySelector('.eidotter-retro-effects__boot')).toBeNull();
       // Completion still signalled so consumers sequencing on it don't stall.
       expect(onBootComplete).toHaveBeenCalledTimes(1);
+      // The skip path must not rewrite/clear the existing flag.
+      expect(window.sessionStorage.getItem(DEFAULT_KEY)).toBe('1');
     });
 
     it('respects a custom bootStorageKey', () => {
@@ -504,9 +523,9 @@ describe('RetroEffects', () => {
       expect(window.sessionStorage.getItem('custom:key')).toBe('1');
     });
 
-    it('falls back to playing when sessionStorage access throws', () => {
+    it('falls back to playing when sessionStorage read throws', () => {
       const getItemSpy = jest
-        .spyOn(window.sessionStorage.__proto__, 'getItem')
+        .spyOn(Storage.prototype, 'getItem')
         .mockImplementation(() => {
           throw new Error('blocked');
         });
@@ -515,24 +534,64 @@ describe('RetroEffects', () => {
       getItemSpy.mockRestore();
     });
 
+    it('completes without crashing when the sessionStorage write throws', () => {
+      const setItemSpy = jest
+        .spyOn(Storage.prototype, 'setItem')
+        .mockImplementation(() => {
+          throw new Error('blocked');
+        });
+      const onBootComplete = jest.fn();
+      render(<RetroEffects boot bootOnce onBootComplete={onBootComplete} />);
+      const layer = document.querySelector('.eidotter-retro-effects__boot') as HTMLElement;
+      fireAnimationEnd(layer, 'eidotter-retro-boot-glow');
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+      setItemSpy.mockRestore();
+    });
+
     it('settles and records the flag under reduced motion', () => {
-      const original = window.matchMedia;
-      window.matchMedia = jest.fn().mockImplementation((query: string) => ({
-        matches: query.includes('reduced-motion'),
-        media: query,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      }));
+      setReducedMotion(true);
       const onBootComplete = jest.fn();
       render(<RetroEffects boot bootOnce onBootComplete={onBootComplete} />);
       expect(document.querySelector('.eidotter-retro-effects__boot')).toBeNull();
       expect(onBootComplete).toHaveBeenCalledTimes(1);
       expect(window.sessionStorage.getItem(DEFAULT_KEY)).toBe('1');
-      window.matchMedia = original;
+    });
+
+    it('fires onBootComplete once when the safety timeout would follow animationend', () => {
+      jest.useFakeTimers();
+      const onBootComplete = jest.fn();
+      render(<RetroEffects boot bootOnce onBootComplete={onBootComplete} />);
+      const layer = document.querySelector('.eidotter-retro-effects__boot') as HTMLElement;
+      fireAnimationEnd(layer, 'eidotter-retro-boot-glow');
+      act(() => {
+        jest.advanceTimersByTime(1300);
+      });
+      // animationend settles boot and cancels the safety timer; the ref guard
+      // makes a second call a no-op regardless.
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires onBootComplete exactly once under StrictMode when already booted', () => {
+      window.sessionStorage.setItem(DEFAULT_KEY, '1');
+      const onBootComplete = jest.fn();
+      render(
+        <React.StrictMode>
+          <RetroEffects boot bootOnce onBootComplete={onBootComplete} />
+        </React.StrictMode>,
+      );
+      expect(document.querySelector('.eidotter-retro-effects__boot')).toBeNull();
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires onBootComplete exactly once under StrictMode with reduced motion', () => {
+      setReducedMotion(true);
+      const onBootComplete = jest.fn();
+      render(
+        <React.StrictMode>
+          <RetroEffects boot bootOnce onBootComplete={onBootComplete} />
+        </React.StrictMode>,
+      );
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
     });
 
     it('is a no-op without boot', () => {

--- a/src/components/RetroEffects/components/RetroEffects.tsx
+++ b/src/components/RetroEffects/components/RetroEffects.tsx
@@ -5,6 +5,28 @@ import './RetroEffects.css';
 
 export type PowerState = 'on' | 'powering-on' | 'powering-off' | 'off';
 
+const DEFAULT_BOOT_STORAGE_KEY = 'eidotter:retro-boot';
+
+/** Read a sessionStorage flag, swallowing access errors (private mode, SSR). */
+const hasBootedThisSession = (key: string): boolean => {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.sessionStorage.getItem(key) !== null;
+  } catch {
+    return false;
+  }
+};
+
+/** Record the sessionStorage flag, swallowing access errors. */
+const markBootedThisSession = (key: string): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(key, '1');
+  } catch {
+    /* storage unavailable — boot still plays, just won't be remembered */
+  }
+};
+
 export interface RetroEffectsProps {
   /**
    * Enable scanline overlay effect
@@ -35,6 +57,21 @@ export interface RetroEffectsProps {
    * pattern (DMNC-1047).
    */
   boot?: boolean;
+  /**
+   * Gate `boot` to once per browser tab/session (via sessionStorage). The boot
+   * sequence plays on the first load of a tab and is suppressed on every
+   * subsequent mount within the same tab — both SPA route changes and MPA
+   * full-reload navigation. A new tab/visit replays it; a hard refresh does not.
+   * No-op unless `boot` is also set. Falls back to playing if storage is
+   * unavailable (e.g. private mode).
+   */
+  bootOnce?: boolean;
+  /**
+   * sessionStorage key used by `bootOnce`. Defaults to `'eidotter:retro-boot'`.
+   * Override to scope the once-per-session flag independently, or to force a
+   * replay (e.g. a fresh key in a Storybook story).
+   */
+  bootStorageKey?: string;
   /**
    * Intensity of the effects (0-1)
    */
@@ -80,6 +117,8 @@ export const RetroEffects: React.FC<RetroEffectsProps> = ({
   bloom = false,
   powered = true,
   boot = false,
+  bootOnce = false,
+  bootStorageKey = DEFAULT_BOOT_STORAGE_KEY,
   intensity = 1,
   className,
   onPowerStateChange,
@@ -89,7 +128,34 @@ export const RetroEffects: React.FC<RetroEffectsProps> = ({
 }) => {
   const prevPoweredRef = useRef(powered);
   const [powerState, setPowerState] = useState<PowerState>(powered ? 'on' : 'off');
-  const [booting, setBooting] = useState(boot);
+  // Non-gated boot keeps its on-mount behavior; the gated (bootOnce) path starts
+  // un-booted and is decided post-mount so SSR/first paint never render a stale
+  // overlay (no hydration mismatch on reload when the flag is already set).
+  const [booting, setBooting] = useState(boot && !bootOnce);
+
+  // Settle the boot layer and signal completion. For the gated path the session
+  // flag is recorded HERE (on completion) rather than at the play decision, so a
+  // discarded StrictMode dev double-mount doesn't pre-set the flag and suppress
+  // the real boot. The flag is only "remembered" once a boot has actually run.
+  const completeBoot = () => {
+    setBooting(false);
+    if (bootOnce) markBootedThisSession(bootStorageKey);
+    onBootComplete?.();
+  };
+
+  // Gated boot: decide once on mount whether this tab session has already booted.
+  useEffect(() => {
+    if (!boot || !bootOnce) return;
+    if (hasBootedThisSession(bootStorageKey)) {
+      // Already shown this session — skip, but still signal completion so
+      // consumers sequencing boot text off onBootComplete don't stall.
+      onBootComplete?.();
+      return;
+    }
+    setBooting(true);
+    // Mount-only: gating is a first-load decision, not reactive to prop churn.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Boot settles via the glow's animationend; reduced-motion (where the boot
   // layer is display:none and never animates) and any missed event settle via
@@ -97,13 +163,11 @@ export const RetroEffects: React.FC<RetroEffectsProps> = ({
   useEffect(() => {
     if (!booting) return;
     if (prefersReducedMotion()) {
-      setBooting(false);
-      onBootComplete?.();
+      completeBoot();
       return;
     }
     const safety = window.setTimeout(() => {
-      setBooting(false);
-      onBootComplete?.();
+      completeBoot();
     }, 1200);
     return () => window.clearTimeout(safety);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -111,8 +175,7 @@ export const RetroEffects: React.FC<RetroEffectsProps> = ({
 
   const handleBootAnimationEnd = (event: React.AnimationEvent) => {
     if (event.animationName !== 'eidotter-retro-boot-glow') return;
-    setBooting(false);
-    onBootComplete?.();
+    completeBoot();
   };
 
   // Track power state transitions (intentional: animation state machine requires

--- a/src/components/RetroEffects/components/RetroEffects.tsx
+++ b/src/components/RetroEffects/components/RetroEffects.tsx
@@ -6,12 +6,13 @@ import './RetroEffects.css';
 export type PowerState = 'on' | 'powering-on' | 'powering-off' | 'off';
 
 const DEFAULT_BOOT_STORAGE_KEY = 'eidotter:retro-boot';
+const BOOT_FLAG_VALUE = '1';
 
 /** Read a sessionStorage flag, swallowing access errors (private mode, SSR). */
 const hasBootedThisSession = (key: string): boolean => {
   if (typeof window === 'undefined') return false;
   try {
-    return window.sessionStorage.getItem(key) !== null;
+    return window.sessionStorage.getItem(key) === BOOT_FLAG_VALUE;
   } catch {
     return false;
   }
@@ -21,7 +22,7 @@ const hasBootedThisSession = (key: string): boolean => {
 const markBootedThisSession = (key: string): void => {
   if (typeof window === 'undefined') return;
   try {
-    window.sessionStorage.setItem(key, '1');
+    window.sessionStorage.setItem(key, BOOT_FLAG_VALUE);
   } catch {
     /* storage unavailable — boot still plays, just won't be remembered */
   }
@@ -64,12 +65,15 @@ export interface RetroEffectsProps {
    * full-reload navigation. A new tab/visit replays it; a hard refresh does not.
    * No-op unless `boot` is also set. Falls back to playing if storage is
    * unavailable (e.g. private mode).
+   *
+   * Like `boot`, this is evaluated once on mount; changing it afterwards has no
+   * effect (remount the component — e.g. via `key` — to re-evaluate).
    */
   bootOnce?: boolean;
   /**
    * sessionStorage key used by `bootOnce`. Defaults to `'eidotter:retro-boot'`.
    * Override to scope the once-per-session flag independently, or to force a
-   * replay (e.g. a fresh key in a Storybook story).
+   * replay (e.g. a fresh key in a Storybook story). Read once on mount.
    */
   bootStorageKey?: string;
   /**
@@ -131,7 +135,27 @@ export const RetroEffects: React.FC<RetroEffectsProps> = ({
   // Non-gated boot keeps its on-mount behavior; the gated (bootOnce) path starts
   // un-booted and is decided post-mount so SSR/first paint never render a stale
   // overlay (no hydration mismatch on reload when the flag is already set).
+  // (Non-gated boot is intentionally NOT SSR-gated — it plays on every mount.)
   const [booting, setBooting] = useState(boot && !bootOnce);
+
+  // Boot completes exactly once per mount. Guards against the StrictMode dev
+  // double-invoke of effects and the (theoretical) animationend + safety-timeout
+  // race both calling through twice.
+  const bootSignaledRef = useRef(false);
+
+  // Keep the latest onBootComplete without re-running the mount-only effects that
+  // call it (adding it to their deps would re-trigger the boot decision).
+  const onBootCompleteRef = useRef(onBootComplete);
+  useEffect(() => {
+    onBootCompleteRef.current = onBootComplete;
+  });
+
+  // One-shot completion signal: settle the layer, remember the session, notify.
+  const signalBootComplete = () => {
+    if (bootSignaledRef.current) return;
+    bootSignaledRef.current = true;
+    onBootCompleteRef.current?.();
+  };
 
   // Settle the boot layer and signal completion. For the gated path the session
   // flag is recorded HERE (on completion) rather than at the play decision, so a
@@ -140,7 +164,7 @@ export const RetroEffects: React.FC<RetroEffectsProps> = ({
   const completeBoot = () => {
     setBooting(false);
     if (bootOnce) markBootedThisSession(bootStorageKey);
-    onBootComplete?.();
+    signalBootComplete();
   };
 
   // Gated boot: decide once on mount whether this tab session has already booted.
@@ -149,7 +173,7 @@ export const RetroEffects: React.FC<RetroEffectsProps> = ({
     if (hasBootedThisSession(bootStorageKey)) {
       // Already shown this session — skip, but still signal completion so
       // consumers sequencing boot text off onBootComplete don't stall.
-      onBootComplete?.();
+      signalBootComplete();
       return;
     }
     setBooting(true);

--- a/src/components/RetroEffects/components/RetroEffects.tsx
+++ b/src/components/RetroEffects/components/RetroEffects.tsx
@@ -74,6 +74,10 @@ export interface RetroEffectsProps {
    * sessionStorage key used by `bootOnce`. Defaults to `'eidotter:retro-boot'`.
    * Override to scope the once-per-session flag independently, or to force a
    * replay (e.g. a fresh key in a Storybook story). Read once on mount.
+   *
+   * Instances that mount simultaneously and share a key share one flag (the
+   * intended single-overlay case); give each a distinct key if they must gate
+   * independently.
    */
   bootStorageKey?: string;
   /**
@@ -143,6 +147,13 @@ export const RetroEffects: React.FC<RetroEffectsProps> = ({
   // race both calling through twice.
   const bootSignaledRef = useRef(false);
 
+  // Pin the storage key to its mount-time value. The read (decision effect) and
+  // the write (completeBoot, recreated each render) must use the SAME key, or a
+  // consumer passing a changing key would write a different key than was checked
+  // and the next visit would replay. This makes the "read once on mount" contract
+  // structural rather than documentation-only.
+  const bootStorageKeyRef = useRef(bootStorageKey);
+
   // Keep the latest onBootComplete without re-running the mount-only effects that
   // call it (adding it to their deps would re-trigger the boot decision).
   const onBootCompleteRef = useRef(onBootComplete);
@@ -163,14 +174,14 @@ export const RetroEffects: React.FC<RetroEffectsProps> = ({
   // the real boot. The flag is only "remembered" once a boot has actually run.
   const completeBoot = () => {
     setBooting(false);
-    if (bootOnce) markBootedThisSession(bootStorageKey);
+    if (bootOnce) markBootedThisSession(bootStorageKeyRef.current);
     signalBootComplete();
   };
 
   // Gated boot: decide once on mount whether this tab session has already booted.
   useEffect(() => {
     if (!boot || !bootOnce) return;
-    if (hasBootedThisSession(bootStorageKey)) {
+    if (hasBootedThisSession(bootStorageKeyRef.current)) {
       // Already shown this session — skip, but still signal completion so
       // consumers sequencing boot text off onBootComplete don't stall.
       signalBootComplete();

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,4 +134,4 @@ export type {
 } from './components/registry';
 
 // Version information
-export const version = '0.28.0';
+export const version = '0.29.0';


### PR DESCRIPTION
## Why

The CGA monitor turn-on (`<RetroEffects boot>`, DMNC-1047) is the portfolio-wide first-load signature, but it played on **every component mount** with no persistence — so it replayed on in-site navigation:

- **rizomorf** (Next.js App Router) — `RetroEffects` lives in the `"use client"` layout, which remounts on route changes, so opening a blog post replayed the boot. (Reported case.)
- **eidotter-home** (Astro MPA) — every page is a full document load, so navigating between pages replayed it.

The animation is good; only *when* it fires needed changing.

## What

Add an opt-in `bootOnce` prop that gates `boot` to **once per browser tab/session** via `sessionStorage`:

- Plays on the first load of a tab; suppressed on every later mount in the same tab — **SPA route changes AND MPA full-reload navigation**.
- A new tab/visit replays it; a hard refresh does not (matches dmnc.tech's existing `useSessionFlag` precedent).
- `bootStorageKey` (default `'eidotter:retro-boot'`) scopes the flag or forces a replay.
- `boot` alone is unchanged (plays on every mount) — backward compatible; the Storybook replay story still works.

### Design safeguards
- **SSR-safe:** the gated path is effect-driven, so the server/first paint never renders a stale overlay → no hydration mismatch on reload when the flag is already set.
- **StrictMode-safe:** the session flag is recorded on boot **completion**, not at the play decision, so a discarded React StrictMode dev double-mount can't pre-set the flag and suppress the real boot.
- **Resilient:** all `sessionStorage` access is wrapped — if storage is blocked (private mode), boot just plays normally.

## Tests
- 7 new gating tests (first-load play + flag-on-completion, no-replay when flag set, custom key, storage-throw fallback, reduced-motion, no-op without `boot`).
- Full suite: **1126 passed**; lint clean; build green.

## Rollout (follow-up, after this publishes as 0.29.0)
Consumers consume eidotter from npm, so they need `eidotter@^0.29.0` reinstalled before their `bootOnce` edits build. Touched render sites (separate repos/PRs): rizomorf, betamorf, dmnctech, dmnc-online, eidotter-home (×2 pages). spacewar_landing is untouched (no `boot`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)