### PR TITLE
feat(button): stable eidotter-btn base class + override-hook docs (DMNC-1112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`<Button>` now emits a stable `eidotter-btn` base class (DMNC-1112).** Post-V.37 the Button rendered only `eidotter-btn--{variant}` modifier classes (no block class), so consumer CSS targeting `.eidotter-button` — or even `.eidotter-btn` — silently no-op'd. It now carries the variant-agnostic `eidotter-btn` block class (matching `<Badge>`'s `eidotter-badge` and `<Tag>`'s `eidotter-tag`), giving consumers a reliable override hook. Additive and a visual no-op — eidotter ships no bare `.eidotter-btn` rule. Note: `.eidotter-button` was never a real class and remains unsupported; target `.eidotter-btn` (or the element / a specific `eidotter-btn--*` variant).
+
 ## [0.33.0] - 2026-06-17
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ export const Button: React.FC<ButtonProps> = ({ variant = 'primary', size = 'md'
 - `cn()` from `src/utils/cn.ts` merges Tailwind classes with conflict resolution
 - CSS file contains only phosphor glow effects (box-shadow, keyframes) that Tailwind can't express
 - Variant CSS classes prefixed `eidotter-[component]--*` to avoid consumer collisions
+- Each component also emits a stable `eidotter-[component]` **block** class (e.g. `eidotter-btn`, `eidotter-badge`, `eidotter-tag`) as a variant-agnostic consumer hook. **Consumer override gotcha (DMNC-1112):** target the block class `.eidotter-btn` (or the element / a specific `eidotter-btn--*` variant) — **`.eidotter-button` is not a real class** and never was; CSS written against it silently no-ops.
 - Backward-compatible prop aliases (small→sm, medium→md, large→lg)
 
 ### Legacy pattern: BEM CSS (Terminal, CommandPrompt only)

--- a/src/components/Button/components/Button.test.tsx
+++ b/src/components/Button/components/Button.test.tsx
@@ -11,6 +11,13 @@ describe('Button', () => {
     expect(button).toHaveAttribute('type', 'button');
   });
 
+  it('emits the stable eidotter-btn base class regardless of variant (DMNC-1112)', () => {
+    const { rerender } = render(<Button variant="primary">Primary</Button>);
+    expect(screen.getByRole('button')).toHaveClass('eidotter-btn');
+    rerender(<Button variant="destructive">Destructive</Button>);
+    expect(screen.getByRole('button')).toHaveClass('eidotter-btn');
+  });
+
   it('renders with different variants', () => {
     const { rerender } = render(<Button variant="primary">Primary</Button>);
     expect(screen.getByRole('button')).toHaveClass('eidotter-btn--primary');

--- a/src/components/Button/components/Button.tsx
+++ b/src/components/Button/components/Button.tsx
@@ -80,6 +80,12 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(({
         }
       }}
       className={cn(
+        // Stable BEM block hook (DMNC-1112): variant-agnostic class consumers
+        // can target reliably. Post-V.37 the Button only emitted
+        // `eidotter-btn--{variant}` modifiers, so consumer overrides written
+        // against `.eidotter-button` / `.eidotter-btn` silently no-op'd. Matches
+        // Badge (`eidotter-badge`) / Tag (`eidotter-tag`) which already emit a block class.
+        'eidotter-btn',
         'inline-flex items-center justify-center relative',
         'border-2 border-solid',
         'font-dos leading-none whitespace-nowrap select-none',


### PR DESCRIPTION
Closes DMNC-1112.

## Problem
Consumer CSS targeting `.eidotter-button` is a **silent no-op** — that class never existed. Post-V.37 the `<Button>` rendered only `eidotter-btn--{variant}` modifier classes with no block class, so even `.eidotter-btn` matched nothing. There's no build signal; the rule just quietly fails. Button was the outlier — `<Badge>` already emits `eidotter-badge`, `<Tag>` emits `eidotter-tag`. Surfaced during the DMNC-1094 wave (spacewar landing had two dead `.eidotter-button` rules).

## Fix
- **`Button.tsx`** — add the variant-agnostic **`eidotter-btn`** block class to the root. Closes the BEM block/element/modifier gap and gives consumers a reliable override hook.
- **`Button.test.tsx`** — assert the base class is present across variants (contract guard).
- **`CLAUDE.md` (V.37 pattern) + `CHANGELOG`** — document the stable block class and the dead-`.eidotter-button` gotcha (target `.eidotter-btn`, the element, or a specific variant).
- The **eidotter-adoption skill** gets the same anti-pattern note (lives in a separate dotfiles repo; updated there).

## Why it's safe
- **Additive + visual no-op:** eidotter ships no bare `.eidotter-btn` rule, so nothing new activates (Chromatic should confirm).
- Existing tests assert modifier classes via `toHaveClass` (additive-safe); no exact-className/snapshot assertions exist on Button.

## Verification
- Button suite — **25 passed** (incl. the new base-class test).
- `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)