### PR TITLE
chore(release): 0.33.0 — light theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-06-17
+
+### Added
+- **Light theme (`eidotter/themes/light.css`, DMNC-1058 — palette slice).** A clean light palette for the existing semantic roles: warm-white surfaces, warm near-black text, amber brand kept (fills `#FFB000` with dark on-brand text; brand/accent **text** darkens to `#9A5700` for AA on white), honest functional hues darkened for AA (green `#007A00`, red `#AA0000`, info `#006688`). Palette-only — contemporary typography/corners/font are the broader Modern-theme follow-up. The shim (`eidotter/shadcn.css`) now emits a `[data-theme="light"]` block, so shadcn consumers get a real light mode. `aiDraft` stays brand-locked pink in light too.
+
 ## [0.32.0] - 2026-06-17
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,7 +289,7 @@ eiDotter uses Untitled UI as a **pattern reference**, not a dependency. **No UTI
 - **Figma:** UTI Figma library is set up with eiDotter's DOS tokens. eiDotter's Figma file is the source of truth for component design.
 - **License rationale:** eidotter is published under CC-BY-NC-4.0. UTI Pro is a paid commercial license that does not permit sublicensing/redistribution. Bundling UTI Pro assets into `dist/eidotter.css` / `dist/index.es.js` would have been a license violation. Pixelarticons (MIT) avoids this entirely.
 
-## Current Component Status (v0.32.x, June 2026)
+## Current Component Status (v0.33.x, June 2026)
 
 **Components** (41): Accordion, AIText, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Lightbox, Modal, Nav, Notification, Progress, RetroEffects, Separator, Skeleton, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",


### PR DESCRIPTION
Ships the light theme palette slice (DMNC-1058): `eidotter/themes/light.css` + a `[data-theme=light]` block in the shadcn shim. After merge: tag v0.33.0 → GitHub Release → OIDC publish. Then rizomorf full convergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)