### PR TITLE
chore(release): 0.30.0 — component compliance & a11y cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.30.0] - 2026-06-16
+
+Component compliance & a11y cluster from the 2026-06-16 audit (DMNC-1060/1063/1061/1070/1059).
 
 ### Fixed
 - **Keyboard & focus a11y across five components (DMNC-1060).** From the 2026-06-16 compliance audit:
@@ -27,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Token-discipline cleanup (DMNC-1059, partial).** Removed 49 dead hardcoded-hex fallbacks from `var(--color-cga-*, #hex)` references across 19 component stylesheets — every referenced token resolves (enforced by `lint-tokens`), so the fallbacks never fired; this is a visual no-op that drops the misleading hex (e.g. the destructive Button's `#AA0000` fallback, which already rendered the amber-mono primitive). `FilterBarItem.color` JSDoc now steers consumers toward semantic role tokens. The full primitive→semantic re-theming sweep is deferred pending the color-system rationalization (DMNC-922/1001).
+- Dependency batch since 0.29.0: esbuild + storybook (#388), the minor-and-patch group (#389), form-data 4.0.6 (#387), storybook group (#384).
+
+### Internal
+- Added a **Component compliance** reviewer checklist to the PR template (DMNC-1070, partial). The axe a11y gate was already enforced in CI; the token-discipline lint is deferred with the DMNC-1059 sweep.
 
 ## [0.29.0] - 2026-06-15
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,7 +289,7 @@ eiDotter uses Untitled UI as a **pattern reference**, not a dependency. **No UTI
 - **Figma:** UTI Figma library is set up with eiDotter's DOS tokens. eiDotter's Figma file is the source of truth for component design.
 - **License rationale:** eidotter is published under CC-BY-NC-4.0. UTI Pro is a paid commercial license that does not permit sublicensing/redistribution. Bundling UTI Pro assets into `dist/eidotter.css` / `dist/index.es.js` would have been a license violation. Pixelarticons (MIT) avoids this entirely.
 
-## Current Component Status (v0.29.x, June 2026)
+## Current Component Status (v0.30.x, June 2026)
 
 **Components** (41): Accordion, AIText, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Lightbox, Modal, Nav, Notification, Progress, RetroEffects, Separator, Skeleton, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,4 +134,4 @@ export type {
 } from './components/registry';
 
 // Version information
-export const version = '0.29.0';
+export const version = '0.30.0';


### PR DESCRIPTION
Release **0.30.0**. Bundles the 2026-06-16 component compliance & a11y cluster (5 merged PRs).

## Included
- **DMNC-1060** (#390) — keyboard/focus a11y: Icon keyboard-operable, Tag/Terminal/Accordion `:focus-visible`, CommandPrompt redundant role removed
- **DMNC-1063** (#391) — behavioral bugs: InlineExpand grid-rows (no 500px clip), Timeline `[+]`/`Ctrl+=` zoom-in, Lightbox keyframes self-contained
- **DMNC-1061** (#392) — Nav overlay a11y: focus trap + restore, `inert` closed panel, `aria-current` + underline active state, high-contrast glow neutralized
- **DMNC-1070** (#393, partial) — PR-template compliance checklist
- **DMNC-1059** (#394, partial) — stripped 49 dead hex fallbacks; FilterBar.color semantic nudge
- Dependency batch (#384/#387/#388/#389)

## Version
Synced in `package.json`, `src/index.ts`, and the CLAUDE.md status header. CHANGELOG `[Unreleased]` → `[0.30.0]`.

## Publish
Merging + a GitHub Release (tag `v0.30.0`) triggers the OIDC `publish.yml` (`npm publish --provenance`). No token needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)