### PR TITLE
chore(release): 0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-06-18
+
 ### Added
 - **`<EmptyState>` — DOS zero-state primitive (DMNC-859).** Centred title + optional description + optional action slot, with tone-driven title colour (`default`/`error`/`warning`/`info`). Ported from Steuerdash; tones + description route through `text-dos-*` semantic roles (description → AA-safe `text-muted`). `role="status"`.
 - **`<SectionHeading>` — DOS section-label primitive (DMNC-855).** Uppercase `<h3>` with an optional trailing `(count)` and tone-driven colour (`default`/`error`/`warning`/`info`). Ported from Steuerdash; tones route through `text-dos-*` semantic roles (not raw `cga-*`) so the heading re-themes and stays AA-safe under amber-mono.
+
+### Fixed
+- **Timeline master-detail rail flows instead of inner-scrolling.** The rail-list imposed `max-height: 70vh; overflow-y: auto`, painting a scrollbar over the timeline axis. Removed it so the rail flows with the page; consumers needing a fixed-height, independently-scrolling rail can set `max-height` + `overflow` on the container themselves.
 
 ## [0.34.0] - 2026-06-18
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,9 +290,9 @@ eiDotter uses Untitled UI as a **pattern reference**, not a dependency. **No UTI
 - **Figma:** UTI Figma library is set up with eiDotter's DOS tokens. eiDotter's Figma file is the source of truth for component design.
 - **License rationale:** eidotter is published under CC-BY-NC-4.0. UTI Pro is a paid commercial license that does not permit sublicensing/redistribution. Bundling UTI Pro assets into `dist/eidotter.css` / `dist/index.es.js` would have been a license violation. Pixelarticons (MIT) avoids this entirely.
 
-## Current Component Status (v0.34.x, June 2026)
+## Current Component Status (v0.35.x, June 2026)
 
-**Components** (41): Accordion, AIText, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Lightbox, Modal, Nav, Notification, Progress, RetroEffects, Separator, Skeleton, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
+**Components** (43): Accordion, AIText, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, EmptyState, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Lightbox, Modal, Nav, Notification, Progress, RetroEffects, SectionHeading, Separator, Skeleton, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
 
 **AIText (v0.24.x, DMNC-946):** Inline marker for AI-drafted prose — renders a `<span data-provenance="ai-draft">` with a **static, theme-aware** magenta gradient ('AI writer' style) from `src/styles/provenance.css` (shared with the per-paragraph diff pipeline, DMNC-884). Theme-aware stops: `#FF1A8C→#FF55FF` on amber/dark, `#C0228A→#7A3CC0` under light themes (`[data-theme="light"]`/`.light`). Restyled 2026-06-17 from the old animated magenta→white→cyan shimmer (the white midpoint failed on light backgrounds). Use for marking a phrase inside otherwise-human prose; for whole paragraphs in MDX prefer the raw `data-provenance` attribute.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eidotter",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eidotter",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "license": "CC-BY-NC-4.0",
       "dependencies": {
         "pixelarticons": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",


### PR DESCRIPTION
Version bump + changelog finalization for **0.35.0**.

## Ships
- **feat: `<SectionHeading>`** — DOS section-label primitive (DMNC-855)
- **feat: `<EmptyState>`** — DOS zero-state primitive (DMNC-859)
- **fix: master-detail rail flows** instead of inner-scrolling (no scrollbar over the axis)

First two steuerdash → eidotter ports (parent DMNC-854) + the rail-scrollbar fix.

## Publish (after merge)
Cut a **GitHub Release `v0.35.0`** on `main` → OIDC `publish.yml` → npm. Then eidotter.com bumps to `^0.35` (picks up the rail fix on the live master-detail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)