### PR TITLE
docs(tokens): token architecture map + colour-system principles (DMNC-922)

### DIFF
--- a/solutions/best-practices/color-system-principles.md
+++ b/solutions/best-practices/color-system-principles.md
@@ -1,0 +1,139 @@
+---
+title: Colour-system principles — amber-phosphor identity, semantic-first theming, and first-class light mode
+date: 2026-06-16
+category: best-practices
+module: tokens
+problem_type: best_practice
+component: design-tokens
+severity: high
+applies_when:
+  - You are adding or changing a colour token, semantic role, or theme
+  - You are deciding whether a value belongs in a primitive, a semantic role, or a theme
+  - You are authoring a new theme (light/business/modern) and need the rules and the contrast gate
+  - You are routing a component off raw primitives onto semantic roles (DMNC-1059)
+  - You are reviewing a colour PR and need the principles to hold it against
+tags: [tokens, colour, theming, light-mode, oklch, accessibility, contrast, amber, dmnc-922, dmnc-1058, dmnc-1059, semantic-tokens]
+related:
+  - token-architecture-map.md
+---
+
+# Colour-system principles
+
+**Living document.** The rules the colour system is held to — for components, themes, and reviews. Pairs with [token-architecture-map.md](./token-architecture-map.md) (the *where*). These are what DMNC-1070's token-discipline lint will mechanically enforce; until then they are reviewer law (in the PR template).
+
+---
+
+## Identity — why amber
+
+eidotter is **amber phosphor**, grounded in late-1980s amber monochrome monitors (IBM 5151 / Compaq Portable). This is brand identity, not a theme choice — the *default* theme is amber-on-warm-black, and the CRT/phosphor effects are part of the signature.
+
+Consequences that drive the rules below:
+- **Real red and real green for function, not a hue shift.** Errors must read as errors. A warning signalled only by a shift *within* amber fails colour-blind users and unconscious processing alike. Honest functional colour lives in `color.cga-true.*` (`#AA0000` / `#00AA00` / `#00AAAA`), theme-invariant (DMNC-1001).
+- **We are not "full CGA."** The 16-colour CGA namespace is kept as a *reference pool*, but cyan/magenta/blue primitives are not in service — keeping them implies retro-PC theming we don't do.
+
+---
+
+## Core principles
+
+### 1. Components paint **only** through semantic roles
+Never `var(--color-cga-*)` or hardcoded hex in component CSS/TSX. Always `var(--color-semantic-*)` (or the `dos-*` Tailwind utility that resolves to it). This is the single rule that makes theming work: a component on roles re-themes for free; a component on primitives is frozen. (The DMNC-1059 sweep is the act of making every component obey this; DMNC-1070 is the lint that keeps it true.)
+
+### 2. T1 is a reference pool; not every primitive is in service
+Adding a primitive is cheap and reference-only. A primitive enters *service* only when a **semantic role aliases it**. So:
+- **Keep** the full `cga.*` palette (and `cga-true.*`) even though most aren't used — they're a vetted pool to draw from when a new role needs a value.
+- **Don't** delete/rename primitives just because they're unused (that was the original 922 framing; this supersedes it for the web slice — lower risk, same outcome).
+- The work of 922 is therefore mostly at the **semantic layer**: make the roles honest and complete, drawing values from the pool.
+
+### 3. Every semantic role is defined in **every** theme
+Completeness *is* themeability. A role that some theme forgets to define falls back to the base value and breaks that theme silently. A theme is "done" only when it defines (or deliberately inherits) every role. A test should assert role-set parity across themes.
+
+### 4. Functional colour passes **WCAG AA per theme**
+Every role used for text/icons must pass AA against the background role it sits on, **in each theme**. Gated by `scripts/check-contrast.mjs`, run **per theme** (not just the default). A theme cannot merge if any role fails AA on its own surface. Disabled states are exempt (WCAG 1.4.3).
+
+### 5. Glows and CRT effects are **theme-scoped**
+Phosphor glow / bloom / scanline tokens are dark-native. A light theme must tone them down or null them (a light surface with an amber bloom looks broken). Treat the effect colour tokens (`effects.*`, the `shadow.glow*` set) as theme-overridable, not constants.
+
+### 6. Generated files are never hand-edited
+Edit the JSON sources in `src/tokens/`; run `npm run build-tokens`. CI fails on drift. `npm run lint-tokens` fails on any `var(--*)`/`dos-*` reference that doesn't resolve.
+
+---
+
+## Light mode is a first-class goal
+
+Not an afterthought — the second supported theme, gated like the first.
+
+### How it works (mechanism already exists)
+A theme is a file that re-points the **same semantic roles** to theme-appropriate values, compiled to `[data-theme="light"]`. So light mode = `src/tokens/theme.light.tokens.json`. Nothing in components changes — **if** they obey Principle 1. That's why **1059 is the real prerequisite for reliable light mode**, and a complete honest semantic layer (922) is the prerequisite for 1059. Same arc.
+
+### You define light by role, not by inversion
+Inverting amber-on-black yields mud. Instead pick, per role: a light surface, dark-on-light text, an accent that holds contrast on light, functional red/green that pass AA on light. **Same role names, flipped values.**
+
+### Mine the existing consumer themes — don't lift them
+Two consumers already ship light/business themes (discovered 2026-06-16). They are **decisions to mine, not code to copy**, because both use the **shadcn role vocabulary** (`--background`, `--primary`, `--destructive`, …), not eidotter's `--color-semantic-*`:
+
+- **rizomorf** — `next-themes` with themes `["light", "retro"]`; the light theme is **stock shadcn neutral** (white bg, near-black text, standard red). Low design value, but confirms the role taxonomy and that a non-amber theme coexists with the amber "retro" one.
+- **ux.dominickennedy.de (uxdmncde) — "business" theme** — a *designed* professional light palette in **OKLCH**: warm-paper background `oklch(0.98 0.002 90)` (~#FAFAF9), near-black ink `oklch(0.15 0 0)`, muted-blue accent `oklch(0.45 0.08 250)`, honest red destructive `oklch(0.55 0.20 25)`, warm-grey muted/secondary. **This is effectively a validated "modern/light" eidotter theme already.** Seed `theme.light`/`theme.business` from these role→value decisions, translated into eidotter semantic roles.
+
+### Recommendation: author themes in OKLCH
+uxdmncde proves the value — OKLCH is perceptually uniform, so you can hold chroma/hue and tune lightness to hit contrast targets predictably. Style Dictionary emits whatever the source says; we can store light-theme values as OKLCH and keep the amber/DOS themes in hex. Document the conversion in the map doc.
+
+### The brand decision the light theme forces — DECIDED: amber in daylight
+The light/"business" theme keeps **amber as the accent** ("amber phosphor in daylight"), not a professional blue (2026-06-16, Dom). Constraint: amber on a light surface is low-contrast and can read as "warning", so the light theme uses a **darkened amber** (`amber-dim`-family, e.g. `#9A5700` or darker) for the accent/text-on-light so it passes AA, and reserves bright `#FFB000` for fills/glows where a light foreground sits on it. Functional red/green stay honest (`cga-true.*`). Every role still gets a light value (Principle 3) and passes AA per theme (Principle 4).
+
+---
+
+## Semantic role vocabulary — DECIDED: UTI-tier canonical + shadcn alias shim
+
+(2026-06-16, Dom.) eidotter's web semantic layer standardizes on **Untitled UI's emphasis-tier model** as canonical, with a thin **shadcn-compatible alias layer** for consumer convenience.
+
+**Why tiers, not shadcn-as-canonical:** semantic layers are per-platform by design (web in `web.tokens.json`, Apple-HIG in the iOS/macOS DS Figma, Material later in its own). The emphasis-tier model (`primary/secondary/tertiary`) is the **cross-platform common denominator** — it maps ~1:1 onto Apple HIG (`label/secondaryLabel/tertiaryLabel/quaternaryLabel`, background tiers) and onto Material surface tiers. shadcn's model mixes in component-slot roles (`card`, `popover`, `sidebar`) that are web-only and don't generalize — fine as an alias, wrong as the canon. eidotter is also already authored against UTI (V.37), so this matches the component source.
+
+**Canonical roles (UTI v8 vocabulary):**
+
+| Group | Roles |
+|-------|-------|
+| `text` | `primary`, `secondary`, `tertiary`, `quaternary`, `disabled`, `placeholder`, `brand`, `error`, `warning`, `success` (+ `_hover`, `_on-brand` where needed) |
+| `bg` (surface) | `primary`, `secondary`, `tertiary`, `quaternary`, `active`, `disabled`, `overlay`, `brand`, `error/warning/success` |
+| `fg` (icons/graphics) | `primary`, `secondary`, `tertiary`, `quaternary`, `brand`, `error/warning/success` |
+| `border` | `primary`, `secondary`, `tertiary`, `disabled`, `brand`, `error` |
+| brand | the single brand hue = **amber** |
+| utility ramps | `gray`, `brand(amber)`, `error`, `warning`, `success` (25→950) for charts/badges |
+
+> Sourced from UTI v8's documented theme tokens. The UTI MCP exposes component installers, not the token list, so these names are from UTI's published `theme.css` vocabulary — confirm against the installed V.37 theme when wiring the actual tokens.
+
+**shadcn alias shim** (so rizomorf / uxdmncde / shadcn apps converge with minimal churn — both already use these names):
+
+| shadcn token | → eidotter canonical role |
+|--------------|---------------------------|
+| `--background` / `--foreground` | `bg-primary` / `text-primary` |
+| `--card` / `--card-foreground` | `bg-primary` (or `secondary`) / `text-primary` |
+| `--popover` / `--popover-foreground` | `bg-primary` / `text-primary` |
+| `--primary` / `--primary-foreground` | `bg-brand` (or `text-brand`) / `text-on-brand` |
+| `--secondary` / `--muted` | `bg-secondary` / `bg-secondary` + `text-tertiary` |
+| `--accent` | `bg-secondary` (or `bg-brand` subtle) |
+| `--destructive` | `error` (backed by `cga-true.red`) |
+| `--border` / `--input` / `--ring` | `border-primary` / `border-primary` / `border-brand` (focus) |
+
+This is the linchpin of the **rizomorf↔eidotter convergence**: rizomorf is a shadcn app, so the shim lets it consume eidotter tokens without rewriting every class, while the canonical tier layer keeps eidotter portable to iOS/Material. (Counter-pull noted: tiers are a touch more abstract than literal `card`/`popover`; the shim absorbs that for consumers.)
+
+---
+
+## Enforcement summary
+
+| Rule | Enforced by | Status |
+|------|-------------|--------|
+| Refs resolve to declared tokens | `scripts/lint-token-refs.mjs` (`lint-tokens`) | ✅ in CI |
+| No raw `cga-*`/hex in components | DMNC-1070 token-discipline lint (extends lint-token-refs) | ⏳ planned, gated on 1059 |
+| Roles pass AA per theme | `scripts/check-contrast.mjs`, run per theme | ⚠️ exists for default; per-theme run TODO |
+| No new axe violations | Storybook axe gate + `a11y-known-failures.json` | ✅ in CI |
+| Visual no-regression | Chromatic | ✅ in CI |
+| Reviewer checklist | PR template "Component compliance" | ✅ shipped (DMNC-1070 partial) |
+
+---
+
+## TL;DR for a contributor
+
+- Paint with `var(--color-semantic-*)` only.
+- Need a colour that has no role? Add a **role** (and define it in every theme) — pull the value from the primitive pool; don't paint the primitive directly.
+- Functional state? Use `cga-true.*`-backed status roles, not amber-mono.
+- Light mode is real: keep components on roles and it works. Mine uxdmncde's business palette; author in OKLCH; gate on per-theme contrast.

--- a/solutions/best-practices/token-architecture-map.md
+++ b/solutions/best-practices/token-architecture-map.md
@@ -1,0 +1,159 @@
+---
+title: Token architecture map — how a colour decision propagates from primitives to components and platforms
+date: 2026-06-16
+category: best-practices
+module: tokens
+problem_type: reference
+component: design-tokens
+severity: high
+applies_when:
+  - You are about to change a colour/token and need to know what it ripples to
+  - You are adding a theme (e.g. light mode) and need to know what "complete" means
+  - You are routing a component off raw primitives onto semantic roles (DMNC-1059)
+  - You need to understand how web and Apple platforms share T1 but diverge at the semantic layer
+  - You are reviewing a token PR and want the source-of-truth map
+tags: [tokens, design-system, style-dictionary, theming, figma, swift, semantic-tokens, dmnc-922, dmnc-916, dmnc-1059, light-mode]
+related:
+  - color-system-principles.md
+---
+
+# Token architecture map
+
+**Living document.** Update it whenever the layers, build outputs, or propagation paths change. It is the source of truth for *where a colour decision flows*. Pairs with [color-system-principles.md](./color-system-principles.md) (the rules).
+
+The taxonomy is the 4-tier model from DMNC-916. This doc focuses on **colour**, but the same layering applies to dimensions (T3) and effects (T4).
+
+---
+
+## The one-paragraph version
+
+A colour is defined once as a **primitive** (T1, the reference pool), given **meaning** once as a **semantic role** (T2), and **re-pointed per theme** (theme files). Style Dictionary compiles those into CSS custom properties (`:root` + `[data-theme=…]`), a Tailwind preset, Swift constants, and Figma DTCG exports. **Components paint only through semantic roles** — so flipping `data-theme` re-themes everything for free. Web and Apple platforms **share T1 primitives** but each owns its **own semantic layer** (web's in `web.tokens.json`, Apple's in the Figma DS files).
+
+---
+
+## The layers
+
+### T1 — primitives (the reference pool)
+`src/tokens/base.tokens.json`
+
+- `color.cga.*` — the 18-entry CGA-named palette. **In the default build these values are amber-monochromed** (`cga.green = #411F06`, a brown; `cga.brightRed = #DCA934`, a gold). The names preserve CGA semantics; the values are amber. **This is the pool — not everything here is "in service."**
+- `color.cga-true.*` — authentic CGA functional-status primitives (`green #00AA00`, `red #AA0000`, `cyan #00AAAA`). **Theme-invariant** (same hex in every theme), added by DMNC-1001 so apps can alias honest status colour. Exposed as `--color-cga-true-*` CSS vars + a Figma Foundation primitive; deliberately **not** a Tailwind utility.
+- `color.semantic.text.aiDraft` / `aiDraftGlow` — brand-locked hot-pink AI-provenance marker, promoted into T1 so every theme inherits it.
+
+> **Principle:** adding a primitive is cheap and reference-only. A primitive enters *service* only when a semantic role aliases it. Keep unused primitives as a pool; don't delete them. (See principles doc.)
+
+### T2 — semantic roles (the "meaning" layer)
+`src/tokens/web.tokens.json` → `color.semantic.*`
+
+Roles, each aliasing a T1 primitive by reference (e.g. `{color.cga.lightGray}`):
+
+| Group | Roles |
+|-------|-------|
+| `background` | `primary`, `secondary`, `accent` |
+| `text` | `primary`, `secondary`, `accent`, `disabled`, `muted` |
+| `border` | `default`, `focus`, `hover`, `disabled` |
+| `link` | `default`, `hover`, `active`, `visited` |
+| `status` | `success`, `warning`, `error`, `info` |
+| `alert` | `info`, `success`, `warning`, `error` (component backgrounds; literal hex) |
+
+**This is the only layer components should paint with.** It is also where the known gap lives today: there is no role resolving to true phosphor-amber `#FFB000`, and `status-*` resolve to amber-mono golds — the reason DMNC-1059 can't sweep yet and DMNC-922 exists.
+
+### T3 — dimensions, T4 — effects
+`dimensions.tokens.json`, `effects-params.tokens.json`, `motion.tokens.json`, plus `web.tokens.json` (spacing, radius, shadow/glow, duration, opacity, z-index, focusRing, effects.*). Out of scope for the colour rationalization but built by the same pipeline.
+
+### Themes (the divergence layer)
+`src/tokens/theme.<name>.tokens.json` — 5 today: `amber-mono`, `cga-amber`, `cga-mode4-p0`, `cga-mode4-p1`, `cga-mode5`.
+
+A theme file can do **two** things:
+1. **Re-define T1 values** — e.g. `theme.cga-amber` restores the *real* 16-colour CGA (`cga.green = #00AA00`).
+2. **Re-point T2 aliases** — e.g. `theme.cga-amber` sets `background.accent → {color.cga.blue}` instead of amber.
+
+Both are scoped under `[data-theme="<name>"], .theme-<name>` in the compiled CSS, so they override the `:root` defaults when the attribute is present.
+
+---
+
+## The build (Style Dictionary)
+`style-dictionary.config.mjs` → `npm run build-tokens`
+
+| Output | Path | Selector / form | Consumed by |
+|--------|------|-----------------|-------------|
+| `tokens.css` | `src/styles/` | `:root` | base/default theme — all web components |
+| `theme.<name>.css` | `src/styles/` | `[data-theme="<name>"]` | per-theme overrides |
+| `tokens.js` / `tokens.json` | `src/styles/` | JS/JSON | programmatic consumers |
+| `tailwind.preset.cjs` | repo root | `dos-*` utilities → `var(--color-semantic-*)` | Tailwind consumers |
+| `EiDotterTokens.swift` | `platforms/swiftui/…` | flat Swift constants (hex) | SwiftUI shared core |
+| `foundation.dtcg.json` | `dist/tokens/` | T1 + T3 + T4 | **Foundation Figma** import |
+| `web.dtcg.json` | `dist/tokens/` | T2 web | **Web DS Figma** import |
+
+Generated files are **never hand-edited**; CI (`build.yml`) rebuilds and fails on drift. Edit the JSON sources. The token-ref lint (`scripts/lint-token-refs.mjs`, `npm run lint-tokens`) fails on any `var(--*)` / `dos-*` reference that doesn't resolve to a declared token.
+
+---
+
+## Propagation diagram
+
+```
+T1 PRIMITIVES — reference pool (base.tokens.json)
+   color.cga.*  (amber-mono)   color.cga-true.* (honest, theme-invariant)
+        │  aliased by reference {color.cga.X}
+        ▼
+T2 SEMANTIC ROLES (web.tokens.json)  ── the ONLY layer components paint with
+   color.semantic.{background,text,border,link,status,alert}
+        │                         ▲
+        │                         │ themes re-define T1 values AND/OR re-point T2 aliases
+        │            src/tokens/theme.*.tokens.json
+        ▼
+STYLE DICTIONARY (style-dictionary.config.mjs)
+   ├─ tokens.css (:root) ─ theme.*.css ([data-theme]) ─ tailwind.preset.cjs (dos-*)
+   │        └─────────────── web React components ──────────────┘
+   │                 (rizomorf, dmnc.tech, eidotter-home, …)
+   ├─ EiDotterTokens.swift  (shared-core primitives)
+   └─ foundation.dtcg.json ──► Foundation Figma (KoGTFX8)
+              │                       │ subscribed-to library
+              │        ┌──────────────┼─────────────────┐
+              │   Web DS Fig     iOS DS Fig         macOS DS Fig
+              │   (T2 web)       (Apple-HIG T2)     (Apple-HIG T2)
+       web.dtcg.json                 │                  │
+                              sync-figma-to-swift.ts (reads Figma snapshots)
+                                      │                  │
+                              AppleIOS.swift      AppleMacOS.swift  ──► SwiftUI apps
+```
+
+**The critical asymmetry:** web and Apple **share T1 primitives** (via Foundation) but **each owns its semantic layer**. Web's T2 is `web.tokens.json` (compiled to CSS). Apple's T2 lives *inside the iOS/macOS Figma DS files* in Apple-HIG vocabulary (Labels / Backgrounds / Fills / Accents), aliased to Foundation, and reverse-synced to Swift by `scripts/sync-figma-to-swift.ts`. A foundation change ripples to both; meaning is decided per platform.
+
+---
+
+## Worked example — "the destructive button should be red"
+
+1. **Primitive:** honest red already exists — `color.cga-true.red = #AA0000` (theme-invariant). No new primitive needed.
+2. **Semantic:** today `status.error → {color.cga.brightRed}` = amber-mono gold. The fix is to point a (new or existing) error role at `{color.cga-true.red}` so it's honestly red. *This is a 922 decision — see principles.*
+3. **Component:** `Button.css .eidotter-btn--destructive` should paint `var(--color-semantic-status-error)` (or a dedicated destructive role), **not** `var(--color-cga-red)`. *This is the 1059 sweep.*
+4. **Theme:** every theme must define that error role (completeness). A light theme points it at a red that passes AA on the light background.
+5. **Apple:** the iOS/macOS DS error/destructive role aliases Foundation `cga-true/red`; `sync-figma-to-swift` regenerates the Swift constant.
+
+That single decision touches T1 (already done), T2 (922), the component (1059), every theme, and the Apple chain — which is exactly why the map exists.
+
+---
+
+## Per-role resolution table (default vs cga-amber theme)
+
+Illustrates how the *same role* diverges by theme (values abbreviated). Keep this current as roles change.
+
+| Role | `:root` (base, amber-mono) | `[data-theme="cga-amber"]` |
+|------|----------------------------|----------------------------|
+| `background.primary` | `cga.black` `#020003` | `cga.black` `#050300` |
+| `background.accent` | `cga.amber` `#FFB000` | `cga.blue` `#0000AA` |
+| `text.primary` | `cga.lightGray` `#B87C1A` | `cga.lightGray` `#ADAAA5` |
+| `text.accent` | `cga.yellow` `#E5B936` | `cga.amber` `#FFB000` |
+| `status.error` | `cga.brightRed` `#DCA934` (gold) | `cga.brightRed` `#FF5555` (red) |
+| `status.success` | `cga.brightGreen` `#CB9529` (gold) | `cga.brightGreen` `#55FF55` (green) |
+
+Note the base theme's `status.*` are amber-mono — honest status needs `cga-true.*` (922).
+
+---
+
+## Gaps this map makes visible (tracked work)
+
+- **No honest amber role** and amber-mono `status.*` in the base semantic layer → **DMNC-922** (rationalize the semantic layer; keep primitives as a pool).
+- **Components paint raw primitives** instead of roles → **DMNC-1059** (sweep).
+- **No enforcement** that components stay on roles → **DMNC-1070** (token-discipline lint).
+- **No light theme** yet, and the semantic layer isn't complete enough to make one reliable → unblocked by 922 + 1059; see the light-mode section of the principles doc.


### PR DESCRIPTION
Foundation docs for **DMNC-922** — written before touching a single token, so the rationalization edits against an agreed source of truth.

## Two living reference docs (`solutions/best-practices/`)

**`token-architecture-map.md`** — the propagation map: T1 primitives (the reference pool, incl. `cga-true.*` honest status) → T2 semantic roles → themes → Style Dictionary outputs (`tokens.css`/`theme.*.css`/`tailwind.preset`/Swift/Figma DTCG) → web components, plus the *separate* Apple Foundation-Figma → iOS/macOS DS → `sync-figma-to-swift` → Swift path. Worked examples ("the destructive button should be red") and the gap list (922/1059/1070).

**`color-system-principles.md`** — the rules the colour system is held to, the amber "why", and **light mode as a first-class goal**. Captures the decisions locked with Dom:
- **Amber in daylight** — the light theme keeps amber as accent (darkened to pass AA on light; bright `#FFB000` reserved for fills/glow).
- **UTI-tier canonical + shadcn-alias shim** — emphasis-tier roles (`text/bg/border` primary/secondary/tertiary + functional + brand) as canonical because they're the cross-platform common denominator (≈ Apple HIG, ≈ Material surface tiers; eidotter already authors against UTI), with a thin shadcn alias so shadcn consumers (rizomorf, uxdmncde) converge.
- **Primitives are a pool** — keep the full `cga.*` set for reference; only roles that are *in service* matter.

## Why now
These unblock the 922 web slice, `theme.light`, and the **rizomorf↔eidotter token convergence** (rizomorf currently runs a parallel shadcn token system that re-derives amber; the shim lets it consume eidotter instead).

Docs only — no code/token/CHANGELOG impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)