### PR TITLE
refactor(tokens): strip dead hex fallbacks + FilterBar.color semantic nudge (DMNC-1059, partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Active route now carries `aria-current="page"` and an underline — no longer signalled by colour alone (WCAG 1.4.1).
   - The MENU-trigger hover glow `text-shadow` is neutralized under `prefers-contrast: high`.
 
+### Changed
+- **Token-discipline cleanup (DMNC-1059, partial).** Removed 49 dead hardcoded-hex fallbacks from `var(--color-cga-*, #hex)` references across 19 component stylesheets — every referenced token resolves (enforced by `lint-tokens`), so the fallbacks never fired; this is a visual no-op that drops the misleading hex (e.g. the destructive Button's `#AA0000` fallback, which already rendered the amber-mono primitive). `FilterBarItem.color` JSDoc now steers consumers toward semantic role tokens. The full primitive→semantic re-theming sweep is deferred pending the color-system rationalization (DMNC-922/1001).
+
 ## [0.29.0] - 2026-06-15
 
 ### Added

--- a/src/components/Badge/components/Badge.css
+++ b/src/components/Badge/components/Badge.css
@@ -12,7 +12,7 @@
 /* Variants */
 .eidotter-badge--default {
   background-color: var(--color-semantic-background-secondary);
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   border: 1px solid var(--color-semantic-border-default);
 }
 .eidotter-badge--success {
@@ -45,7 +45,7 @@
 .eidotter-badge__dot {
   width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
 }
-.eidotter-badge--default .eidotter-badge__dot { background-color: var(--color-cga-amber, #ffb000); }
+.eidotter-badge--default .eidotter-badge__dot { background-color: var(--color-cga-amber); }
 .eidotter-badge--success .eidotter-badge__dot { background-color: var(--color-cga-bright-green); }
 .eidotter-badge--warning .eidotter-badge__dot { background-color: var(--color-cga-yellow); }
 .eidotter-badge--error .eidotter-badge__dot { background-color: var(--color-cga-bright-red); }

--- a/src/components/Brand/components/Brand.css
+++ b/src/components/Brand/components/Brand.css
@@ -12,16 +12,16 @@
   line-height: 1;
   letter-spacing: 0.02em;
   font-weight: 400;
-  color: var(--color-semantic-text-accent, #FFB000);
+  color: var(--color-semantic-text-accent);
 }
 
 .eidotter-wordmark__prefix {
-  color: var(--color-cga-amber-dim, #B87C1A);
+  color: var(--color-cga-amber-dim);
   text-shadow: 0 0 4px rgba(255, 176, 0, 0.4);
 }
 
 .eidotter-wordmark__body {
-  color: var(--color-cga-amber, #FFB000);
+  color: var(--color-cga-amber);
 }
 
 .eidotter-wordmark--glow .eidotter-wordmark__body,

--- a/src/components/Breadcrumb/components/Breadcrumb.css
+++ b/src/components/Breadcrumb/components/Breadcrumb.css
@@ -9,7 +9,7 @@
 }
 
 .eidotter-breadcrumb__link:hover {
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   opacity: 1;
 }
 

--- a/src/components/Button/components/Button.css
+++ b/src/components/Button/components/Button.css
@@ -28,19 +28,19 @@
 @keyframes scanline-crawl { 0% { background-position: 0 0; } 100% { background-position: 0 40px; } }
 
 .eidotter-btn--secondary {
-  background-color: var(--color-semantic-background-secondary); color: var(--color-cga-amber, #ffb000);
+  background-color: var(--color-semantic-background-secondary); color: var(--color-cga-amber);
   border-color: var(--color-semantic-border-default);
   transition: background-color 400ms cubic-bezier(0.5, -0.2, 0.2, 1.2), border-color 400ms cubic-bezier(0.5, -0.2, 0.2, 1.2), box-shadow 400ms cubic-bezier(0.5, -0.2, 0.2, 1.2), text-shadow 400ms cubic-bezier(0.5, -0.2, 0.2, 1.2);
 }
 .eidotter-btn--secondary:not([disabled]):hover, .eidotter-btn--secondary:not([disabled])[data-hovered] {
-  background-color: var(--color-cga-amber, #ffb000); color: var(--color-semantic-background-primary);
+  background-color: var(--color-cga-amber); color: var(--color-semantic-background-primary);
   border-color: var(--color-semantic-text-secondary);
   box-shadow: 0 0 8px 0 var(--color-cga-amber-glow), 0 0 20px 2px var(--effects-phosphor-glow);
   text-shadow: 0 0 3px var(--color-cga-amber-glow);
   animation: phosphor-warmup var(--duration-slow, 400ms) ease-out;
 }
 .eidotter-btn--secondary:not([disabled]):active, .eidotter-btn--secondary:not([disabled])[data-pressed] {
-  background-color: var(--color-semantic-background-secondary); color: var(--color-cga-amber, #ffb000);
+  background-color: var(--color-semantic-background-secondary); color: var(--color-cga-amber);
   border-color: var(--color-semantic-text-disabled);
   box-shadow: 0 0 10px 2px var(--color-cga-amber-glow), 0 0 24px 4px var(--effects-phosphor-glow);
   text-shadow: 0 0 5px var(--color-cga-amber-glow);
@@ -48,7 +48,7 @@
 }
 
 .eidotter-btn--tertiary {
-  background-color: transparent; color: var(--color-cga-amber, #ffb000); border-color: transparent; transition: all 300ms ease;
+  background-color: transparent; color: var(--color-cga-amber); border-color: transparent; transition: all 300ms ease;
 }
 .eidotter-btn--tertiary:not([disabled]):hover, .eidotter-btn--tertiary:not([disabled])[data-hovered] {
   background-color: var(--color-semantic-background-secondary); border-color: var(--color-semantic-border-default);
@@ -60,32 +60,32 @@
 }
 
 .eidotter-btn--destructive {
-  background-color: var(--color-cga-red, #AA0000); color: var(--color-cga-white, #FFFFFF); border-color: var(--color-cga-bright-red, #FF5555);
+  background-color: var(--color-cga-red); color: var(--color-cga-white); border-color: var(--color-cga-bright-red);
   transition: background-color 400ms cubic-bezier(0.5, -0.2, 0.2, 1.2), border-color 400ms cubic-bezier(0.5, -0.2, 0.2, 1.2), box-shadow 400ms cubic-bezier(0.5, -0.2, 0.2, 1.2), text-shadow 400ms cubic-bezier(0.5, -0.2, 0.2, 1.2);
 }
 .eidotter-btn--destructive:not([disabled]):hover, .eidotter-btn--destructive:not([disabled])[data-hovered] {
-  background-color: var(--color-cga-bright-red, #FF5555);
+  background-color: var(--color-cga-bright-red);
   box-shadow: 0 0 8px 0 rgba(255,85,85,0.5), 0 0 20px 2px rgba(255,85,85,0.3);
   text-shadow: 0 0 3px rgba(255,85,85,0.5); animation: phosphor-warmup var(--duration-slow, 400ms) ease-out;
 }
 .eidotter-btn--destructive:not([disabled]):active, .eidotter-btn--destructive:not([disabled])[data-pressed] {
-  background-color: var(--color-cga-red, #AA0000);
+  background-color: var(--color-cga-red);
   box-shadow: 0 0 12px 2px rgba(255,85,85,0.5), 0 0 30px 4px rgba(255,85,85,0.3);
   animation: phosphor-energize 150ms ease-out forwards;
 }
 
 .eidotter-btn--ghost {
-  background-color: transparent; color: var(--color-cga-amber, #ffb000); border-color: var(--color-semantic-border-default);
+  background-color: transparent; color: var(--color-cga-amber); border-color: var(--color-semantic-border-default);
   transition: background-color 300ms cubic-bezier(0.5, -0.1, 0.2, 1.1), border-color 300ms cubic-bezier(0.5, -0.1, 0.2, 1.1), box-shadow 300ms cubic-bezier(0.5, -0.1, 0.2, 1.1), text-shadow 300ms cubic-bezier(0.5, -0.1, 0.2, 1.1);
 }
 .eidotter-btn--ghost:not([disabled]):hover, .eidotter-btn--ghost:not([disabled])[data-hovered] {
-  background-color: var(--color-cga-amber, #ffb000); color: var(--color-semantic-background-primary);
+  background-color: var(--color-cga-amber); color: var(--color-semantic-background-primary);
   border-color: var(--color-semantic-text-secondary);
   box-shadow: 0 0 8px 0 var(--color-cga-amber-glow); text-shadow: 0 0 3px var(--color-cga-amber-glow);
   animation: phosphor-warmup var(--duration-normal, 200ms) ease-out;
 }
 .eidotter-btn--ghost:not([disabled]):active, .eidotter-btn--ghost:not([disabled])[data-pressed] {
-  background-color: var(--color-semantic-background-secondary); color: var(--color-cga-amber, #ffb000);
+  background-color: var(--color-semantic-background-secondary); color: var(--color-cga-amber);
   box-shadow: 0 0 12px 2px var(--color-cga-amber-glow); text-shadow: 0 0 4px var(--color-cga-amber-glow);
   animation: phosphor-energize 150ms ease-out forwards;
 }

--- a/src/components/Chat/components/ChatInput.css
+++ b/src/components/Chat/components/ChatInput.css
@@ -8,7 +8,7 @@
   flex: 1;
   background: transparent;
   border: none;
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   font-family: inherit;
   font-size: inherit;
   line-height: 1.4;
@@ -26,7 +26,7 @@
 }
 
 .eidotter-chat-input__cursor {
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   animation: blink 1s step-end infinite;
   user-select: none;
   flex-shrink: 0;

--- a/src/components/Chat/components/ChatMessage.css
+++ b/src/components/Chat/components/ChatMessage.css
@@ -1,7 +1,7 @@
 /* ChatMessage — Role variant colors and streaming cursor */
 
 .eidotter-chat-message--user {
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
 }
 
 .eidotter-chat-message--assistant {

--- a/src/components/Checkbox/components/Checkbox.css
+++ b/src/components/Checkbox/components/Checkbox.css
@@ -1,12 +1,12 @@
 /* eiDotter Checkbox — Bracket Text + Phosphor Glow */
 
 .eidotter-checkbox {
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
 }
 
 .eidotter-checkbox__box {
   display: inline-block; white-space: nowrap; text-align: center;
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   transition: color var(--duration-fast, 100ms) ease-out;
 }
 

--- a/src/components/CommandPrompt/components/CommandPrompt.css
+++ b/src/components/CommandPrompt/components/CommandPrompt.css
@@ -11,7 +11,7 @@
 }
 
 .command-prompt__prompt {
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   margin-right: var(--spacing-2);
   white-space: nowrap;
   user-select: none;
@@ -28,7 +28,7 @@
 .command-prompt__input {
   background: transparent;
   border: none;
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   font-family: inherit;
   font-size: inherit;
   outline: none;
@@ -43,7 +43,7 @@
 }
 
 .command-prompt__cursor {
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   animation: blink 1s step-end infinite;
   user-select: none;
   flex-shrink: 0;

--- a/src/components/FilterBar/components/FilterBar.css
+++ b/src/components/FilterBar/components/FilterBar.css
@@ -17,7 +17,7 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   white-space: nowrap;
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   opacity: 0.7;
   transition:
     color var(--duration-fast, 100ms) ease-out,
@@ -86,13 +86,13 @@
   line-height: 1;
   border-radius: 2px;
   background-color: transparent;
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   border: 1px solid var(--color-semantic-border-default);
 }
 
 .eidotter-filter-bar__item--active .eidotter-filter-bar__count {
   background-color: var(--color-semantic-background-secondary);
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   border-color: var(--color-semantic-border-default);
 }
 
@@ -150,8 +150,8 @@
   }
 
   .eidotter-filter-bar__item--active {
-    border-color: var(--color-cga-amber, #ffb000);
-    outline: 1px solid var(--color-cga-amber, #ffb000);
+    border-color: var(--color-cga-amber);
+    outline: 1px solid var(--color-cga-amber);
     outline-offset: -1px;
     text-shadow: none;
     box-shadow: none;

--- a/src/components/FilterBar/components/FilterBar.tsx
+++ b/src/components/FilterBar/components/FilterBar.tsx
@@ -12,7 +12,13 @@ export interface FilterBarItem {
   count?: number;
   /** Whether this item is disabled */
   disabled?: boolean;
-  /** Optional CGA color token for active state (e.g. '--color-cga-bright-cyan') */
+  /**
+   * Optional colour-role token for the active state, applied as a CSS custom
+   * property. Prefer a semantic role (e.g. `--color-semantic-text-accent`) so
+   * the active colour follows the active theme; raw `--color-cga-*` primitives
+   * are accepted but won't re-theme. (A themeable per-category palette is
+   * tracked with the token rationalization, DMNC-922/1059.)
+   */
   color?: string;
 }
 

--- a/src/components/InlineExpand/components/InlineExpand.css
+++ b/src/components/InlineExpand/components/InlineExpand.css
@@ -46,7 +46,7 @@
 /* [+]/[-] indicator — inline text, no animation (DOS character cells update instantly) */
 .eidotter-inline-expand__indicator {
   margin-left: var(--spacing-1, 4px);
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
 }
 
 /* Brief phosphor flash when toggling */
@@ -103,7 +103,7 @@
   border-left: var(--border-width-medium, 2px) solid var(--color-semantic-border-default);
   font-size: var(--typography-font-size-text-sm, 14px);
   line-height: var(--typography-line-height-text-md, 1.5);
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
 }
 
 /* =============================================================================

--- a/src/components/Nav/components/Nav.css
+++ b/src/components/Nav/components/Nav.css
@@ -112,7 +112,7 @@
   z-index: 120;
   transform: translateX(100%);
   transition: transform var(--duration-slow, 300ms) ease-in-out;
-  background-color: var(--color-semantic-background-primary, #000);
+  background-color: var(--color-semantic-background-primary);
   border-left: var(--border-width-thin, 1px) solid var(--color-cga-amber-glow);
 }
 

--- a/src/components/Progress/components/Progress.css
+++ b/src/components/Progress/components/Progress.css
@@ -65,7 +65,7 @@
   top: 0;
   left: 0;
   width: 100%;
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   white-space: nowrap;
   clip-path: inset(0 calc(100% - var(--fill-pct, 0) * 1%) 0 0);
   transition: clip-path var(--duration-slow, 300ms) ease-out;
@@ -79,7 +79,7 @@
   position: absolute;
   top: 0;
   left: 0;
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   opacity: var(--opacity-50);
   white-space: nowrap;
   transform: translateX(calc(var(--fill-pct, 0) / 100 * 100%));
@@ -128,7 +128,7 @@
    ========================================================================== */
 
 .eidotter-progress__label {
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   min-width: 4ch;
   text-align: right;
 }
@@ -145,7 +145,7 @@
   position: absolute;
   top: 0;
   left: 0;
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   animation: dos-scan 2s ease-in-out infinite alternate;
 }
 

--- a/src/components/Separator/components/Separator.css
+++ b/src/components/Separator/components/Separator.css
@@ -2,6 +2,6 @@
 
 @media (prefers-contrast: high) {
   .eidotter-separator {
-    background-color: var(--color-cga-amber, #ffb000);
+    background-color: var(--color-cga-amber);
   }
 }

--- a/src/components/Switch/components/Switch.css
+++ b/src/components/Switch/components/Switch.css
@@ -17,7 +17,7 @@
 .eidotter-switch__thumb {
   position: absolute; left: 2px;
   width: 12px; height: 12px;
-  background-color: var(--color-cga-amber, #ffb000);
+  background-color: var(--color-cga-amber);
   border-radius: 1px;
   transition: transform var(--duration-normal, 200ms) cubic-bezier(0.2, 0.8, 0.2, 1.4),
     background-color var(--duration-fast, 100ms) ease-out;

--- a/src/components/Tag/components/Tag.css
+++ b/src/components/Tag/components/Tag.css
@@ -20,13 +20,13 @@
 /* Variants */
 .eidotter-tag--default {
   background-color: var(--color-semantic-background-secondary);
-  color: var(--tag-color, var(--color-cga-amber, #ffb000));
+  color: var(--tag-color, var(--color-cga-amber));
   border: 1px solid var(--tag-color, var(--color-semantic-border-default));
 }
 .eidotter-tag--outlined {
   background-color: transparent;
-  color: var(--tag-color, var(--color-cga-amber, #ffb000));
-  border: 1px solid var(--tag-color, var(--color-cga-amber, #ffb000));
+  color: var(--tag-color, var(--color-cga-amber));
+  border: 1px solid var(--tag-color, var(--color-cga-amber));
 }
 .eidotter-tag--filled {
   background-color: var(--tag-color, var(--color-semantic-background-accent));

--- a/src/components/Terminal/components/Terminal.css
+++ b/src/components/Terminal/components/Terminal.css
@@ -5,9 +5,9 @@
   --terminal-title-bg: var(--color-semantic-background-secondary);
   --terminal-title-text: var(--color-semantic-text-secondary);
   --terminal-title-bg-inactive: var(--color-semantic-background-secondary);
-  --terminal-title-text-inactive: var(--color-cga-amber, #ffb000);
-  --terminal-text: var(--color-cga-amber, #ffb000);
-  --terminal-control-bg: var(--color-cga-amber, #ffb000);
+  --terminal-title-text-inactive: var(--color-cga-amber);
+  --terminal-text: var(--color-cga-amber);
+  --terminal-control-bg: var(--color-cga-amber);
   --terminal-control-symbol: var(--color-semantic-background-primary);
 }
 

--- a/src/components/TimelineContainer/components/TimelineEntryCard.css
+++ b/src/components/TimelineContainer/components/TimelineEntryCard.css
@@ -77,7 +77,7 @@
 
 /* Collapsed content preview */
 .eidotter-timeline-card__preview {
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   font-size: var(--typography-font-size-text-sm, 0.875rem);
   line-height: var(--typography-line-height-text-md);
   margin: var(--spacing-1) 0 0;

--- a/src/components/TimelineContainer/components/views/views.css
+++ b/src/components/TimelineContainer/components/views/views.css
@@ -59,7 +59,7 @@
 }
 
 .timeline-view__entry-preview {
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   font-size: var(--typography-font-size-text-sm);
   line-height: var(--typography-line-height-text-md);
   margin: 0;
@@ -73,7 +73,7 @@
 }
 
 .timeline-view__entry-content {
-  color: var(--color-cga-amber, #ffb000);
+  color: var(--color-cga-amber);
   font-size: var(--typography-font-size-text-sm);
   line-height: var(--typography-line-height-text-md);
   white-space: pre-wrap;

--- a/src/components/TimelineNode/components/TimelineNode.css
+++ b/src/components/TimelineNode/components/TimelineNode.css
@@ -71,8 +71,8 @@
 }
 
 .eidotter-timeline-node--secondary .eidotter-timeline-node__marker {
-  background: var(--color-cga-amber, #ffb000);
-  border-color: var(--color-cga-amber, #ffb000);
+  background: var(--color-cga-amber);
+  border-color: var(--color-cga-amber);
 }
 
 .eidotter-timeline-node--accent .eidotter-timeline-node__marker {


### PR DESCRIPTION
Partial **DMNC-1059** — the safe, non-blocked slice. (The full sweep is blocked; see below + the issue's blocker comment.)

## What

- **Removed 49 dead `var(--color-cga-*, #hex)` fallbacks** across 19 component stylesheets → `var(--color-cga-*)`. Every referenced token resolves (CI's `lint-tokens` enforces this), so the fallbacks never rendered — **provably a visual no-op**. It also drops misleading literals like the destructive Button's `#AA0000`, which already rendered the amber-mono primitive `--color-cga-red` (`#65360c`), not red.
- **`FilterBarItem.color` JSDoc** now steers consumers toward semantic role tokens (non-breaking; raw `--color-cga-*` still accepted, since the per-category colour feature has no semantic-role equivalent yet).

## Why the full sweep is deferred

The audit's goal — route components through `--color-semantic-*` so they re-theme — **can't be done faithfully today**:
- No semantic role resolves to phosphor-amber `#ffb000` (the colour ~30 components paint with). `text-accent`→yellow, `text-primary`→light-gray, `text-muted`→amber-dim.
- `status-error`/`status-success` resolve to **amber-mono golds** (`#dca934`/`#cb9529`), not red/green, so the destructive Button can't be made honestly red.

Routing through the current semantic layer would regress the look (amber→yellow library-wide) and still couldn't fix the status colours. That needs the **color-system rationalization (DMNC-922)** + **honest status primitives (DMNC-1001)**. Full blocker writeup is on DMNC-1059.

## Verification
- `lint-tokens`: **OK — 227 tokens, no unresolved references** (proves the stripped fallbacks were dead).
- `npm run lint` clean; `tsc -p tsconfig.build.json` clean; affected component tests green. CI runs the full suite + build.

## Notes
- Accumulating under `## [Unreleased]`. DMNC-1059 stays open for the real sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)