### PR TITLE
fix(a11y): keyboard & focus fixes — Icon, Tag, Terminal, CommandPrompt, Accordion (DMNC-1060)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Keyboard & focus a11y across five components (DMNC-1060).** From the 2026-06-16 compliance audit:
+  - **Icon** — a `role="button"` icon is now keyboard-operable: focusable (`tabIndex=0`) with Enter/Space activation. Previously it had a click handler but no tab stop, so its shipped `:focus-visible` style could never fire. Added a normal-contrast focus ring (was high-contrast only).
+  - **Tag** — interactive tags and the close button now have a visible `:focus-visible` ring. A `closeable` but non-interactive tag keeps its close button in the tab order (it's the only keyboard dismiss path); interactive tags still exclude it (the body offers Delete/Backspace).
+  - **Terminal** — focus is now visible at normal contrast via a `:focus-visible` outline (was `outline: none` outside `prefers-contrast: high`); composes with the drop shadow.
+  - **CommandPrompt** — removed a redundant `role="textbox"` + `aria-label` from the non-focusable wrapper around the real `<input>` (which carries its own label) — it exposed a duplicate, non-operable textbox.
+  - **Accordion** — header focus ring keys off `:focus-visible` instead of `:focus`, so it no longer shows on pointer press.
+
 ## [0.29.0] - 2026-06-15
 
 ### Added

--- a/src/components/Accordion/components/Section.css
+++ b/src/components/Accordion/components/Section.css
@@ -67,8 +67,9 @@
   color: var(--color-semantic-text-secondary);
 }
 
-/* Focus styles */
-.eidotter-section__header:focus {
+/* Focus styles — :focus-visible so the ring shows for keyboard users only,
+   not on pointer press. */
+.eidotter-section__header:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--color-semantic-border-focus);
 }
@@ -89,7 +90,7 @@
     border-width: 3px;
   }
 
-  .eidotter-section__header:focus {
+  .eidotter-section__header:focus-visible {
     box-shadow: 0 0 0 3px var(--color-semantic-border-focus);
   }
 }

