### PR TITLE
fix: behavioral bugs — InlineExpand clipping, dead Timeline zoom-in, Lightbox CSS coupling (DMNC-1063)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Terminal** — focus is now visible at normal contrast via a `:focus-visible` outline (was `outline: none` outside `prefers-contrast: high`); composes with the drop shadow.
   - **CommandPrompt** — removed a redundant `role="textbox"` + `aria-label` from the non-focusable wrapper around the real `<input>` (which carries its own label) — it exposed a duplicate, non-operable textbox.
   - **Accordion** — header focus ring keys off `:focus-visible` instead of `:focus`, so it no longer shows on pointer press.
+- **Behavioral bug fixes across three components (DMNC-1063).** From the 2026-06-16 compliance audit:
+  - **InlineExpand** — expand/collapse animated `max-height: 500px`, which clipped content taller than 500px. Switched to the `grid-template-rows: 0fr → 1fr` + `overflow: clip` pattern (same as Accordion) — animates to the natural height with no cap and is compositor-friendly. Content + sources are now wrapped in a single grid-clip child.
+  - **TimelineContainer** — the `[+]` zoom-in button rendered enabled but was wired to a no-op (`onZoomIn={() => {}}`), and the documented `Ctrl/Cmd+=` shortcut was unimplemented. Both now drill into the first bucket of the current view (the most recent period under the default `desc` sort). Bucket clicks still drill into that specific period.
+  - **Lightbox** — depended on `modal-crt-enter/exit` + `backdrop-open/close` keyframes that were defined only in `Modal.css`, so it broke if Modal's stylesheet wasn't loaded. Those keyframes now live in the shared `src/styles/keyframes.css`, imported from each overlay's TSX (Modal, Lightbox, CmdPalette) — every overlay is self-contained.
 
 ## [0.29.0] - 2026-06-15
 

--- a/src/components/CmdPalette/components/CmdPalette.tsx
+++ b/src/components/CmdPalette/components/CmdPalette.tsx
@@ -13,6 +13,7 @@ import {
   Dialog as AriaDialog,
 } from 'react-aria-components';
 import { cn } from '../../../utils/cn';
+import '../../../styles/keyframes.css';
 import './CmdPalette.css';
 
 export interface CmdPaletteItem {

--- a/src/components/InlineExpand/components/InlineExpand.css
+++ b/src/components/InlineExpand/components/InlineExpand.css
@@ -54,21 +54,30 @@
   text-shadow: 0 0 6px var(--color-cga-amber-glow);
 }
 
-/* Content container — stays in DOM, visibility toggled for exit animation */
+/* Content container — stays in DOM, visibility toggled for exit animation.
+   grid-template-rows 0fr → 1fr animates to the natural content height with no
+   hard cap (a 500px max-height previously clipped tall content — DMNC-1063).
+   Same pattern as Accordion's Section. */
 .eidotter-inline-expand__content {
-  display: block;
+  display: grid;
+  grid-template-rows: 0fr;
   visibility: hidden;
   opacity: 0;
   filter: blur(1px) brightness(0.5);
   transform: translateY(-0.2rem);
-  overflow: clip;
-  max-height: 0;
   transition:
+    grid-template-rows var(--duration-fast, 100ms) ease-in,
     opacity var(--duration-fast, 100ms) ease-in,
     visibility var(--duration-fast, 100ms),
     filter var(--duration-fast, 100ms) ease-in,
-    transform var(--duration-fast, 100ms) ease-in,
-    max-height var(--duration-fast, 100ms) ease-in;
+    transform var(--duration-fast, 100ms) ease-in;
+}
+
+/* Single grid child collapses with the row — min-height:0 lets it shrink below
+   content size; overflow:clip hides the content while the row is at 0fr. */
+.eidotter-inline-expand__content-clip {
+  min-height: 0;
+  overflow: clip;
 }
 
 /* Expanded content — phosphor warm-up + Swift Out easing */
@@ -77,13 +86,13 @@
   opacity: 1;
   filter: blur(0) brightness(1);
   transform: translateY(0);
-  max-height: 500px;
+  grid-template-rows: 1fr;
   transition:
+    grid-template-rows var(--duration-normal, 200ms) cubic-bezier(0.175, 0.885, 0.32, 1.1),
     opacity var(--duration-normal, 200ms) cubic-bezier(0.175, 0.885, 0.32, 1.1),
     visibility var(--duration-normal, 200ms),
     filter var(--duration-normal, 200ms) cubic-bezier(0.175, 0.885, 0.32, 1.1),
