### PR TITLE
fix(styles): bundle the default amber-mono theme into eidotter/styles (DMNC-1079)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,12 @@
 
 import './styles/fonts.css';
 import './styles/tokens.css';
+// Default theme (amber-mono) ships in the main bundle so `data-theme="amber-mono"`
+// works out of the box (DMNC-1079). The override rules are `[data-theme]`-scoped
+// and inert until the attribute is set, so this is non-breaking for consumers
+// that don't theme. Other themes (cga-amber, modes, future light) stay as opt-in
+// `eidotter/themes/*.css` subpath imports.
+import './styles/theme.amber-mono.css';
 import './styles/tailwind.css';
 import './styles/provenance.css';
 

--- a/src/styles/dist-bundle.test.ts
+++ b/src/styles/dist-bundle.test.ts
@@ -67,6 +67,14 @@ describeIfBuilt('dist/eidotter.css — built-bundle contract', () => {
   it('ships the --color-semantic-text-ai-draft-glow custom property (token retained)', () => {
     expect(css).toMatch(/--color-semantic-text-ai-draft-glow:\s*(rgba\(|#ff1a8c80)/i);
   });
+
+  it('bundles the default amber-mono theme so `data-theme="amber-mono"` works OOTB (DMNC-1079)', () => {
+    // Theme overrides used to ship only as separate `eidotter/themes/*.css`
+    // subpath exports, so consumers importing `eidotter/styles` got `:root`
+    // only and could not theme-switch. The default theme is now bundled.
+    // Minifier may strip the attribute-value quotes (`=amber-mono`).
+    expect(css).toMatch(/\[data-theme=["']?amber-mono["']?\]/);
+  });
 });
 
 if (!hasBuild) {


### PR DESCRIPTION
## Problem (found while prototyping the rizomorf theme bridge)
eidotter's theme override CSS (`theme.*.css`) shipped **only** as separate subpath exports (`eidotter/themes/amber-mono.css`), never in the main `eidotter/styles` bundle. A consumer importing `eidotter/styles` + `eidotter/tokens.css` got the `:root` baseline and **no theme overrides** — so eidotter was effectively un-themeable out of the box, and setting `data-theme` did nothing. This blocked consumer theming (DMNC-1079) and would block DMNC-1058 adoption.

## Fix
Bundle the **default** theme (amber-mono) into the main stylesheet via `src/index.ts`. The override rules are `[data-theme="amber-mono"]`-scoped, so they're **inert until the attribute is set** → non-breaking for consumers that don't theme.

- Other themes (cga-amber, the CGA modes, and the future light/Modern theme) stay as opt-in `eidotter/themes/*.css` subpath imports.
- `dist-bundle.test.ts` gains a contract assertion that the built `dist/eidotter.css` ships the `[data-theme="amber-mono"]` block (verified locally — 9/9).

## Why this matters
This is the packaging prerequisite for consumers (rizomorf, eidotter.com) to actually switch eidotter themes from a single toggle. After this ships, a consumer's `data-theme="amber-mono"` activates the amber-mono semantic-role overrides with no extra import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)