### PR TITLE
chore(release): 0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-06-18
+
 ### Added
 - **`<TimelineContainer mode="master-detail">` — level-3 split view (DMNC-878).** Completes the timeline's three-level expansion model (hover → card-expand → full content). A new layout mode where the timeline collapses to a navigable rail and the selected entry fills a detail pane (Apple-Mail-style split); switching entries swaps the pane without losing rail position. The open entry is the existing controlled `selectedEntryId`/`onSelectEntry`, so it is **deep-linkable** (wire it to your router). Rail uses navigation semantics (`aria-current`); arrow keys walk entries, Escape/BACK returns to the rail, focus moves into the pane on open and back on close (no focus trap). Responsive via container queries — side-by-side ≥480px, full-screen detail + BACK button below. Compositor-only cross-fade (reduced-motion + high-contrast safe). Detail body reuses `TimelineEntryCard`/`renderEntry`, so custom renderers work in the pane.
 - **`<Button>` now emits a stable `eidotter-btn` base class (DMNC-1112).** Post-V.37 the Button rendered only `eidotter-btn--{variant}` modifier classes (no block class), so consumer CSS targeting `.eidotter-button` — or even `.eidotter-btn` — silently no-op'd. It now carries the variant-agnostic `eidotter-btn` block class (matching `<Badge>`'s `eidotter-badge` and `<Tag>`'s `eidotter-tag`), giving consumers a reliable override hook. Additive and a visual no-op — eidotter ships no bare `.eidotter-btn` rule. Note: `.eidotter-button` was never a real class and remains unsupported; target `.eidotter-btn` (or the element / a specific `eidotter-btn--*` variant).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,7 +290,7 @@ eiDotter uses Untitled UI as a **pattern reference**, not a dependency. **No UTI
 - **Figma:** UTI Figma library is set up with eiDotter's DOS tokens. eiDotter's Figma file is the source of truth for component design.
 - **License rationale:** eidotter is published under CC-BY-NC-4.0. UTI Pro is a paid commercial license that does not permit sublicensing/redistribution. Bundling UTI Pro assets into `dist/eidotter.css` / `dist/index.es.js` would have been a license violation. Pixelarticons (MIT) avoids this entirely.
 
-## Current Component Status (v0.33.x, June 2026)
+## Current Component Status (v0.34.x, June 2026)
 
 **Components** (41): Accordion, AIText, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Lightbox, Modal, Nav, Notification, Progress, RetroEffects, Separator, Skeleton, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eidotter",
-  "version": "0.29.0",
+  "version": "0.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eidotter",
-      "version": "0.29.0",
+      "version": "0.34.0",
       "license": "CC-BY-NC-4.0",
       "dependencies": {
         "pixelarticons": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",


### PR DESCRIPTION
Version bump + changelog finalization for the **0.34.0** release. No code changes — just `package.json`/lockfile version, the `[Unreleased]` → `[0.34.0]` changelog rollup, and the CLAUDE.md status header.

## Ships
- **feat(timeline): master-detail (level-3) layout mode** — DMNC-878 (#417)
- **feat(button): stable `eidotter-btn` base class** — DMNC-1112 (#416)
- **fix(badge): `info` variant uses honest `text-info`, not `status-info`** — DMNC-1111 (#415)

## How to publish (after merge)
Cut a **GitHub Release `v0.34.0`** on `main` → the OIDC `publish.yml` workflow publishes to npm (trusted publishing; no token/2FA). 

Once it's live on npm I'll bump the consumers — first **eidotter.com** (`eidotter-home`) to adopt `mode="master-detail"`, behind the consumer-update gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)