### PR TITLE
docs: consumer-facing principles + refresh llms.txt for the new colour system

### DIFF
--- a/guidelines/design-principles.md
+++ b/guidelines/design-principles.md
@@ -44,6 +44,14 @@ eidotter's distinctive DOS aesthetic — principles for *this theme*:
 
 A Modern/clean theme alongside DOS, so every app can look modern instead of the DOS interface. It keeps **all of Part 1 and Part 2** — but defines its **own visual language**: its own broader palette, likely light/dark, contemporary type and spacing, restrained-but-not-DOS. The discipline is identical (semantic tokens, never hex; a11y as a gate; keyboard-first); only the values and look differ. Products choose a theme; the interaction quality is constant.
 
+## Part 4 — Adoption posture (the DS is the default, not a cage)
+
+Portfolio apps and sites **default to eidotter** — its principles, components, infrastructure, and guidance are the starting point, not an optional add-on.
+
+- **Amber (DOS) is the standard default theme; the light theme is offered alongside it.** Every product ships amber-by-default and exposes a **light-theme toggle in a consistent place** (e.g. a settings option) — the switch behaves the same way across surfaces, not reinvented per app.
+- **Exceptions are allowed when explicitly chosen.** Creative freedom is preserved — a product may deviate from the DS where there's a deliberate reason. But deviation is the conscious exception, not the default: reach for the DS first.
+- **DS changes reach products through a gate.** When a DS update changes how a consumer looks, the update is **previewed (before/after) with its reasoning** (which principle or changelog entry drove it) and **approved before it lands**. The design system explains itself; it does not silently mutate products.
+
 ---
 
 _Implementation rules (token pipeline, CI, file structure, BEM-for-phosphor, per-component specs) are eidotter mechanics — see `CLAUDE.md` and `solutions/`. They serve these principles; they are not themselves design principles._

--- a/llms.txt
+++ b/llms.txt
@@ -4,16 +4,19 @@
 
 ## Quick Facts
 - 41 components (Accordion, AIText, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Lightbox, Modal, Nav, Notification, Progress, RetroEffects, Separator, Skeleton, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens)
-- Dark theme only (amber-on-black phosphor CRT aesthetic)
+- Amber theme is the default (amber-on-black phosphor CRT); a light theme ("amber in daylight") is in progress (DMNC-1058). Components paint via semantic roles so they re-theme — do not hardcode dark-only assumptions.
 - CSS custom properties + Tailwind preset
 - React 18/19, Tailwind 3/4 compatible
-- Published on npm: `npm install eidotter` (current v0.24.x)
+- Published on npm: `npm install eidotter` (current v0.30.x)
 - Consumer imports: `eidotter/styles` (required); `eidotter/themes/<name>.css` (optional theme); `eidotter/utilities` (optional `.dos-*` classes for raw HTML/MDX/prose; 12 classes; v0.19.4+)
 
 ## Key Principle
-NEVER hardcode colors. Always use:
-- CSS: `var(--color-semantic-*)` or `var(--color-cga-*)`
-- Tailwind: `text-cga-amber`, `bg-dos-bg-primary`, etc.
+NEVER hardcode colors. Paint via SEMANTIC ROLES (not raw primitives) so components re-theme:
+- CSS: `var(--color-semantic-*)` (prefer over raw `var(--color-cga-*)`)
+- Tailwind: `text-dos-text-brand` (amber), `bg-dos-bg-primary`, etc. — prefer semantic `dos-*` utilities over raw `cga-*`
+
+## Theme defaults (adoption posture)
+Apps default to the amber theme and offer the light theme via a consistent settings toggle (e.g. in settings). The DS is the default starting point; deviate only by deliberate exception. DS changes reach products through a preview + approval gate (before/after + the principle that drove each change). See `guidelines/design-principles.md` Part 4.
 
 ## Files for AI Agents
 - CLAUDE.md: Coding instructions, component patterns, and token reference
@@ -38,9 +41,11 @@ NEVER hardcode colors. Always use:
 
 ### Text
 - `--color-semantic-text-primary` → `text-dos-text-primary` (body text, #b87c1a)
+- `--color-semantic-text-brand` → `text-dos-text-brand` (phosphor amber #ffb000 — the honest amber text role; PREFER over raw `text-cga-amber`)
 - `--color-semantic-text-accent` → `text-dos-text-accent` (highlights, #e5b936)
-- `--color-semantic-text-muted` → `text-dos-text-muted` (captions, timestamps, counts — per-theme hex; v0.19.4+)
-- `--color-cga-amber` → `text-cga-amber` (brightest amber, #ffb000)
+- `--color-semantic-text-muted` / `--color-semantic-text-tertiary` → `text-dos-text-muted` / `text-dos-text-tertiary` (supplementary text)
+- Functional (honest, theme-invariant): `text-dos-text-success` (#00AA00), `text-dos-text-error` (#FF5555, readable on dark), `text-dos-text-info` (#00AAAA), `text-dos-text-white` (#FFFFFF, light foreground on functional fills)
+- Functional FILLS: `bg-dos-bg-error` (#AA0000 solid red, e.g. destructive button) with `text-dos-text-white`
 
 ### Borders
 - `--color-semantic-border-default` → `border-dos-border-default` (#b87c1a)
@@ -124,12 +129,11 @@ Components originate from different projects. Use `getComponentsByOrigin(project
 | ChatContainer | eidotter | (none yet) |
 
 ## Anti-Patterns (NEVER DO)
-- NEVER hardcode hex colors: `color: #FFB000`
-- NEVER use `prefers-color-scheme` (eidotter is dark-only)
+- NEVER hardcode hex colors: `color: #FFB000` — use semantic roles so components re-theme
+- NEVER bake in a dark-only assumption — a light theme is coming; paint via `--color-semantic-*` roles, not raw dark primitives. Switch themes via `data-theme="<name>"` / the theme toggle, not `prefers-color-scheme`.
 - NEVER edit tokens.css directly (edit JSON, rebuild)
 - NEVER use rounded corners > 4px (DOS aesthetic)
-- NEVER use light backgrounds
-- NEVER use sans-serif fonts
+- NEVER use sans-serif fonts (DOS theme)
 
 ## Integration Quick Start
 ```css

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "src/styles/tokens.css",
     "src/styles/theme.*.css",
     "src/styles/dos-utilities.css",
-    "guidelines"
+    "guidelines",
+    "llms.txt"
   ],
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes the gap surfaced while reviewing doc reach: the new `solutions/best-practices/*` principle docs **don't ship to npm** (`files` ships `guidelines/` + now `llms.txt`, not `solutions/`). So consumer-relevant principles + the AI on-ramp need to live where consumers actually get them.

## Changes
- **`guidelines/design-principles.md`** (ships to npm) — new **Part 4 — Adoption posture**: apps default to the amber theme + offer the light theme via a **consistent settings toggle**; the DS is the **default, not a cage** (exceptions by deliberate choice); DS changes reach products through a **preview + approval gate**.
- **`llms.txt`** — was stale ("dark theme only", v0.24.x, raw `cga-amber`, "never light backgrounds"). Now: amber-default + light-theme-coming, the new semantic roles (`text.brand`, functional `text/bg.error/success/info`, `text.white`), the adoption posture + gate, prefer-semantic guidance, and corrected anti-patterns.
- **`package.json`** — add `llms.txt` to `files` so AI consumers get it from the package.

Pairs with the `eidotter-adoption` skill gaining an `/eidotter update` command that enforces the change-preview gate (lives in dotfiles).

Docs/config only — no code, no token changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)