### PR TITLE
fix(TimelineNode): pin marker box-sizing to content-box so dots stay on the axis (DMNC-1090)

### DIFF
--- a/src/components/TimelineNode/components/TimelineNode.css
+++ b/src/components/TimelineNode/components/TimelineNode.css
@@ -3,6 +3,13 @@
 /* Marker base styles */
 .eidotter-timeline-node__marker {
   display: block;
+  /* Pin content-box: the axis geometry (TimelineAxis line centre = 8px,
+     views.css node margin-left = -24px) assumes the medium marker renders at
+     12px content + 4px border = 16px (centre 8px). A consumer global reset
+     (e.g. Tailwind preflight, used by eidotter.com) sets border-box, which
+     would shrink the rendered marker to 12px (centre 6px) and pull the dot
+     2px off the line. Pinning content-box makes the geometry reset-proof. */
+  box-sizing: content-box;
   background: var(--color-semantic-background-brand-dim);
   border: 2px solid var(--color-semantic-border-brand-dim);
   transition: all 0.15s ease;


### PR DESCRIPTION
## Problem
Reported on eidotter.com: the dots on the timeline's vertical axis aren't centered on the line — they sit ~2px to the left. Looks unprofessional.

## Root cause (empirically measured)
`.eidotter-timeline-node__marker` sets `width`/`height` + a 2px border but never pins `box-sizing`. The axis geometry assumes **content-box**:
- `TimelineAxis.css` line at `left:7px` → centre **8px**
- `views.css` node `margin-left:-24px` pulls the marker's left edge to the axis column origin
- medium marker = 12px content + 4px border = **16px rendered → centre 8px** ✅

A consumer global reset that sets `box-sizing: border-box` (**Tailwind preflight**, which eidotter.com uses) makes the 12px marker render at 12px → centre **6px** → **−2px** off the 8px line.

## Probe (Playwright, border-box context, real geometry)
| | rendered | centre | offset from line |
|---|---|---|---|
| before (border-box) | 12px | 36px | **−2px** |
| after (`content-box`) | 16px | 38px | **0px** ✅ |

## Fix
One line: `box-sizing: content-box` on the marker, so the rendered geometry the axis math relies on is deterministic regardless of the consumer's box-sizing reset.

- **No-op** in eidotter's own (content-box) Storybook.
- Corrects the regression for border-box consumers (eidotter.com adopts on upgrade).
- Timeline suites **166/166** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)