### PR TITLE
feat(checklist-row): port ChecklistRow primitive (DMNC-856)

### DIFF
--- a/.storybook/a11y-known-failures.json
+++ b/.storybook/a11y-known-failures.json
@@ -116,6 +116,9 @@
   "components-card--all-variants": [
     "color-contrast"
   ],
+  "components-checklistrow--pending": [
+    "color-contrast"
+  ],
   "components-commandprompt--disabled": [
     "color-contrast"
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`<ChecklistRow>` — DOS checklist-row primitive (DMNC-856).** A `[x]`/`[ ]` toggle (real `role="checkbox"` button, keyboard-operable) plus label, optional note, and leading/trailing slots; `labelTone` `default`/`muted`(strikethrough)/`error`. Ported from Steuerdash; tones + note route through `text-dos-*` semantic roles (AA-safe under amber-mono). English default aria-labels (was German in the source).
+
 ## [0.35.0] - 2026-06-18
 
 ### Added

--- a/src/components/ChecklistRow/components/ChecklistRow.stories.tsx
+++ b/src/components/ChecklistRow/components/ChecklistRow.stories.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ChecklistRow } from './ChecklistRow';
+import { Badge } from '../../Badge';
+
+const meta = {
+  title: 'Components/ChecklistRow',
+  component: ChecklistRow,
+  parameters: {
+    layout: 'padded',
+    backgrounds: {
+      default: 'dos',
+      values: [{ name: 'dos', value: '#000000' }],
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ChecklistRow>;
+
+export default meta;
+type Story = StoryObj<typeof ChecklistRow>;
+
+const Interactive = (args: { labelTone?: 'default' | 'muted' | 'error'; label?: string }) => {
+  const [checked, setChecked] = useState(false);
+  return (
+    <ChecklistRow
+      checked={checked}
+      onToggle={() => setChecked((c) => !c)}
+      label={args.label ?? 'Upload W-2 form'}
+      labelTone={checked ? 'muted' : args.labelTone ?? 'default'}
+    />
+  );
+};
+
+export const Basic: Story = {
+  render: () => <Interactive />,
+};
+
+export const Checked: Story = {
+  args: { checked: true, onToggle: () => {}, label: 'Filed return', labelTone: 'muted' },
+};
+
+export const WithLeadingBadges: Story = {
+  args: {
+    checked: false,
+    onToggle: () => {},
+    label: 'Anlage N — Werbungskosten',
+    note: 'Last edited 2 days ago',
+    leading: (
+      <span style={{ display: 'flex', gap: 'var(--spacing-2)' }}>
+        <Badge variant="warning">high</Badge>
+        <Badge variant="info">Dom</Badge>
+      </span>
+    ),
+  },
+};
+
+export const WithTrailing: Story = {
+  args: {
+    checked: false,
+    onToggle: () => {},
+    label: 'Verify receipts',
+    trailing: <Badge variant="error">3 open</Badge>,
+  },
+};
+
+export const Disabled: Story = {
+  args: { checked: false, onToggle: () => {}, label: 'Locked item', disabled: true },
+};
+
+export const Pending: Story = {
+  args: { checked: true, onToggle: () => {}, label: 'Saving…', pending: true },
+};

--- a/src/components/ChecklistRow/components/ChecklistRow.test.tsx
+++ b/src/components/ChecklistRow/components/ChecklistRow.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ChecklistRow } from './ChecklistRow';
+
+describe('ChecklistRow', () => {
+  it('renders the label with an unchecked checkbox', () => {
+    render(<ChecklistRow checked={false} onToggle={() => {}} label="Upload W-2" />);
+    expect(screen.getByText('Upload W-2')).toBeInTheDocument();
+    const cb = screen.getByRole('checkbox');
+    expect(cb).toHaveAttribute('aria-checked', 'false');
+    expect(cb).toHaveTextContent('[ ]');
+  });
+
+  it('renders a checked checkbox with [x]', () => {
+    render(<ChecklistRow checked onToggle={() => {}} label="Done" />);
+    const cb = screen.getByRole('checkbox');
+    expect(cb).toHaveAttribute('aria-checked', 'true');
+    expect(cb).toHaveTextContent('[x]');
+  });
+
+  it('calls onToggle when the checkbox is clicked', () => {
+    const onToggle = jest.fn();
+    render(<ChecklistRow checked={false} onToggle={onToggle} label="X" />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('has a state-reflecting default aria-label, overridable', () => {
+    const { rerender } = render(<ChecklistRow checked={false} onToggle={() => {}} label="X" />);
+    expect(screen.getByRole('checkbox')).toHaveAccessibleName('Mark as complete');
+    rerender(<ChecklistRow checked onToggle={() => {}} label="X" />);
+    expect(screen.getByRole('checkbox')).toHaveAccessibleName('Mark as incomplete');
+    rerender(<ChecklistRow checked={false} onToggle={() => {}} label="X" ariaLabel="Toggle item" />);
+    expect(screen.getByRole('checkbox')).toHaveAccessibleName('Toggle item');
+  });
+
+  it('applies label tone (muted strikes through; error colour)', () => {
+    const { rerender } = render(<ChecklistRow checked onToggle={() => {}} label="X" labelTone="muted" />);
+    expect(screen.getByText('X')).toHaveClass('line-through', 'text-dos-text-muted');
+    rerender(<ChecklistRow checked={false} onToggle={() => {}} label="X" labelTone="error" />);
+    expect(screen.getByText('X')).toHaveClass('text-dos-error');
+  });
+
+  it('does not toggle when disabled', () => {
+    const onToggle = jest.fn();
+    render(<ChecklistRow checked={false} onToggle={onToggle} disabled label="X" />);
+    const cb = screen.getByRole('checkbox');
+    expect(cb).toBeDisabled();
+    fireEvent.click(cb);
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('renders note, leading, trailing, and free children', () => {
+    render(
+      <ChecklistRow
+        checked={false}
+        onToggle={() => {}}
+        label="X"
+        note="due tomorrow"
+        leading={<span data-testid="lead">L</span>}
+        trailing={<span data-testid="trail">T</span>}
+      >
+        <span data-testid="child">C</span>
+      </ChecklistRow>,
+    );
+    expect(screen.getByText('due tomorrow')).toBeInTheDocument();
+    expect(screen.getByTestId('lead')).toBeInTheDocument();
+    expect(screen.getByTestId('trail')).toBeInTheDocument();
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('dims while pending and carries the stable hook class', () => {
+    const { container } = render(<ChecklistRow checked={false} onToggle={() => {}} label="X" pending />);
+    const row = container.querySelector('.eidotter-checklist-row');
+    expect(row).toHaveClass('opacity-50');
+  });
+});

--- a/src/components/ChecklistRow/components/ChecklistRow.tsx
+++ b/src/components/ChecklistRow/components/ChecklistRow.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import React from 'react';
+import { cn } from '../../../utils/cn';
+
+export interface ChecklistRowProps {
+  /** Whether the item is checked. */
+  checked: boolean;
+  /** Toggle handler. */
+  onToggle: () => void;
+  /** Disable the toggle. */
+  disabled?: boolean;
+  /** Dim the row while a mutation is in flight. */
+  pending?: boolean;
+  /** Accessible label for the toggle (overrides the default). */
+  ariaLabel?: string;
+  /**
+   * Label colour. `muted` strikes through + dims (completed items). Routes
+   * through `text-dos-*` semantic roles, AA-safe under amber-mono.
+   * @default 'default'
+   */
+  labelTone?: 'default' | 'muted' | 'error';
+  /** Primary label content (toned). Optional — omit and use `children` for free body content. */
+  label?: React.ReactNode;
+  /** Free body content rendered below the label (alternative/addition to `label`). */
+  children?: React.ReactNode;
+  /** Optional secondary note rendered under the label. */
+  note?: React.ReactNode;
+  /** Optional content above the label (e.g. a badge row). */
+  leading?: React.ReactNode;
+  /** Optional trailing content (e.g. an action), right-aligned. */
+  trailing?: React.ReactNode;
+  /** Additional CSS class name. */
+  className?: string;
+}
+
+const labelToneClasses: Record<NonNullable<ChecklistRowProps['labelTone']>, string> = {
+  default: 'text-dos-text-primary',
+  muted: 'text-dos-text-muted line-through',
+  error: 'text-dos-error',
+};
+
+/**
+ * DOS-styled checklist row — a `[x]`/`[ ]` toggle plus label, optional note,
+ * and leading/trailing slots. Ported from Steuerdash (DMNC-856).
+ *
+ * The toggle is a real `<button>` (keyboard + screen-reader operable); the
+ * `[x]`/`[ ]` glyph is the DOS checkbox aesthetic. Tones and the note route
+ * through `text-dos-*` semantic roles (not raw `cga-*`) so the row re-themes.
+ */
+export const ChecklistRow: React.FC<ChecklistRowProps> = ({
+  checked,
+  onToggle,
+  disabled,
+  pending,
+  ariaLabel,
+  labelTone = 'default',
+  label,
+  children,
+  note,
+  leading,
+  trailing,
+  className,
+}) => (
+  <div
+    className={cn(
+      'eidotter-checklist-row',
+      'flex items-start gap-3 py-2 border-b border-dos-border-disabled',
+      pending && 'opacity-50',
+      className,
+    )}
+  >
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={checked}
+      onClick={onToggle}
+      disabled={disabled}
+      aria-label={ariaLabel ?? (checked ? 'Mark as incomplete' : 'Mark as complete')}
+      className={cn(
+        'shrink-0 pt-0.5 font-dos text-dos-text-sm',
+        'text-dos-text-primary hover:text-dos-text-accent',
+        'cursor-pointer disabled:cursor-not-allowed',
+      )}
+    >
+      {checked ? '[x]' : '[ ]'}
+    </button>
+    <div className="flex-1 min-w-0">
+      {leading && <div className="mb-1">{leading}</div>}
+      {label !== undefined && (
+        <div className={cn('font-dos text-dos-text-sm', labelToneClasses[labelTone])}>{label}</div>
+      )}
+      {children}
+      {note && <p className="font-dos text-dos-text-xs text-dos-text-muted mt-0.5">{note}</p>}
+    </div>
+    {trailing && <div className="flex items-center gap-2 shrink-0">{trailing}</div>}
+  </div>
+);
+
+ChecklistRow.displayName = 'ChecklistRow';

--- a/src/components/ChecklistRow/components/index.ts
+++ b/src/components/ChecklistRow/components/index.ts
@@ -1,0 +1,2 @@
+export { ChecklistRow } from './ChecklistRow';
+export type { ChecklistRowProps } from './ChecklistRow';

--- a/src/components/ChecklistRow/index.ts
+++ b/src/components/ChecklistRow/index.ts
@@ -1,0 +1,2 @@
+export { ChecklistRow } from './components';
+export type { ChecklistRowProps } from './components';

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export { InlineExpand } from './components/InlineExpand';
 export { Separator } from './components/Separator';
 export { SectionHeading } from './components/SectionHeading';
 export { EmptyState } from './components/EmptyState';
+export { ChecklistRow } from './components/ChecklistRow';
 export { TextScramble } from './components/TextScramble';
 export { Nav, DesktopNav, MobileNav } from './components/Nav';
 export { ChatMessage, ChatHistory, ChatInput, ChatContainer } from './components/Chat';
@@ -105,6 +106,7 @@ export type { InlineExpandProps, InlineExpandSource } from './components/InlineE
 export type { SeparatorProps } from './components/Separator';
 export type { SectionHeadingProps } from './components/SectionHeading';
 export type { EmptyStateProps } from './components/EmptyState';
+export type { ChecklistRowProps } from './components/ChecklistRow';
 export type { TextScrambleProps } from './components/TextScramble';
 export type { NavProps, NavItem } from './components/Nav';
 export type { ChatMessageProps, ChatHistoryProps, ChatMessageEntry, ChatInputProps, ChatContainerProps } from './components/Chat';


### PR DESCRIPTION
Closes DMNC-856. steuerdash → eidotter port batch (parent DMNC-854).

`<ChecklistRow>` — a `[x]`/`[ ]` checklist row: a real `role="checkbox"` toggle button (keyboard-operable, state-reflecting `aria-label`) plus label, optional note, and leading/trailing slots. `labelTone` = `default` / `muted` (strikethrough, for completed) / `error`.

**Port notes:** tones + note route through `text-dos-*` semantic roles (not raw `cga-*`) so the row re-themes and clears the axe gate; `label` is optional with free `children`; default aria-labels are English (the source was German). Stable `eidotter-checklist-row` hook.

**Verified:** 8 tests pass (checkbox role/aria-checked, toggle, default+override aria-label, tones, disabled, slots, pending); lint + lint-tokens clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)