### PR TITLE
fix(badge): info variant uses honest text-info, not status-info (DMNC-1111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Badge `info` variant uses the honest `text-info` role, not `status-info` (DMNC-1111).** `info`'s colour/border/dot wired to `--color-semantic-status-info` (the status ramp), so it could never render honest cyan under colour themes / the honest `:root` baseline — inconsistent with `success`/`error`, which use the `text-*`/`border-*` roles. Now consumes `--color-semantic-text-info` (honest CGA cyan `#00AAAA` at `:root`); a new `text-info` amber-mono override → `lightGray` (`#B87C1A`) keeps amber-mono a visual no-op (info stays tan-amber there). Surfaced by steuerdash (the honest-functional-colour consumer). `warning` still uses `status-warning` by design.
+
 ## [0.33.0] - 2026-06-17
 
 ### Added

--- a/src/components/Badge/components/Badge.css
+++ b/src/components/Badge/components/Badge.css
@@ -32,8 +32,8 @@
 }
 .eidotter-badge--info {
   background-color: transparent;
-  color: var(--color-semantic-status-info);
-  border: 1px solid var(--color-semantic-status-info);
+  color: var(--color-semantic-text-info);
+  border: 1px solid var(--color-semantic-text-info);
 }
 .eidotter-badge--accent {
   background-color: var(--color-semantic-background-accent);
@@ -49,7 +49,7 @@
 .eidotter-badge--success .eidotter-badge__dot { background-color: var(--color-semantic-border-success); }
 .eidotter-badge--warning .eidotter-badge__dot { background-color: var(--color-semantic-status-warning); }
 .eidotter-badge--error .eidotter-badge__dot { background-color: var(--color-semantic-border-error); }
-.eidotter-badge--info .eidotter-badge__dot { background-color: var(--color-semantic-status-info); }
+.eidotter-badge--info .eidotter-badge__dot { background-color: var(--color-semantic-text-info); }
 .eidotter-badge--accent .eidotter-badge__dot { background-color: var(--color-semantic-text-secondary); }
 
 /* Content optical alignment */

--- a/src/components/Badge/components/BadgeDocs.mdx
+++ b/src/components/Badge/components/BadgeDocs.mdx
@@ -106,7 +106,7 @@ Badges work well for priority levels, source labels, scope tags, and status indi
 | `--color-semantic-text-success` / `--color-semantic-border-success` | Success variant text, border, and dot (amber under the default amber-mono theme; honest green under colour themes) |
 | `--color-semantic-status-warning` | Warning variant text, border, and dot (yellow-gold under amber-mono; bright yellow under colour themes) |
 | `--color-semantic-text-error` / `--color-semantic-border-error` | Error variant text, border, and dot (amber under amber-mono; honest red under colour themes) |
-| `--color-semantic-status-info` | Info variant text, border, and dot (muted amber under amber-mono; honest cyan under colour themes) |
+| `--color-semantic-text-info` | Info variant text, border, and dot (warm tan-amber `#B87C1A` under amber-mono; honest cyan `#00AAAA` under colour themes / the honest `:root` baseline) |
 | `--color-semantic-background-accent` | Accent variant background |
 | `--color-semantic-text-secondary` | Accent variant text and dot |
 | `--typography-font-family-primary` | DOS font family |

--- a/src/styles/theme.amber-mono.css
+++ b/src/styles/theme.amber-mono.css
@@ -47,6 +47,7 @@
   --color-semantic-text-muted: var(--color-cga-light-gray);
   --color-semantic-text-success: var(--color-cga-amber-bright); /** DMNC-1059: amber-mono default — success text is amber (mirrors status.success), not honest green. Honest green resolves only under colour themes. */
   --color-semantic-text-error: var(--color-cga-amber); /** DMNC-1059: amber-mono default — error text is amber (mirrors status.error), not honest red. */
+  --color-semantic-text-info: var(--color-cga-light-gray); /** DMNC-1111: amber-mono default — info text is the warm tan-amber lightGray (#B87C1A, ~5.9:1 AA-safe), matching the old status.info amber-mono look. Honest cyan (text.info → cga.true.cyan #00AAAA) resolves only under colour themes / the honest :root baseline. Badge `info` now wires to text.info (was status.info) so honest themes get true cyan. */
   --color-semantic-background-primary: var(--color-cga-black);
   --color-semantic-background-secondary: var(--color-cga-dark-gray);
   --color-semantic-background-accent: var(--color-cga-amber);

--- a/src/tokens/theme.amber-mono.tokens.json
+++ b/src/tokens/theme.amber-mono.tokens.json
@@ -17,7 +17,8 @@
         "disabled":  { "$value": "{color.cga.amberDim}" },
         "muted":     { "$value": "{color.cga.lightGray}" },
         "success":   { "$value": "{color.cga.amberBright}", "$description": "DMNC-1059: amber-mono default — success text is amber (mirrors status.success), not honest green. Honest green resolves only under colour themes." },
-        "error":     { "$value": "{color.cga.amber}", "$description": "DMNC-1059: amber-mono default — error text is amber (mirrors status.error), not honest red." }
+        "error":     { "$value": "{color.cga.amber}", "$description": "DMNC-1059: amber-mono default — error text is amber (mirrors status.error), not honest red." },
+        "info":      { "$value": "{color.cga.lightGray}", "$description": "DMNC-1111: amber-mono default — info text is the warm tan-amber lightGray (#B87C1A, ~5.9:1 AA-safe), matching the old status.info amber-mono look. Honest cyan (text.info → cga.true.cyan #00AAAA) resolves only under colour themes / the honest :root baseline. Badge `info` now wires to text.info (was status.info) so honest themes get true cyan." }
       },
       "border": {
         "default":  { "$value": "{color.cga.amber}" },


### PR DESCRIPTION
Closes DMNC-1111.

## Problem
`Badge variant="info"` wired its colour/border/dot to `--color-semantic-status-info` (the status ramp), so it could never render honest cyan under colour themes or the honest `:root` baseline — inconsistent with `success`/`error`, which already use the honest `text-*`/`border-*` roles. Surfaced during the steuerdash adoption (the honest-functional-colour consumer): its `info` badges rendered amber-family instead of cyan.

## Fix
- **`Badge.css`** — `info` colour, border, and dot now consume `--color-semantic-text-info` (honest CGA cyan `#00AAAA` at `:root`) instead of `status-info`.
- **`theme.amber-mono.tokens.json`** — add a `text.info` override → `lightGray` (`#B87C1A`, ~5.9:1 AA-safe), matching the previous amber-mono info appearance. So amber-mono stays a **visual no-op** (info = tan-amber under amber-mono; honest cyan only under colour themes / the honest baseline).

## Why it's safe
- `text-info` had **no other consumers**; `status-info` was **Badge-only** → no collateral.
- Generated-file diff is tight: only `theme.amber-mono.css` changed (`tokens.css` already defined `text-info` from DMNC-922).

## Verification
- `npm run lint-tokens` — clean (no unresolved refs).
- Badge + tokens + tailwind-preset suites — **142 passed**.
- Resolved values confirmed: `:root` `text-info → cga-true-cyan (#00AAAA)`; amber-mono `text-info → cga-light-gray (#B87C1A)`.

## Scope note
`warning` still uses `status-warning` (yellow). Switching it to `text-warning` would change its hue (amber) — a separate design call, intentionally left as-is here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)