### PR TITLE
chore(ci): component-compliance reviewer checklist in PR template (DMNC-1070, partial)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,11 +17,25 @@ Fixes #
 
 ## Checklist
 
-- [ ] My code follows the project's coding style (BEM CSS, TypeScript interfaces with JSDoc)
+- [ ] My code follows the project's coding style (V.37 React Aria + Tailwind, or BEM for the bitmap-font exceptions; TypeScript interfaces with JSDoc)
 - [ ] I have added tests that prove my fix/feature works
 - [ ] All new and existing tests pass (`npm run test`)
-- [ ] I have updated the documentation if needed
+- [ ] I have updated the documentation if needed (README, CLAUDE.md, CHANGELOG on releases)
 - [ ] I have added a changeset if this change affects the public API (`npx changeset`)
+
+## Component compliance (for any component change)
+
+<!-- Skip if this PR touches no component code. Otherwise confirm each item. -->
+
+- [ ] **Reuse** — used an existing eidotter component/primitive where one fits, rather than re-implementing
+- [ ] **Tokens** — colours/spacing/radius use semantic (`--color-semantic-*`) or primitive (`--color-cga-*`) tokens; **no** hardcoded hex, `rgba()` glows, or Tailwind arbitrary colour values (`bg-[#…]`)
+- [ ] **Keyboard** — every action a pointer can take is operable by keyboard (Enter/Space/arrows as appropriate); interactive controls are in the tab order
+- [ ] **Focus** — a visible `:focus-visible` ring at normal contrast (not `outline: none` without a replacement)
+- [ ] **ARIA** — correct roles/states/labels; no prohibited attributes; overlays trap + restore focus and `inert` their closed/off-screen content
+- [ ] **Reduced motion** — every animation has a `@media (prefers-reduced-motion: reduce)` path (and JS bypass via `prefersReducedMotion()` where animation is scripted)
+- [ ] **High contrast** — phosphor `text-shadow`/`box-shadow` glows neutralized under `@media (prefers-contrast: high)`; emphasis carried by border/underline, not colour alone
+- [ ] **Responsive** — component-level breakpoints use CSS container queries, not media queries
+- [ ] **Axe gate** — Storybook stories cover the key variants and the axe gate passes; no new entries added to `a11y-known-failures.json` without a linked tracking issue
 
 ## Screenshots (if applicable)
 


### PR DESCRIPTION
Partial **DMNC-1070** — the independent, non-blocked piece of "make component compliance a CI gate."

## What

Adds a **Component compliance** checklist to `.github/PULL_REQUEST_TEMPLATE.md` covering the dimensions from the 2026-06-16 audit: reuse, token discipline (no hex/arbitrary colours), keyboard operability, visible `:focus-visible`, ARIA/overlay correctness (trap + restore + `inert`), reduced-motion, high-contrast glow neutralization, container-query responsiveness, and the axe gate / `a11y-known-failures.json` ratchet.

Self-contained — no references to private/external docs.

## Status of the other two 1070 pieces

- **Axe a11y gate — already done.** It exists and is **enforced in CI**: `build.yml` runs `test-a11y` with `A11Y_FAIL_ON_VIOLATION: '1'`, `test-runner.ts` fails on any new WCAG violation, ratcheted by `a11y-known-failures.json` (only-shrinks policy documented in the runner). It runs on every story, so new components are covered automatically.
- **Token-discipline lint — deferred.** Enabling a lint that fails on `--color-cga-*`/hex in component CSS now would turn CI red on the ~30 components the **DMNC-1059** sweep still has to convert. The sweep itself is blocked on the color-system work (DMNC-922/1001) — see the blocker comment on DMNC-1059. The lint lands with/after the sweep.

DMNC-1070 stays open for the deferred token-lint.

## Notes
- Markdown-only; no code, no library/CHANGELOG impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)