### PR TITLE
fix(timeline): master-detail rail flows instead of inner-scrolling

### DIFF
--- a/src/components/TimelineContainer/components/MasterDetailLayout.css
+++ b/src/components/TimelineContainer/components/MasterDetailLayout.css
@@ -23,8 +23,10 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-1);
-  max-height: 70vh;
-  overflow-y: auto;
+  /* No imposed max-height / inner scrollbar — the rail flows with the page so
+     it doesn't paint an ugly scrollbar over the axis. Consumers that need a
+     fixed-height, independently-scrolling rail can set max-height + overflow
+     on the container themselves. */
 }
 
 .eidotter-timeline-md__rail-item {


### PR DESCRIPTION
The master-detail rail-list imposed `max-height: 70vh; overflow-y: auto`, which painted a scrollbar over the timeline axis — looked awful on eidotter.com. Removed it so the rail flows with the page (no inner scrollbar). Consumers that genuinely want a fixed-height, independently-scrolling rail can set `max-height` + `overflow` on the container themselves.

Pure CSS removal — no API/behaviour change. Visual no-op except the scrollbar is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)