-    transform var(--duration-normal, 200ms) cubic-bezier(0.175, 0.885, 0.32, 1.1),
-    max-height var(--duration-normal, 200ms) cubic-bezier(0.175, 0.885, 0.32, 1.1);
+    transform var(--duration-normal, 200ms) cubic-bezier(0.175, 0.885, 0.32, 1.1);
 }
 
 /* Inner content styling */

--- a/src/components/InlineExpand/components/InlineExpand.test.tsx
+++ b/src/components/InlineExpand/components/InlineExpand.test.tsx
@@ -46,6 +46,22 @@ describe('InlineExpand', () => {
       render(<InlineExpand {...defaultProps} defaultExpanded />);
       expect(screen.getByRole('region')).toBeInTheDocument();
     });
+
+    // DMNC-1063 — content and sources must sit inside a single grid child so
+    // grid-template-rows 0fr→1fr collapses the whole block with no height cap
+    // (the old 500px max-height clipped tall content).
+    it('wraps content and sources in a single grid-clip child', () => {
+      const sources: InlineExpandSource[] = [{ title: 'Ref', url: 'https://example.com' }];
+      const { container } = render(
+        <InlineExpand {...defaultProps} defaultExpanded sources={sources} />,
+      );
+      const content = container.querySelector('.eidotter-inline-expand__content')!;
+      expect(content.children).toHaveLength(1);
+      const clip = content.children[0];
+      expect(clip).toHaveClass('eidotter-inline-expand__content-clip');
+      expect(clip.querySelector('.eidotter-inline-expand__inner')).toBeInTheDocument();
+      expect(clip.querySelector('.eidotter-inline-expand__sources')).toBeInTheDocument();
+    });
   });
 
   describe('uncontrolled mode', () => {

--- a/src/components/InlineExpand/components/InlineExpand.tsx
+++ b/src/components/InlineExpand/components/InlineExpand.tsx
@@ -130,12 +130,15 @@ export const InlineExpand: React.FC<InlineExpandProps> = ({
         role="region"
         inert={!isExpanded}
       >
-        <span className="eidotter-inline-expand__inner">
-          {content}
-        </span>
-        {sources.length > 0 && (
-          <span className="eidotter-inline-expand__sources" role="list">
-            {sources.map((source) => (
+        {/* Single grid child so grid-template-rows 0fr→1fr collapses the whole
+            block (both inner content and sources) without a height cap. */}
+        <span className="eidotter-inline-expand__content-clip">
+          <span className="eidotter-inline-expand__inner">
+            {content}
+          </span>
+          {sources.length > 0 && (
+            <span className="eidotter-inline-expand__sources" role="list">
+              {sources.map((source) => (
               <span key={source.url} className="eidotter-inline-expand__source-item" role="listitem">
                 <a
                   href={isSafeUrl(source.url) ? source.url : undefined}
@@ -160,9 +163,10 @@ export const InlineExpand: React.FC<InlineExpandProps> = ({
                   <span className="eidotter-inline-expand__source-title">{source.title}</span>
                 </a>
               </span>
-            ))}
-          </span>
-        )}
+              ))}
+            </span>
+          )}
+        </span>
       </span>
     </span>
   );

--- a/src/components/Lightbox/components/Lightbox.tsx
+++ b/src/components/Lightbox/components/Lightbox.tsx
@@ -8,6 +8,7 @@ import {
 import { Icon } from '../../Icon/components/Icon';
 import { cn } from '../../../utils/cn';
 import type { TimelineImage } from '../../TimelineContainer/components/types';
+import '../../../styles/keyframes.css';
 import './Lightbox.css';
 
 export interface LightboxProps {

--- a/src/components/Modal/components/Modal.css
+++ b/src/components/Modal/components/Modal.css
@@ -107,42 +107,9 @@
   color: var(--color-cga-light-gray);
 }
 
-/* Keyframes */
-@keyframes modal-crt-enter {
-  from {
-    opacity: 0;
-    filter: blur(4px) brightness(0.3);
-    transform: scale(0.95);
-  }
-  to {
-    opacity: 1;
-    filter: blur(0) brightness(1);
-    transform: scale(1);
-  }
-}
-
-@keyframes modal-crt-exit {
-  from {
-    opacity: 1;
-    filter: blur(0) brightness(1);
-    transform: scale(1);
-  }
-  to {
-    opacity: 0;
-    filter: blur(2px) brightness(0.5);
-    transform: scale(0.95);
-  }
-}
-
-@keyframes backdrop-open {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@keyframes backdrop-close {
-  from { opacity: 1; }
-  to { opacity: 0; }
-}
+/* Keyframes (modal-crt-enter/exit, backdrop-open/close) live in
+   src/styles/keyframes.css — shared with Lightbox and CmdPalette and imported
+   from each component's TSX (DMNC-1063). */
 
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/Modal/components/Modal.tsx
+++ b/src/components/Modal/components/Modal.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-aria-components';
 import { Icon } from '../../Icon/components/Icon';
 import { cn } from '../../../utils/cn';
+import '../../../styles/keyframes.css';
 import './Modal.css';
 
 export interface ModalProps {

--- a/src/components/TimelineContainer/components/TimelineContainer.test.tsx
+++ b/src/components/TimelineContainer/components/TimelineContainer.test.tsx
@@ -115,6 +115,32 @@ describe('TimelineContainer', () => {
       render(<TimelineContainer entries={sampleEntries} defaultZoomLevel="hour" />);
       expect(screen.getByLabelText(/Zoom in/)).toBeDisabled();
     });
+
+    // DMNC-1063 — the [+] button used to render enabled but was wired to a
+    // no-op; it now drills into the first bucket. Drilling down one level makes
+    // zoom-out (disabled at the year root) become enabled.
+    it('drills into the first bucket when [+] zoom-in is clicked', () => {
+      render(<TimelineContainer entries={sampleEntries} defaultZoomLevel="year" />);
+      expect(screen.getByLabelText(/Zoom out/)).toBeDisabled();
+      fireEvent.click(screen.getByLabelText(/Zoom in/));
+      expect(screen.getByLabelText(/Zoom out/)).toBeEnabled();
+    });
+
+    it('announces the drilled-into period on zoom-in (first bucket, desc order)', () => {
+      render(<TimelineContainer entries={sampleEntries} defaultZoomLevel="year" />);
+      fireEvent.click(screen.getByLabelText(/Zoom in/));
+      // Default sortOrder 'desc' → first bucket is the most recent year (2025).
+      expect(screen.getByText(/Showing months in 2025/)).toBeInTheDocument();
+    });
+
+    it('zooms in via the Ctrl+= keyboard shortcut', () => {
+      render(<TimelineContainer entries={sampleEntries} defaultZoomLevel="year" />);
+      const region = screen.getByRole('region', { name: 'Timeline' });
+      region.focus();
+      expect(screen.getByLabelText(/Zoom out/)).toBeDisabled();
+      fireEvent.keyDown(region, { key: '=', ctrlKey: true });
+      expect(screen.getByLabelText(/Zoom out/)).toBeEnabled();
+    });
   });
 
   describe('controlled mode', () => {

--- a/src/components/TimelineContainer/components/TimelineContainer.tsx
+++ b/src/components/TimelineContainer/components/TimelineContainer.tsx
@@ -176,6 +176,24 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
     [allBuckets, currentPeriod, parentZoomLevel],
   );
 
+  // Drill into a specific bucket — shared by bucket clicks, the [+] zoom-in
+  // control, and the Ctrl/Cmd+= shortcut.
+  const drillIntoBucket = useCallback((bucket: DateBucket) => {
+    if (!canZoomIn) return;
+    drillDown(bucket.periodStart, bucket.label);
+    setAnnouncement(
+      `Showing ${zoomLevel === 'year' ? 'months' : zoomLevel === 'month' ? 'days' : 'hours'} in ${bucket.label}`,
+    );
+  }, [canZoomIn, drillDown, zoomLevel]);
+
+  // Generic zoom-in has no inherent target (unlike drill-up, which pops the
+  // stack), so the [+] control and Ctrl/Cmd+= drill into the first bucket of the
+  // current view — the most recent period under the default sortOrder. Clicking
+  // a specific bucket still drills into that exact period.
+  const handleZoomIn = useCallback(() => {
+    if (buckets.length > 0) drillIntoBucket(buckets[0]);
+  }, [buckets, drillIntoBucket]);
+
   // Scroll-to-zoom: Ctrl/Cmd + wheel (interactive mode only)
   useEffect(() => {
     if (isVerticalFeed || !scrollToZoom) return;
@@ -221,7 +239,10 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
 
       const isMod = e.ctrlKey || e.metaKey;
 
-      if (isMod && e.key === '-') {
+      if (isMod && (e.key === '=' || e.key === '+')) {
+        e.preventDefault();
+        handleZoomIn();
+      } else if (isMod && e.key === '-') {
         e.preventDefault();
         drillUp();
       } else if (isMod && e.key === '0') {
@@ -236,14 +257,13 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isVerticalFeed, keyboardShortcuts, drillUp, reset, deselect]);
+  }, [isVerticalFeed, keyboardShortcuts, handleZoomIn, drillUp, reset, deselect]);
 
   // Bucket click triggers drill-down
-  const handleBucketClick = useCallback((bucket: DateBucket) => {
-    if (!canZoomIn) return;
-    drillDown(bucket.periodStart, bucket.label);
-    setAnnouncement(`Showing ${zoomLevel === 'year' ? 'months' : zoomLevel === 'month' ? 'days' : 'hours'} in ${bucket.label}`);
-  }, [canZoomIn, drillDown, zoomLevel]);
+  const handleBucketClick = useCallback(
+    (bucket: DateBucket) => drillIntoBucket(bucket),
+    [drillIntoBucket],
+  );
 
   // Focus management: move focus after drill-down transitions
   const prevBreadcrumbLengthRef = useRef(breadcrumbs.length);
@@ -337,7 +357,7 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
           zoomLevel={zoomLevel}
           canZoomIn={canZoomIn}
           canZoomOut={canZoomOut}
-          onZoomIn={() => {}}
+          onZoomIn={handleZoomIn}
           onZoomOut={drillUp}
           onReset={reset}
           breadcrumbs={isDrillDownEnabled ? breadcrumbs : []}

--- a/src/styles/keyframes.css
+++ b/src/styles/keyframes.css
@@ -25,3 +25,43 @@
     opacity: 0;
   }
 }
+
+/* CRT panel enter/exit — used by Modal, Lightbox, and CmdPalette overlays.
+   Shared here so each overlay is self-contained and doesn't depend on Modal's
+   stylesheet being loaded (DMNC-1063). */
+@keyframes modal-crt-enter {
+  from {
+    opacity: 0;
+    filter: blur(4px) brightness(0.3);
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    filter: blur(0) brightness(1);
+    transform: scale(1);
+  }
+}
+
+@keyframes modal-crt-exit {
+  from {
+    opacity: 1;
+    filter: blur(0) brightness(1);
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    filter: blur(2px) brightness(0.5);
+    transform: scale(0.95);
+  }
+}
+
+/* Backdrop fade — shared by the same overlays' scrims. */
+@keyframes backdrop-open {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes backdrop-close {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}


### PR DESCRIPTION
Closes DMNC-1063. Second of the compliance & a11y cluster from the 2026-06-16 audit (after #390).

## Three genuine behavioral defects

### 1. InlineExpand — `max-height: 500px` clipped tall content
Expand/collapse animated `max-height: 500px`, so content taller than 500px was cut off (the `LongContent` story was at risk). Switched to the **`grid-template-rows: 0fr → 1fr` + `overflow: clip`** pattern (same as Accordion's `Section`) — animates to the natural height with no cap, compositor-friendly. Content + sources are wrapped in a single grid-clip child (the technique needs exactly one grid row to collapse).

### 2. TimelineContainer — dead `[+]` zoom-in button + unimplemented `Ctrl+=`
The `[+]` button rendered enabled (`canZoomIn`) but was wired to `onZoomIn={() => {}}` — clicking did nothing — and the documented `Ctrl/Cmd+=` shortcut wasn't handled. Generic zoom-in has no inherent target (unlike drill-up, which pops the stack), so **both now drill into the first bucket of the current view** (the most recent period under the default `desc` sort). Clicking a specific bucket still drills into that exact period. Extracted a shared `drillIntoBucket` helper used by bucket clicks, `[+]`, and the shortcut.

### 3. Lightbox — CSS coupling to Modal
`Lightbox.css` referenced `modal-crt-enter/exit` + `backdrop-open/close` keyframes **defined only in `Modal.css`**, so animations broke if Modal's stylesheet wasn't loaded. (CmdPalette had the same latent coupling.) Relocated those four keyframes to the shared **`src/styles/keyframes.css`**, imported from each overlay's TSX (Modal, Lightbox, CmdPalette). Every overlay is now self-contained; no duplication.

## Tests
- **+4**: InlineExpand single grid-clip child invariant; TimelineContainer zoom-in via `[+]` and via `Ctrl+=`, plus the drill-into announcement.
- Full suite green: **1147 passed**. Lint clean. `tsc -p tsconfig.build.json` clean.

## Notes
- No version bump — accumulating under `## [Unreleased]`; the cluster cuts one release after the remaining PRs (1059, 1061, 1070) land.
- No public API changes. `Ctrl/Cmd+=` now matches the long-standing `keyboardShortcuts` prop doc ("Ctrl+=/-/0").

🤖 Generated with [Claude Code](https://claude.com/claude-code)