### PR TITLE
chore(release): 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.0] - 2026-06-18
+
+The steuerdash → eidotter primitive ports (DMNC-854), part 2: five new components.
+
 ### Added
 - **`<LabeledProgress>` — DOS labelled progress bar (DMNC-861).** Optional leading label, a width-accurate amber fill, and a trailing value with a custom `valueSuffix` (`'%'`, `' EUR'`, `/24`, …). Ported from Steuerdash as a standalone div-bar (not the block-fill `<Progress>`, whose `█`/`░` fill is wider than the track in some fonts); the fill animates via `transform: scaleX` (compositor-only, reduced-motion-safe). Clamps to 0–100 and guards `max=0`.
 - **`<LedgerRow>` — DOS value-row primitive (DMNC-857).** Label/note on the left, a right-aligned `value` (accent + `tabular-nums`) with optional `copyValue` (→ `<CopyButton>`) and a `trailing` slot. Generalised from Steuerdash's money-specific row — currency/locale formatting, document links, and verify/source badges are intentionally **not** built in: pass a pre-formatted `value` and compose domain chrome via `trailing`, keeping the DS locale-agnostic and themeable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,9 +290,9 @@ eiDotter uses Untitled UI as a **pattern reference**, not a dependency. **No UTI
 - **Figma:** UTI Figma library is set up with eiDotter's DOS tokens. eiDotter's Figma file is the source of truth for component design.
 - **License rationale:** eidotter is published under CC-BY-NC-4.0. UTI Pro is a paid commercial license that does not permit sublicensing/redistribution. Bundling UTI Pro assets into `dist/eidotter.css` / `dist/index.es.js` would have been a license violation. Pixelarticons (MIT) avoids this entirely.
 
-## Current Component Status (v0.35.x, June 2026)
+## Current Component Status (v0.36.x, June 2026)
 
-**Components** (43): Accordion, AIText, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, CmdPalette, CommandPrompt, DosFigure, EmptyState, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LegalPage, Lightbox, Modal, Nav, Notification, Progress, RetroEffects, SectionHeading, Separator, Skeleton, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
+**Components** (48): Accordion, AIText, Alert, Badge, Brand (Logo, Wordmark, BrandLockup), Breadcrumb, Button, Card, ChatMessage, ChatHistory, ChatInput, ChatContainer, Checkbox, ChecklistRow, CmdPalette, CommandPrompt, CopyButton, DosFigure, EmptyState, FilterBar, Footer, Header, Icon, InlineExpand, InlineLink, Input, LabeledProgress, LedgerRow, LegalPage, Lightbox, Modal, Nav, Notification, Progress, RetroEffects, SectionHeading, Select, Separator, Skeleton, Stat, Switch, Tabs, Tag, Terminal, TextScramble, TimelineContainer, TimelineNode, Tokens
 
 **AIText (v0.24.x, DMNC-946):** Inline marker for AI-drafted prose — renders a `<span data-provenance="ai-draft">` with a **static, theme-aware** magenta gradient ('AI writer' style) from `src/styles/provenance.css` (shared with the per-paragraph diff pipeline, DMNC-884). Theme-aware stops: `#FF1A8C→#FF55FF` on amber/dark, `#C0228A→#7A3CC0` under light themes (`[data-theme="light"]`/`.light`). Restyled 2026-06-17 from the old animated magenta→white→cyan shimmer (the white midpoint failed on light backgrounds). Use for marking a phrase inside otherwise-human prose; for whole paragraphs in MDX prefer the raw `data-provenance` attribute.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eidotter",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eidotter",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "license": "CC-BY-NC-4.0",
       "dependencies": {
         "pixelarticons": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",


### PR DESCRIPTION
Version bump + changelog finalization for **0.36.0** — part 2 of the steuerdash → eidotter primitive ports (DMNC-854).

## Ships (5 new components)
- `<ChecklistRow>` (DMNC-856) · `<CopyButton>` (DMNC-858) · `<Select>` (DMNC-860) · `<LedgerRow>` (DMNC-857, generalized) · `<LabeledProgress>` (DMNC-861, standalone bar)

Component count 43 → 48.

## Publish (after merge)
Cut a **GitHub Release `v0.36.0`** on `main` → OIDC `publish.yml` → npm. Then steuerdash can drop its local `src/components/ui/*` copies and consume the shared components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)