--- a/src/components/CommandPrompt/components/CommandPrompt.test.tsx
+++ b/src/components/CommandPrompt/components/CommandPrompt.test.tsx
@@ -93,11 +93,23 @@ describe('CommandPrompt', () => {
   });
 
   it('applies custom className correctly', () => {
-    render(<CommandPrompt className="custom-class" onCommand={mockOnCommand} />);
+    const { container: root } = render(
+      <CommandPrompt className="custom-class" onCommand={mockOnCommand} />,
+    );
 
-    const container = screen.getByRole('textbox', { name: 'Command prompt' });
+    const container = root.querySelector('.command-prompt');
     expect(container).toHaveClass('custom-class');
     expect(container).toHaveClass('command-prompt');
+  });
+
+  it('does not put a redundant role/label on the wrapper (input is the only textbox)', () => {
+    render(<CommandPrompt onCommand={mockOnCommand} />);
+
+    // The wrapper previously carried role="textbox" + aria-label="Command
+    // prompt" while the real <input> has its own label — a duplicate control.
+    // Only the input should be exposed as a textbox now.
+    expect(screen.getAllByRole('textbox')).toHaveLength(1);
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-label', 'Command input');
   });
 
   it('shows placeholder when provided', () => {
@@ -109,9 +121,8 @@ describe('CommandPrompt', () => {
 
   it('focuses input when container is clicked', async () => {
     const user = userEvent.setup();
-    render(<CommandPrompt onCommand={mockOnCommand} />);
-
-    const container = screen.getByRole('textbox', { name: 'Command prompt' });
+    const { container: root } = render(<CommandPrompt onCommand={mockOnCommand} />);
+    const container = root.querySelector('.command-prompt') as HTMLElement;
     const input = screen.getByRole('textbox', { name: 'Command input' });
 
     await user.click(container);

--- a/src/components/CommandPrompt/components/CommandPrompt.tsx
+++ b/src/components/CommandPrompt/components/CommandPrompt.tsx
@@ -74,8 +74,6 @@ export const CommandPrompt: React.FC<CommandPromptProps> = ({
     <div
       className={`command-prompt ${disabled ? 'command-prompt--disabled' : ''} ${className}`.trim()}
       onClick={handleContainerClick}
-      role="textbox"
-      aria-label="Command prompt"
     >
       <span className="command-prompt__prompt" aria-hidden="true">{prompt}</span>
       <div className="command-prompt__input-wrapper">

--- a/src/components/Icon/components/Icon.css
+++ b/src/components/Icon/components/Icon.css
@@ -22,6 +22,11 @@
   color: var(--color-semantic-link-hover);
 }
 
+.icon--button:focus-visible {
+  outline: 2px solid var(--color-semantic-border-focus);
+  outline-offset: 2px;
+}
+
 @media (prefers-contrast: high) {
   .icon--button:focus-visible {
     outline: 3px solid currentColor;

--- a/src/components/Icon/components/Icon.test.tsx
+++ b/src/components/Icon/components/Icon.test.tsx
@@ -80,6 +80,46 @@ describe('Icon', () => {
     });
   });
 
+  describe('keyboard operability (role="button")', () => {
+    it('is focusable (tabIndex 0) when role is button', () => {
+      render(<Icon name="Close" role="button" onClick={jest.fn()} />);
+      expect(screen.getByRole('button')).toHaveAttribute('tabindex', '0');
+    });
+
+    it('is not focusable when not a button', () => {
+      render(<Icon name="Close" onClick={jest.fn()} />);
+      expect(screen.getByLabelText('Close icon')).not.toHaveAttribute('tabindex');
+    });
+
+    it('activates onClick on Enter', () => {
+      const onClick = jest.fn();
+      render(<Icon name="Close" role="button" onClick={onClick} />);
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'Enter' });
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('activates onClick on Space', () => {
+      const onClick = jest.fn();
+      render(<Icon name="Close" role="button" onClick={onClick} />);
+      fireEvent.keyDown(screen.getByRole('button'), { key: ' ' });
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not activate on other keys', () => {
+      const onClick = jest.fn();
+      render(<Icon name="Close" role="button" onClick={onClick} />);
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'a' });
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('does not add a key handler for non-button icons', () => {
+      const onClick = jest.fn();
+      render(<Icon name="Close" onClick={onClick} />);
+      fireEvent.keyDown(screen.getByLabelText('Close icon'), { key: 'Enter' });
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
   describe('role', () => {
     it('defaults to role="img" so aria-label is allowed (ARIA 1.2 prohibits aria-label on generic role)', () => {
       render(<Icon name="Warning" />);

--- a/src/components/Icon/components/Icon.tsx
+++ b/src/components/Icon/components/Icon.tsx
@@ -101,12 +101,28 @@ export const Icon: FC<IconProps> = ({
   // marks the icon as an interactive control via role="button", that takes
   // precedence and the consumer is responsible for handling activation.
   const resolvedRole = role ?? 'img';
+  const isButton = role === 'button';
+
+  // When the icon is itself the interactive control (role="button"), make it
+  // keyboard-operable: focusable + Enter/Space activation, matching native
+  // button behavior. Without this the shipped :focus-visible style can never
+  // fire because the span isn't in the tab order.
+  const handleKeyDown = isButton
+    ? (event: React.KeyboardEvent<HTMLSpanElement>) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onClick?.();
+        }
+      }
+    : undefined;
 
   return (
     <span
-      className={cn('icon', role === 'button' && 'icon--button', className)}
+      className={cn('icon', isButton && 'icon--button', className)}
       onClick={onClick}
+      onKeyDown={handleKeyDown}
       role={resolvedRole}
+      tabIndex={isButton ? 0 : undefined}
       aria-label={ariaLabel || `${name} icon`}
       style={color ? { color } : undefined}
     >

--- a/src/components/Tag/components/Tag.css
+++ b/src/components/Tag/components/Tag.css
@@ -45,6 +45,13 @@
   text-shadow: 0 0 4px var(--tag-color, var(--color-cga-amber-glow));
 }
 
+/* Keyboard focus — visible for the interactive body and the close button. */
+.eidotter-tag[role="button"]:focus-visible,
+.eidotter-tag__close:focus-visible {
+  outline: 2px solid var(--color-semantic-border-focus);
+  outline-offset: 2px;
+}
+
 /* Close button */
 .eidotter-tag__close {
   background: none; border: none; padding: 0; cursor: pointer;
@@ -61,6 +68,10 @@
     /* Neutralize phosphor glow — thicker border replaces the soft halo. */
     box-shadow: none;
     text-shadow: none;
+  }
+  .eidotter-tag[role="button"]:focus-visible,
+  .eidotter-tag__close:focus-visible {
+    outline-width: 3px;
   }
 }
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/Tag/components/Tag.test.tsx
+++ b/src/components/Tag/components/Tag.test.tsx
@@ -84,9 +84,18 @@ describe('Tag', () => {
       expect(screen.getByText('[x]')).toBeInTheDocument();
     });
 
-    it('close button has tabIndex=-1', () => {
-      render(<Tag closeable onClose={() => {}}>Label</Tag>);
+    it('keeps the close button out of the tab order when the body is interactive', () => {
+      // The interactive body is focusable and offers Delete/Backspace dismissal,
+      // so the close button is redundant in the tab order.
+      render(<Tag closeable onClose={() => {}} onClick={() => {}}>Label</Tag>);
       expect(document.querySelector('.eidotter-tag__close')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('keeps the close button focusable when the tag is not interactive', () => {
+      // The body isn't focusable, so the close button is the only keyboard
+      // dismiss path and must stay in the tab order.
+      render(<Tag closeable onClose={() => {}}>Label</Tag>);
+      expect(document.querySelector('.eidotter-tag__close')).not.toHaveAttribute('tabindex', '-1');
     });
 
     it('adds closing class when close button is clicked', () => {
@@ -189,6 +198,16 @@ describe('Tag', () => {
       await user.tab();
       await user.keyboard('{Delete}');
       // Should trigger close (closing animation)
+      expect(getTag()).toHaveClass('eidotter-tag--closing');
+    });
+
+    it('a non-interactive closeable tag can be dismissed by keyboard via the close button', async () => {
+      const user = userEvent.setup();
+      render(<Tag closeable onClose={() => {}}>Standalone</Tag>);
+      // Tab lands on the close button (the only focusable element), Enter fires it.
+      await user.tab();
+      expect(screen.getByLabelText('Remove Standalone')).toHaveFocus();
+      await user.keyboard('{Enter}');
       expect(getTag()).toHaveClass('eidotter-tag--closing');
     });
   });

--- a/src/components/Tag/components/Tag.tsx
+++ b/src/components/Tag/components/Tag.tsx
@@ -112,7 +112,12 @@ export const Tag: React.FC<TagProps> = ({
         <AriaButton
           className="eidotter-tag__close"
           aria-label={'Remove ' + (typeof children === 'string' ? children : 'tag')}
-          excludeFromTabOrder
+          // Keep the close button out of the tab order only when the body is
+          // itself focusable (interactive) and already offers Delete/Backspace
+          // dismissal. For a closeable, non-interactive tag the body is not
+          // focusable, so the close button must stay tabbable to give keyboard
+          // users any dismiss path at all.
+          excludeFromTabOrder={isInteractive}
           onPress={handleClosePress}
           isDisabled={disabled}
         >

--- a/src/components/Terminal/components/Terminal.css
+++ b/src/components/Terminal/components/Terminal.css
@@ -24,10 +24,17 @@
   min-height: 200px;
 }
 
-.terminal:focus,
 .terminal--active {
   border-color: var(--terminal-border-active);
-  outline: none;
+}
+
+/* Keyboard focus — a visible ring at normal contrast. `outline` (not
+   box-shadow) is used so it composes with the base drop-shadow instead of
+   replacing it. Pointer focus stays ring-free via :focus-visible. */
+.terminal:focus-visible {
+  border-color: var(--terminal-border-active);
+  outline: 2px solid var(--color-semantic-border-focus);
+  outline-offset: 2px;
 }
 
 .terminal--active .terminal__title-bar {
@@ -177,7 +184,7 @@
     border-width: 2px;
   }
 
-  .terminal:focus {
+  .terminal:focus-visible {
     outline: 3px solid var(--color-semantic-border-focus);
     outline-offset: 2px;
   }


### PR DESCRIPTION
Closes DMNC-1060. First of the 5-PR compliance & a11y cluster from the 2026-06-16 component audit.

## What

Five small, localized keyboard/focus defects — the system is otherwise strong on a11y:

| Component | Defect | Fix |
|-----------|--------|-----|
| **Icon** | `role="button"` had a click handler but no tab stop or key handler → not keyboard-operable; its `:focus-visible` rule could never fire | `tabIndex=0` + Enter/Space activation when `role="button"`; added a normal-contrast `:focus-visible` ring (was high-contrast only) |
| **Tag** | interactive body had no `:focus-visible` (invisible keyboard focus); a `closeable && !onClick` tag had **no** keyboard dismiss path (body not focusable, close button `excludeFromTabOrder`) | `:focus-visible` ring on body + close button; close button stays tabbable when the tag isn't interactive, still excluded when it is (body offers Delete/Backspace) |
| **Terminal** | `outline: none` on `.terminal:focus` with no normal-contrast replacement → focus invisible outside `prefers-contrast: high` | visible `:focus-visible` outline that composes with the drop shadow |
| **CommandPrompt** | `role="textbox"` + `aria-label` on the non-focusable wrapper around a real labelled `<input>` → duplicate, non-operable textbox | removed the role/label from the wrapper |
| **Accordion** | header focus ring keyed off `:focus` (fires on pointer too) | `:focus-visible` |

## Tests

- **+10** new: Icon keyboard activation + focusability (and the non-button negative cases), Tag non-interactive keyboard dismiss via the close button, CommandPrompt single-textbox assertion.
- Updated: CommandPrompt container selection (no longer via the removed role), Tag close-button tab-order expectations to match the new behavior.
- Full suite green: **1143 passed**. Lint clean. `tsc -p tsconfig.build.json` clean.

## Notes

- No version bump — accumulating under `## [Unreleased]` in the CHANGELOG; the cluster will cut a single release once the other PRs (1063, 1059, 1061, 1070) land.
- Pure a11y behavior/CSS; no public API changes (Icon gains keyboard support behind the existing `role="button"` opt-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)