### PR TITLE
fix(provenance): keep inline code legible inside AI-marked regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.1] - 2026-06-18
+
+### Fixed
+- **Inline code stays legible inside AI-marked regions.** The AI-draft marker (`data-provenance="ai-draft"` / `data-ai-block`) paints prose with a magenta text-clip gradient using `-webkit-text-fill-color: transparent` + `color: transparent`. Both inherit into descendants, but the `background-image`/`background-clip: text` that fills the glyphs does **not** — so a `<code>` inside an AI-marked paragraph inherited transparent text with no gradient to show, rendering its glyphs invisible and leaving any code-box background (`.dos-code`) as an empty rectangle (observed on dmnc.tech: `SKShapeNode`, `SKNode.copy()` shown as blank boxes). `code`/`kbd`/`samp`/`pre` are now excluded from the gradient and reset to the accent colour inside AI regions.
+
 ## [0.36.0] - 2026-06-18
 
 The steuerdash → eidotter primitive ports (DMNC-854), part 2: five new components.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eidotter",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eidotter",
-      "version": "0.36.0",
+      "version": "0.36.1",
       "license": "CC-BY-NC-4.0",
       "dependencies": {
         "pixelarticons": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",

--- a/src/styles/provenance.css
+++ b/src/styles/provenance.css
@@ -51,7 +51,7 @@
 }
 
 [data-provenance="ai-draft"],
-[data-ai-block] :is(h1, h2, h3, h4, h5, h6, p, li, blockquote, strong, em, code) {
+[data-ai-block] :is(h1, h2, h3, h4, h5, h6, p, li, blockquote, strong, em) {
   background-image: linear-gradient(
     135deg,
     var(--ai-marker-from) 0%,
@@ -80,4 +80,22 @@
   background-clip: initial;
   -webkit-text-fill-color: initial;
   color: inherit;
+}
+
+/* Verbatim code is never "drafted prose" — keep it readable inside AI-marked
+   regions. The text-clip gradient relies on `-webkit-text-fill-color:
+   transparent` + `color: transparent`, both of which INHERIT into descendants.
+   A `<code>` inside a `[data-provenance="ai-draft"]` paragraph therefore
+   inherits transparent text but NOT the `background-image`/`background-clip`
+   (those don't inherit) — so its glyphs vanish, and any code-box background
+   (e.g. `.dos-code`) renders as an empty rectangle. Reset code/kbd/samp/pre to
+   the accent colour so they stay legible. (SKShapeNode boxes on dmnc.tech.) */
+[data-provenance="ai-draft"] :is(code, kbd, samp, pre),
+[data-ai-block] :is(code, kbd, samp, pre),
+code[data-provenance="ai-draft"] {
+  background-image: none;
+  -webkit-background-clip: border-box;
+  background-clip: border-box;
+  -webkit-text-fill-color: var(--color-semantic-text-accent);
+  color: var(--color-semantic-text-accent);
 }

--- a/src/styles/tokens.test.ts
+++ b/src/styles/tokens.test.ts
@@ -194,6 +194,26 @@ describe('AI-content provenance token contract', () => {
     expect(css).toMatch(/\[data-ai-block\][^{]*:is\([^)]*\bp\b[^)]*\)/);
   });
 
+  // Verbatim code must stay legible inside AI-marked regions. The gradient
+  // relies on transparent text-fill, which inherits into a descendant <code>
+  // while the gradient background does not — so code glyphs vanished and any
+  // .dos-code box rendered as an empty rectangle (SKShapeNode boxes on
+  // dmnc.tech). Code must be excluded from the gradient and reset to a real
+  // colour.
+  it('provenance.css does NOT clip code into the AI-marker gradient', () => {
+    const css = readFileSync(resolve(__dirname, 'provenance.css'), 'utf-8');
+    // The gradient :is() list no longer includes `code`.
+    expect(css).not.toMatch(/:is\([^)]*\bem\b[^)]*\bcode\b[^)]*\)/);
+  });
+
+  it('provenance.css resets code/kbd/samp/pre to a readable colour in AI regions', () => {
+    const css = readFileSync(resolve(__dirname, 'provenance.css'), 'utf-8');
+    expect(css).toMatch(/\[data-ai-block\]\s*:is\(code,\s*kbd,\s*samp,\s*pre\)/);
+    expect(css).toMatch(/\[data-provenance="ai-draft"\]\s*:is\(code,\s*kbd,\s*samp,\s*pre\)/);
+    // The reset gives code an opaque fill (not transparent) so glyphs render.
+    expect(css).toMatch(/-webkit-text-fill-color:\s*var\(--color-semantic-text-accent\)/);
+  });
+
   // ---- Bundle wiring ----
   it('src/index.ts imports provenance.css so the rule reaches the default bundle', () => {
     const indexTs = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf-8');


### PR DESCRIPTION
## Problem

On **dmnc.tech**, inline code like `SKShapeNode`, `SKNode.copy()`, etc. renders as **filled rectangles with invisible text** — but only inside AI-authored sections (the magenta-gradient intro paragraph and the `DECISIONS` list). The human-authored `DEVLOG` section is unaffected.

### Root cause — it's an eidotter problem, not a consumer misuse

This is eidotter's own `src/styles/provenance.css` (shipped in the default `eidotter/styles` bundle via `src/index.ts`). The AI-draft marker (`data-provenance="ai-draft"` / `data-ai-block`) paints prose with a magenta text-clip gradient:

```css
-webkit-text-fill-color: transparent;
color: transparent;
background-clip: text;
background-image: linear-gradient(...);
```

The two **transparent-fill** properties *inherit* into descendants, but `background-image` / `background-clip` do **not**. So a `<code>` inside an AI-marked paragraph inherits transparent text **with no gradient to fill its glyphs** → the glyphs disappear, and the code's own box background (`.dos-code`: `background-color` + border) renders as an empty rectangle.

The consumer is using the provenance API correctly — eidotter's selector was just sweeping verbatim `<code>` into a prose-only effect.

## Fix

1. Drop `code` from the gradient `:is()` list — verbatim code isn't "drafted prose".
2. Reset `code` / `kbd` / `samp` / `pre` inside AI-marked regions to the accent colour (matching `.dos-code`) with an opaque `-webkit-text-fill-color`, so glyphs and the code box both render.
3. Add regression tests in `tokens.test.ts`.

## Testing

- `npx jest src/styles/tokens.test.ts` — 66 passed (incl. 2 new regression tests)
- `node scripts/lint-token-refs.mjs` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013xmvsnhCk7mh5fVgN9bGyv)_