### PR TITLE
docs(plan): DMNC-1130 — per-component RSC-safe subpath exports

### DIFF
--- a/docs/plans/2026-06-20-dmnc-1130-plan.md
+++ b/docs/plans/2026-06-20-dmnc-1130-plan.md
@@ -1,0 +1,1064 @@
+# Per-Component Subpath Exports (RSC-safe deep imports) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Linear:** [DMNC-1130](https://linear.app/lizomorf/issue/DMNC-1130/per-component-subpath-exports-preserving-use-client-rsc-safe-deep) · **Unblocks:** [DMNC-854](https://linear.app/lizomorf/issue/DMNC-854) part 3 · **Follows:** [DMNC-864](https://linear.app/lizomorf/issue/DMNC-864)
+
+**Goal:** Let RSC consumers deep-import individual eidotter components such that pure-presentational components are importable in **server** components (no client code pulled in), and interactive components carry a real `'use client'` boundary so Next treats them as client references (no SSR crash) — without changing the existing `.` barrel.
+
+**Architecture:** Additive, mirroring the icons pipeline (`build-icons` → `dist/icons/*` + `./icons/*` exports). A new `build-components` pass runs a *second* Vite/Rolldown lib build with one entry per public component directory, externalizing React + react-aria and stripping all CSS imports (CSS still ships once via `dist/eidotter.css`). A deterministic post-build script prepends `'use client';` to every **interactive** component's output; a small **verified** server-safe allowlist (seeded with `SectionHeading`, `EmptyState`, `LabeledProgress`) ships *without* the directive. `package.json` gains one `./{kebab-name}` subpath per component. The `.` barrel, `./icons`, and all existing exports are untouched.
+
+**Tech Stack:** TypeScript, Vite 8 (Rolldown bundler), Rollup-style `rollupOptions`, Node ESM build scripts (`.mjs`), Jest, GitHub Actions CI, React 18/19 + React Aria.
+
+---
+
+## Global Constraints
+
+Copied verbatim from the spec / repo conventions. Every task's requirements implicitly include this section.
+
+- **Main `.` barrel import keeps working unchanged.** No consumer breakage. `import { Button } from 'eidotter'` and `import 'eidotter/styles'` behave exactly as today.
+- **CSS stays a single sheet.** Deep imports must NOT import a per-component CSS file (none are emitted) and must NOT 404 on CSS. Consumers still `import 'eidotter/styles'` (→ `dist/eidotter.css`).
+- **`'use client'` must be present** as the first statement in every per-component **interactive** output, and **absent** from every **server-safe** output.
+- **Deep imports are ESM-only** (mirrors `./icons/*`, which provides only `import`, no `require`). UMD/`require` deep imports are out of scope.
+- **Node 22.x** in CI; **React** peer `^18.0.0 || ^19.0.0`; **react-dom** peer same.
+- **Generated files stay generated.** `tokens.css`, `tokens.js`, `tailwind.preset.cjs`, `theme.*.css`, `EiDotterTokens.swift`, the icon barrels — never hand-edit. The same discipline applies to anything this plan generates.
+- **Do not bypass CI guards.** No `--no-verify`, `--admin`, or force-push. `main` is branch-protected; `build (22.x)` must be green.
+- **`docs/` is Storybook build output** and is wiped by `npm run build-storybook`. Do not write runtime artifacts there. (This plan doc lives in `docs/plans/` per the DMNC planning-workflow convention and is force-added past `.gitignore`; that is the only file under `docs/` this plan touches.)
+- **Public repo, CC-BY-NC-4.0.** No licensed (UTI Pro) assets in any output. The existing `@untitledui-pro/*` externalization guardrail is preserved in the new build config.
+- **Tailwind v4 build** with the `flatten-css-layers` post-step on the *main* `dist/eidotter.css`. The per-component build emits **no CSS**, so it does not interact with the flatten step.
+
+---
+
+## Background & Research Findings
+
+Established by reading the repo on 2026-06-20 (commit `1ccf509`):
+
+1. **Current dist is one bundle, 0 directives.** `npm run build` → `vite build` (single lib entry `src/index.ts`) → `dist/index.es.js` + `dist/index.umd.js`. `grep -c "use client" dist/index.es.js` → `0`. Vite/Rolldown strips module-level directives when flattening into one bundle. This is the SSR-crash root cause (DMNC-864).
+2. **`'use client'` in source is sparse and unreliable.** Only 9 source files contain it (`CopyButton`, `TimelineNode`, `LedgerRow`, `TimelineContainer`, `MasterDetailLayout`, `Select`, `Nav`, `Header`, `ChecklistRow`). Many interactive components (`Button`, `Modal`, `Tabs`, `Input`, `Switch`, `Checkbox`, …) have **no** directive in source. **Conclusion: we cannot trust source directives** — classification must be derived and the directive injected deterministically.
+3. **Classification is subtle.** A first-pass audit *misclassified* `Stat` and `TextScramble` (both call the `useTextScramble` hook) and `Brand`/`Logo` (calls `useId`) as "presentational." Any component that calls *any* hook — including `useId` — cannot run in an RSC server component. **Conclusion: server-safe must be an explicitly verified allowlist, guarded by an automated purity check; everything else is marked client (safe over-marking).**
+4. **The three issue-named server-safe primitives are genuinely pure.** `SectionHeading`, `EmptyState`, `LabeledProgress` each import only `React` + the pure `cn` util (and, for `LabeledProgress`, a `.css` that will be stripped). No hooks, no context, no react-aria, no browser globals. These are the safe initial allowlist and the steuerdash unblock targets.
+5. **Entry points are uniform.** Every published component is `src/components/<Dir>/index.ts`, which re-exports from `./components`. This is the per-component build entry.
+6. **CSS import patterns.** ~30 components do `import './X.css'` and/or `import '../../../styles/keyframes.css'` (and `provenance.css`). The per-component build must resolve all `.css` to an empty module so no per-component CSS is emitted and no CSS import remains in output.
+7. **`cn` is pure** (`tailwind-merge` only). Safe in the server graph.
+8. **Icons pipeline is the template.** `tsconfig.icons.json` compiles `src/icons/**` 1:1 to `dist/icons/`; `build-barrels.mjs` generates barrels and rewrites a marked `.gitignore` block; `package.json` exposes `./icons`, `./icons/all`, `./icons/*`. Icons are *leaf* modules (no shared deps) so a 1:1 tsc compile works for them — **components are not leaf modules** (they import `cn`, react-aria, hooks, sibling files, CSS), so components need a *bundling* build (Vite multi-entry), not a 1:1 tsc compile.
+9. **`dist/components` is already in `package.json` `files`** (line 54). `tsc -p tsconfig.build.json` (`emitDeclarationOnly`, `rootDir: src`, `outDir: dist`) emits the per-file `.d.ts` mirror, so `dist/components/<Name>/index.d.ts` already exists after a build and is already published. Per-component subpath `types` can point straight at it — **no new `.d.ts` generation needed.**
+10. **CI freshness-guard pattern exists** (`build.yml`: token freshness via `git diff --exit-code`, `lint-tokens`, preset-parity test). We extend it with per-component export/directive guards in the same spirit.
+11. **`external` predicate** in `vite.config.ts` externalizes `react`, `react-dom`, `react/jsx-runtime`, `react/jsx-dev-runtime`, `use-sync-external-store*`, and `@untitledui-pro/*`. The per-component build reuses this and *additionally* externalizes react-aria (see Design §"Externals & the single-instance rule").
+
+---
+
+## Approach Decision
+
+The spec offers two approaches. **This plan implements Approach 1.**
+
+| | **Approach 1 — per-component subpath exports (additive)** ✅ chosen | Approach 2 — `preserveModules` + preserve-directives on the main build |
+|---|---|---|
+| Blast radius | Low. New build pass + new export keys. Main `.`/UMD/`./icons` untouched. | High. Changes the whole dist shape (tree-shaking, `sideEffects`, `flatten-css-layers` over many files, freshness checks, `files`). |
+| Back-compat | Trivially preserved (main bundle unchanged). | Every consumer's import graph changes; must re-verify all. |
+| Directive control | Deterministic post-build injection from a verified list — independent of Rolldown's directive handling (which we observed strips directives). | Depends on a bundler plugin preserving source directives across Rolldown, *and* on source directives being correct (finding #2: they aren't). |
+| CSS | Single sheet preserved; per-component build emits none. | Must reconcile per-module CSS layering with the existing flatten step. |
+| Risk | Contained to new files + additive `exports`. | Touches the package's primary artifact. |
+
+Approach 1 matches the issue's stated preference, mirrors the proven icons pipeline, and isolates risk. Approach 2's only advantage (one pipeline) is outweighed by changing the package's primary artifact for every consumer.
+
+---
+
+## Design
+
+### Single source of truth: the component manifest
+
+One module (`scripts/components/manifest.mjs`) is imported by the Vite config and every script, so the component list, kebab mapping, exclusions, and server-safe allowlist live in exactly one place.
+
+- **Component set** = every directory under `src/components/` that has an `index.ts`, minus `EXCLUDED`.
+- **`EXCLUDED` = `{ Brand, Tokens }`:**
+  - `Brand` — the existing `./brand` export is a **legacy alias to the full barrel** (`package.json` lines 19–23) and must stay for back-compat; we will not repurpose `./brand`. `Brand` is interactive anyway (`Logo` uses `useId`), so RSC gains nothing from a deep import.
+  - `Tokens` — Storybook-only utility, not a published runtime component.
+- **`SERVER_SAFE`** (ship *without* `'use client'`) = `{ SectionHeading, EmptyState, LabeledProgress }` initially. Expanding it requires passing `check-server-safe` + the RSC smoke test for the candidate.
+- **kebab mapping**: `SectionHeading → section-heading`, `CmdPalette → cmd-palette`, `AIText → ai-text`, etc.
+
+### Classification rule (interactive vs server-safe)
+
+> A component is **server-safe** *only if* it and its entire transitive `src/` import graph contain **no** React hook calls (`use*(`, including `useId`), **no** `createContext`, **no** import from `react-aria` / `react-aria-components` / `react-stately`, and **no** module-scope reference to `window`/`document`/`navigator`/`localStorage`/`sessionStorage`. Everything else is **interactive** and gets `'use client'`.
+
+Over-marking a server-safe component as interactive is harmless (it just can't be a server component). Under-marking an interactive one crashes RSC. So the default is `'use client'`, and `SERVER_SAFE` is a small, machine-verified allowlist.
+
+### Directive injection (deterministic, bundler-independent)
+
+We do **not** rely on Rolldown/Rollup preserving source directives (finding #1 shows it strips them, and finding #2 shows source directives are unreliable). After the per-component build, `scripts/components/inject-use-client.mjs` prepends the exact string `'use client';\n` to `dist/components/<kebab>.js` for every interactive component. In ESM, a directive prologue before the first `import` is valid and is what Next's bundler scans for. Server-safe outputs are left untouched.
+
+### CSS handling
+
+A tiny Vite plugin resolves any `*.css` import to an empty virtual module, so:
+- no per-component CSS asset is emitted (no 404 risk),
+- no `import './X.css'` survives in the output,
+- CSS continues to ship exactly once via the main build's `dist/eidotter.css` (`import 'eidotter/styles'`).
+
+### Externals & the single-instance rule
+
+The per-component build externalizes everything the main build does **plus** `react-aria-components`, `react-aria`, and `react-stately`. Rationale: react-aria relies on React context; bundling a *second* copy into per-component files would risk two react-aria instances (broken context) when a consumer mixes deep imports. Externalizing makes deep imports resolve the consumer's single hoisted react-aria (eidotter declares it as a regular `dependency`, so it is installed for consumers). **Caveat (documented, not blocking):** mixing barrel imports (`from 'eidotter'`, which bundles react-aria) with deep imports in the same tree can still produce two instances; deep-import consumers (e.g. steuerdash) should pick one style. Pure-presentational deep imports never touch react-aria, so they are unaffected.
+
+### Output layout & coexistence with the `.d.ts` mirror
+
+- Runtime: `dist/components/<kebab>.js` (e.g. `dist/components/section-heading.js`). Shared internal chunks: `dist/components/_shared/[name]-[hash].js`.
+- Types: the existing tsc mirror at `dist/components/<Name>/index.d.ts` (PascalCase dir). A kebab `.js` file and a PascalCase dir never collide. `emptyOutDir: false` ensures the per-component build does not wipe the tsc-emitted mirror.
+- `dist/components` is already whitelisted in `package.json` `files`, so both the bundles and the `.d.ts` mirror publish. (Verified in Task 6.)
+
+### `package.json` exports shape (per component)
+
+```jsonc
+"./section-heading": {
+  "types": "./dist/components/SectionHeading/index.d.ts",
+  "import": "./dist/components/section-heading.js"
+}
+```
+
+Explicit entries (one per component) are hand-authored for clarity and to avoid a broad `"./*"` wildcard that would intercept typos and reserved subpaths. A freshness check (`check-exports.mjs`) guarantees the block stays complete: every manifest component has an entry, and no entry is stale.
+
+---
+
+## File Structure
+
+**Create:**
+- `scripts/components/manifest.mjs` — single source of truth (component list, kebab, `EXCLUDED`, `SERVER_SAFE`).
+- `scripts/components/manifest.test.mjs` *(or `src/__tests__/components-manifest.test.ts`)* — unit tests for kebab + classification invariants.
+- `vite.config.components.ts` — second lib build: multi-entry, strip-CSS plugin, externals, ES output.
+- `scripts/components/inject-use-client.mjs` — prepend `'use client';` to interactive outputs.
+- `scripts/components/verify-directives.mjs` — post-build CI guard (directive present/absent + no react-aria in server-safe).
+- `scripts/components/check-server-safe.mjs` — pre-build source-graph purity guard for `SERVER_SAFE`.
+- `scripts/components/check-exports.mjs` — `package.json` exports freshness guard.
+- `scripts/components/smoke-rsc.mjs` — server-render smoke for `SERVER_SAFE` bundles (no DOM).
+- `test/rsc-fixture/README.md` — documented minimal Next.js RSC validation (manual acceptance evidence).
+
+**Modify:**
+- `package.json` — add `build-components` script; chain it into `build`; add per-component `exports`; add `check-exports`/`check-server-safe`/`verify-directives`/`smoke-rsc` npm scripts. (`files` already covers `dist/components` — verify only.)
+- `.github/workflows/build.yml` — add guard steps.
+- `README.md` — add "Deep imports / RSC" subsection.
+- `CLAUDE.md` — document the per-component subpath surface + the build pass.
+- `~/.claude/skills/eidotter-adoption/SKILL.md` — add RSC deep-import guidance + steuerdash unblock note. *(Outside the repo; committed via the skill's own mechanism, not this PR. Noted in Task 10.)*
+
+---
+
+## Tasks
+
+### Task 1: Component manifest (single source of truth)
+
+**Files:**
+- Create: `scripts/components/manifest.mjs`
+- Test: `scripts/components/manifest.test.mjs`
+
+**Interfaces:**
+- Produces:
+  - `toKebab(name: string): string`
+  - `listComponents(): Array<{ name: string, kebab: string, entry: string, serverSafe: boolean }>` — sorted by `name`.
+  - `SERVER_SAFE: Set<string>`, `EXCLUDED: Set<string>`
+
+- [ ] **Step 1: Write the manifest module**
+
+```js
+// scripts/components/manifest.mjs
+// Single source of truth for per-component subpath exports (DMNC-1130).
+// Imported by vite.config.components.ts and every scripts/components/*.mjs guard.
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const ROOT = path.resolve(__dirname, '../..');
+const COMPONENTS_DIR = path.join(ROOT, 'src/components');
+
+// Dirs intentionally NOT given a per-component subpath:
+//  - Brand: `./brand` is a legacy alias to the full barrel (back-compat). Brand
+//           is client anyway (Logo uses useId), so a deep import gains nothing.
+//  - Tokens: Storybook-only utility, not a published runtime component.
+export const EXCLUDED = new Set(['Brand', 'Tokens']);
+
+// Verified pure-presentational components — safe to import in an RSC *server*
+// component; these ship WITHOUT a `'use client'` directive. EXPAND ONLY after
+// the candidate passes `npm run check-server-safe` AND the RSC smoke test.
+// Everything not listed here is marked `'use client'` (safe over-marking).
+export const SERVER_SAFE = new Set([
+  'SectionHeading',
+  'EmptyState',
+  'LabeledProgress',
+]);
+
+/** PascalCase dir → kebab subpath. "SectionHeading"→"section-heading", "AIText"→"ai-text". */
+export const toKebab = (name) =>
+  name
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase();
+
+/** Every published component dir (has index.ts), minus EXCLUDED, sorted by name. */
+export function listComponents() {
+  return fs
+    .readdirSync(COMPONENTS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && !EXCLUDED.has(d.name))
+    .map((d) => d.name)
+    .filter((name) => fs.existsSync(path.join(COMPONENTS_DIR, name, 'index.ts')))
+    .sort((a, b) => a.localeCompare(b))
+    .map((name) => ({
+      name,
+      kebab: toKebab(name),
+      entry: `src/components/${name}/index.ts`,
+      serverSafe: SERVER_SAFE.has(name),
+    }));
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```js
+// scripts/components/manifest.test.mjs  (run with: node --test scripts/components/manifest.test.mjs)
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { toKebab, listComponents, SERVER_SAFE } from './manifest.mjs';
+
+test('toKebab handles multi-word and acronym names', () => {
+  assert.equal(toKebab('Button'), 'button');
+  assert.equal(toKebab('SectionHeading'), 'section-heading');
+  assert.equal(toKebab('CmdPalette'), 'cmd-palette');
+  assert.equal(toKebab('AIText'), 'ai-text');
+  assert.equal(toKebab('TimelineContainer'), 'timeline-container');
+});
+
+test('listComponents excludes Brand and Tokens, includes Button + the server-safe trio', () => {
+  const names = new Set(listComponents().map((c) => c.name));
+  assert.ok(!names.has('Brand'));
+  assert.ok(!names.has('Tokens'));
+  assert.ok(names.has('Button'));
+  for (const s of ['SectionHeading', 'EmptyState', 'LabeledProgress']) assert.ok(names.has(s));
+});
+
+test('server-safe flag matches SERVER_SAFE', () => {
+  for (const c of listComponents()) assert.equal(c.serverSafe, SERVER_SAFE.has(c.name));
+});
+
+test('kebab subpaths are unique', () => {
+  const kebabs = listComponents().map((c) => c.kebab);
+  assert.equal(kebabs.length, new Set(kebabs).size);
+});
+```
+
+- [ ] **Step 3: Run the test**
+
+Run: `node --test scripts/components/manifest.test.mjs`
+Expected: all tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/components/manifest.mjs scripts/components/manifest.test.mjs
+git commit -m "feat(build): add per-component manifest (single source of truth) for subpath exports"
+```
+
+---
+
+### Task 2: Per-component Vite build config (multi-entry, CSS-stripped, externals)
+
+**Files:**
+- Create: `vite.config.components.ts`
+
+**Interfaces:**
+- Consumes: `listComponents()` from Task 1.
+- Produces: `vite build -c vite.config.components.ts` emits `dist/components/<kebab>.js` (ES) per component, plus `dist/components/_shared/*` chunks. No CSS assets. React + react-aria externalized.
+
+- [ ] **Step 1: Write the config**
+
+```ts
+// vite.config.components.ts
+// Second lib build (DMNC-1130): one ES bundle per component for RSC-safe deep
+// imports. Runs AFTER the main `vite build` + tsc; coexists via emptyOutDir:false.
+import { defineConfig, type Plugin } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+import { listComponents } from './scripts/components/manifest.mjs';
+
+// Resolve every `*.css` import to an empty module: no per-component CSS is
+// emitted and no CSS import survives. CSS ships once via dist/eidotter.css.
+const stripCss = (): Plugin => ({
+  name: 'eidotter-strip-css',
+  enforce: 'pre',
+  resolveId(id) {
+    if (id.endsWith('.css')) return '\0eidotter-empty-css';
+  },
+  load(id) {
+    if (id === '\0eidotter-empty-css') return 'export default {};';
+  },
+});
+
+const components = listComponents();
+const entry = Object.fromEntries(
+  components.map((c) => [c.kebab, path.resolve(__dirname, c.entry)]),
+);
+
+const EXTERNAL_PKGS = [
+  'react-aria-components',
+  'react-aria',
+  'react-stately',
+];
+
+export default defineConfig({
+  plugins: [stripCss(), react()],
+  resolve: { alias: { '@': path.resolve(__dirname, './src') } },
+  build: {
+    outDir: 'dist/components',
+    emptyOutDir: false, // keep the tsc-emitted .d.ts mirror + main dist
+    cssCodeSplit: false,
+    lib: {
+      entry,
+      formats: ['es'],
+    },
+    rollupOptions: {
+      // Same React externalization as the main build, PLUS react-aria so deep
+      // imports resolve the consumer's single hoisted instance (context safety).
+      external: (id) =>
+        id === 'react' ||
+        id === 'react-dom' ||
+        id === 'react/jsx-runtime' ||
+        id === 'react/jsx-dev-runtime' ||
+        id.includes('use-sync-external-store') ||
+        id.startsWith('@untitledui-pro/') ||
+        EXTERNAL_PKGS.some((p) => id === p || id.startsWith(`${p}/`)),
+      output: {
+        entryFileNames: '[name].js',
+        chunkFileNames: '_shared/[name]-[hash].js',
+      },
+    },
+  },
+});
+```
+
+- [ ] **Step 2: Build it (requires `npm ci` first in a fresh worktree)**
+
+Run: `npm run build && npx vite build -c vite.config.components.ts`
+Expected: `dist/components/section-heading.js`, `dist/components/button.js`, … exist; no `*.css` files appear under `dist/components/`.
+
+- [ ] **Step 3: Verify CSS is stripped and entries are independent**
+
+Run:
+```bash
+ls dist/components/*.js | head
+test -z "$(find dist/components -name '*.css')" && echo "OK: no per-component CSS"
+grep -L "react-aria" dist/components/section-heading.js && echo "OK: server-safe has no react-aria"
+```
+Expected: bundles present; "OK: no per-component CSS"; section-heading.js does not import react-aria.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add vite.config.components.ts
+git commit -m "feat(build): per-component Vite build (multi-entry, CSS-stripped, react-aria externalized)"
+```
+
+---
+
+### Task 3: `build-components` script + directive injection
+
+**Files:**
+- Create: `scripts/components/inject-use-client.mjs`
+- Modify: `package.json` (scripts: add `build-components`; chain into `build`)
+
+**Interfaces:**
+- Consumes: `listComponents()`; the `dist/components/<kebab>.js` outputs from Task 2.
+- Produces: interactive `dist/components/<kebab>.js` files begin with `'use client';`. `npm run build` now ends with the per-component build + injection.
+
+- [ ] **Step 1: Write the injection script**
+
+```js
+// scripts/components/inject-use-client.mjs
+// Deterministically prepend `'use client';` to every INTERACTIVE per-component
+// bundle. We do NOT rely on the bundler preserving source directives — source
+// directives are unreliable (DMNC-1130 finding) and Rolldown strips them.
+import fs from 'node:fs';
+import path from 'node:path';
+import { listComponents, ROOT } from './manifest.mjs';
+
+const OUT = path.join(ROOT, 'dist/components');
+const DIRECTIVE = "'use client';\n";
+
+let injected = 0;
+for (const c of listComponents()) {
+  if (c.serverSafe) continue;
+  const file = path.join(OUT, `${c.kebab}.js`);
+  if (!fs.existsSync(file)) {
+    throw new Error(`[inject-use-client] missing bundle: ${path.relative(ROOT, file)} — run the components build first`);
+  }
+  const src = fs.readFileSync(file, 'utf8');
+  if (/^\s*['"]use client['"]/.test(src)) continue; // idempotent
+  fs.writeFileSync(file, DIRECTIVE + src);
+  injected += 1;
+}
+console.log(`[inject-use-client] prepended directive to ${injected} interactive component bundle(s)`);
+```
+
+- [ ] **Step 2: Wire the build scripts in `package.json`**
+
+Add to `"scripts"`:
+```jsonc
+"build-components": "vite build -c vite.config.components.ts && node scripts/components/inject-use-client.mjs",
+```
+Change `"build"` from:
+```jsonc
+"build": "vite build && node scripts/flatten-css-layers.mjs && tsc -p tsconfig.build.json && npm run build-icons",
+```
+to:
+```jsonc
+"build": "vite build && node scripts/flatten-css-layers.mjs && tsc -p tsconfig.build.json && npm run build-icons && npm run build-components",
+```
+
+- [ ] **Step 3: Build and verify directives landed**
+
+Run:
+```bash
+npm run build
+head -1 dist/components/button.js          # expect: 'use client';
+head -1 dist/components/section-heading.js  # expect: NOT 'use client';
+```
+Expected: `button.js` first line is `'use client';`; `section-heading.js` first line is an `import`/code line, not the directive.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/components/inject-use-client.mjs package.json
+git commit -m "feat(build): inject 'use client' into interactive per-component bundles; wire build-components into build"
+```
+
+---
+
+### Task 4: Post-build directive verification guard
+
+**Files:**
+- Create: `scripts/components/verify-directives.mjs`
+- Modify: `package.json` (script: `verify-directives`)
+
+**Interfaces:**
+- Consumes: `listComponents()`; built `dist/components/<kebab>.js`.
+- Produces: `node scripts/components/verify-directives.mjs` exits non-zero if any directive is missing/misplaced or a server-safe bundle imports react-aria.
+
+- [ ] **Step 1: Write the guard**
+
+```js
+// scripts/components/verify-directives.mjs
+// CI guard: assert each per-component bundle's directive matches its
+// classification, and that server-safe bundles never pull react-aria.
+import fs from 'node:fs';
+import path from 'node:path';
+import { listComponents, ROOT } from './manifest.mjs';
+
+const OUT = path.join(ROOT, 'dist/components');
+const errors = [];
+
+for (const c of listComponents()) {
+  const file = path.join(OUT, `${c.kebab}.js`);
+  if (!fs.existsSync(file)) { errors.push(`missing bundle: ${c.kebab}.js`); continue; }
+  const src = fs.readFileSync(file, 'utf8');
+  const hasDirective = /^\s*['"]use client['"]\s*;?/.test(src);
+
+  if (c.serverSafe && hasDirective) errors.push(`${c.kebab}: server-safe but has 'use client'`);
+  if (!c.serverSafe && !hasDirective) errors.push(`${c.kebab}: interactive but missing 'use client'`);
+  if (c.serverSafe && /from\s*['"]react-aria/.test(src)) {
+    errors.push(`${c.kebab}: server-safe bundle imports react-aria (would crash RSC)`);
+  }
+}
+
+if (errors.length) {
+  console.error('[verify-directives] FAILED:\n  ' + errors.join('\n  '));
+  process.exit(1);
+}
+console.log(`[verify-directives] OK — ${listComponents().length} bundles verified`);
+```
+
+- [ ] **Step 2: Add the npm script**
+
+```jsonc
+"verify-directives": "node scripts/components/verify-directives.mjs",
+```
+
+- [ ] **Step 3: Run after a build**
+
+Run: `npm run build && npm run verify-directives`
+Expected: `[verify-directives] OK — N bundles verified`.
+
+- [ ] **Step 4: Negative check (prove the guard bites)**
+
+Run:
+```bash
+node -e "const fs=require('fs');const f='dist/components/button.js';fs.writeFileSync(f, fs.readFileSync(f,'utf8').replace(/^'use client';\n/,''))"
+npm run verify-directives; echo "exit=$?"   # expect failure, exit=1
+npm run build-components                      # restore
+```
+Expected: guard reports `button: interactive but missing 'use client'`, `exit=1`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/components/verify-directives.mjs package.json
+git commit -m "test(build): add post-build per-component directive verification guard"
+```
+
+---
+
+### Task 5: Server-safe purity guard (source-graph scan)
+
+**Files:**
+- Create: `scripts/components/check-server-safe.mjs`
+- Modify: `package.json` (script: `check-server-safe`)
+
+**Interfaces:**
+- Consumes: `SERVER_SAFE`, `ROOT` from Task 1; the `src/` tree.
+- Produces: `node scripts/components/check-server-safe.mjs` exits non-zero if any `SERVER_SAFE` component's transitive `src/` import graph contains a hook call, `createContext`, a react-aria import, or a module-scope browser global. Runs **without** a build (pure source scan), so it can gate before bundling.
+
+- [ ] **Step 1: Write the guard**
+
+```js
+// scripts/components/check-server-safe.mjs
+// Static purity guard: a component on the SERVER_SAFE allowlist must have a
+// transitive src/ import graph free of client-only signatures. Catches the
+// Stat/useTextScramble and Logo/useId class of misclassification BEFORE it can
+// ship a server-crashing bundle.
+import fs from 'node:fs';
+import path from 'node:path';
+import { SERVER_SAFE, ROOT } from './manifest.mjs';
+
+const SRC = path.join(ROOT, 'src');
+const FORBIDDEN = [
+  { re: /\buse[A-Z]\w*\s*\(/, msg: 'calls a React hook (use*())' },
+  { re: /\bcreateContext\s*\(/, msg: 'calls createContext' },
+  { re: /from\s*['"]react-aria(-components)?['"]|from\s*['"]react-stately['"]/, msg: 'imports react-aria/react-stately' },
+  { re: /\b(window|document|navigator|localStorage|sessionStorage)\b/, msg: 'references a browser global' },
+];
+
+/** Resolve a relative import specifier to an on-disk .ts/.tsx file (or index). */
+function resolve(fromFile, spec) {
+  if (!spec.startsWith('.')) return null; // bare import — checked by FORBIDDEN regexes, not walked
+  const base = path.resolve(path.dirname(fromFile), spec);
+  for (const cand of [base, `${base}.ts`, `${base}.tsx`, path.join(base, 'index.ts'), path.join(base, 'index.tsx')]) {
+    if (fs.existsSync(cand) && fs.statSync(cand).isFile()) return cand;
+  }
+  return null;
+}
+
+const errors = [];
+function walk(file, seen, originName) {
+  if (seen.has(file)) return;
+  seen.add(file);
+  const src = fs.readFileSync(file, 'utf8');
+  for (const { re, msg } of FORBIDDEN) {
+    if (re.test(src)) errors.push(`${originName}: ${path.relative(ROOT, file)} ${msg}`);
+  }
+  for (const m of src.matchAll(/(?:import|export)\s+[^'"]*from\s*['"]([^'"]+)['"]|import\s*['"]([^'"]+)['"]/g)) {
+    const spec = m[1] ?? m[2];
+    if (!spec || spec.endsWith('.css')) continue;
+    const next = resolve(file, spec);
+    if (next) walk(next, seen, originName);
+  }
+}
+
+for (const name of SERVER_SAFE) {
+  const entry = path.join(SRC, 'components', name, 'index.ts');
+  if (!fs.existsSync(entry)) { errors.push(`${name}: missing ${path.relative(ROOT, entry)}`); continue; }
+  walk(entry, new Set(), name);
+}
+
+if (errors.length) {
+  console.error('[check-server-safe] FAILED — these SERVER_SAFE components are NOT pure:\n  ' + errors.join('\n  '));
+  process.exit(1);
+}
+console.log(`[check-server-safe] OK — ${SERVER_SAFE.size} server-safe component(s) verified pure`);
+```
+
+- [ ] **Step 2: Add the npm script**
+
+```jsonc
+"check-server-safe": "node scripts/components/check-server-safe.mjs",
+```
+
+- [ ] **Step 3: Run it (expect pass for the seeded trio)**
+
+Run: `npm run check-server-safe`
+Expected: `[check-server-safe] OK — 3 server-safe component(s) verified pure`.
+
+- [ ] **Step 4: Prove it bites (temporary)**
+
+Add `Stat` to `SERVER_SAFE` in `manifest.mjs`, run `npm run check-server-safe`.
+Expected: FAIL — `Stat: src/.../Stat.tsx calls a React hook (use*())` (via `useTextScramble`). Then revert the edit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/components/check-server-safe.mjs package.json
+git commit -m "test(build): add static purity guard for the SERVER_SAFE allowlist"
+```
+
+---
+
+### Task 6: `package.json` per-component exports + freshness guard
+
+**Files:**
+- Modify: `package.json` (`exports`)
+- Create: `scripts/components/check-exports.mjs`
+- Modify: `package.json` (script: `check-exports`)
+
+**Interfaces:**
+- Consumes: `listComponents()`.
+- Produces: one `./{kebab}` export per component; `node scripts/components/check-exports.mjs` fails if the `exports` block drifts from the manifest.
+
+- [ ] **Step 1: Add per-component exports to `package.json`**
+
+Insert one entry per component (after the existing `./icons/*` block, before the closing brace of `exports`). Full set, sorted by kebab. Example head (the implementer generates the complete list — see Step 2's generator to print it verbatim):
+
+```jsonc
+"./accordion":          { "types": "./dist/components/Accordion/index.d.ts",          "import": "./dist/components/accordion.js" },
+"./ai-text":            { "types": "./dist/components/AIText/index.d.ts",             "import": "./dist/components/ai-text.js" },
+"./alert":              { "types": "./dist/components/Alert/index.d.ts",              "import": "./dist/components/alert.js" },
+"./badge":              { "types": "./dist/components/Badge/index.d.ts",              "import": "./dist/components/badge.js" },
+"./breadcrumb":         { "types": "./dist/components/Breadcrumb/index.d.ts",         "import": "./dist/components/breadcrumb.js" },
+"./button":             { "types": "./dist/components/Button/index.d.ts",             "import": "./dist/components/button.js" },
+"./card":               { "types": "./dist/components/Card/index.d.ts",               "import": "./dist/components/card.js" },
+"./chat":               { "types": "./dist/components/Chat/index.d.ts",               "import": "./dist/components/chat.js" },
+"./checkbox":           { "types": "./dist/components/Checkbox/index.d.ts",           "import": "./dist/components/checkbox.js" },
+"./checklist-row":      { "types": "./dist/components/ChecklistRow/index.d.ts",       "import": "./dist/components/checklist-row.js" },
+"./cmd-palette":        { "types": "./dist/components/CmdPalette/index.d.ts",         "import": "./dist/components/cmd-palette.js" },
+"./command-prompt":     { "types": "./dist/components/CommandPrompt/index.d.ts",      "import": "./dist/components/command-prompt.js" },
+"./copy-button":        { "types": "./dist/components/CopyButton/index.d.ts",         "import": "./dist/components/copy-button.js" },
+"./dos-figure":         { "types": "./dist/components/DosFigure/index.d.ts",          "import": "./dist/components/dos-figure.js" },
+"./empty-state":        { "types": "./dist/components/EmptyState/index.d.ts",         "import": "./dist/components/empty-state.js" },
+"./filter-bar":         { "types": "./dist/components/FilterBar/index.d.ts",          "import": "./dist/components/filter-bar.js" },
+"./footer":             { "types": "./dist/components/Footer/index.d.ts",             "import": "./dist/components/footer.js" },
+"./header":             { "types": "./dist/components/Header/index.d.ts",             "import": "./dist/components/header.js" },
+"./icon":               { "types": "./dist/components/Icon/index.d.ts",               "import": "./dist/components/icon.js" },
+"./inline-expand":      { "types": "./dist/components/InlineExpand/index.d.ts",       "import": "./dist/components/inline-expand.js" },
+"./inline-link":        { "types": "./dist/components/InlineLink/index.d.ts",         "import": "./dist/components/inline-link.js" },
+"./input":              { "types": "./dist/components/Input/index.d.ts",              "import": "./dist/components/input.js" },
+"./labeled-progress":   { "types": "./dist/components/LabeledProgress/index.d.ts",    "import": "./dist/components/labeled-progress.js" },
+"./ledger-row":         { "types": "./dist/components/LedgerRow/index.d.ts",          "import": "./dist/components/ledger-row.js" },
+"./legal-page":         { "types": "./dist/components/LegalPage/index.d.ts",          "import": "./dist/components/legal-page.js" },
+"./lightbox":           { "types": "./dist/components/Lightbox/index.d.ts",           "import": "./dist/components/lightbox.js" },
+"./modal":              { "types": "./dist/components/Modal/index.d.ts",              "import": "./dist/components/modal.js" },
+"./nav":                { "types": "./dist/components/Nav/index.d.ts",                "import": "./dist/components/nav.js" },
+"./notification":       { "types": "./dist/components/Notification/index.d.ts",       "import": "./dist/components/notification.js" },
+"./progress":           { "types": "./dist/components/Progress/index.d.ts",           "import": "./dist/components/progress.js" },
+"./retro-effects":      { "types": "./dist/components/RetroEffects/index.d.ts",       "import": "./dist/components/retro-effects.js" },
+"./section-heading":    { "types": "./dist/components/SectionHeading/index.d.ts",     "import": "./dist/components/section-heading.js" },
+"./select":             { "types": "./dist/components/Select/index.d.ts",             "import": "./dist/components/select.js" },
+"./separator":          { "types": "./dist/components/Separator/index.d.ts",          "import": "./dist/components/separator.js" },
+"./skeleton":           { "types": "./dist/components/Skeleton/index.d.ts",           "import": "./dist/components/skeleton.js" },
+"./stat":               { "types": "./dist/components/Stat/index.d.ts",               "import": "./dist/components/stat.js" },
+"./switch":             { "types": "./dist/components/Switch/index.d.ts",             "import": "./dist/components/switch.js" },
+"./tabs":               { "types": "./dist/components/Tabs/index.d.ts",               "import": "./dist/components/tabs.js" },
+"./tag":                { "types": "./dist/components/Tag/index.d.ts",                "import": "./dist/components/tag.js" },
+"./terminal":           { "types": "./dist/components/Terminal/index.d.ts",           "import": "./dist/components/terminal.js" },
+"./text-scramble":      { "types": "./dist/components/TextScramble/index.d.ts",       "import": "./dist/components/text-scramble.js" },
+"./timeline-container": { "types": "./dist/components/TimelineContainer/index.d.ts",  "import": "./dist/components/timeline-container.js" },
+"./timeline-node":      { "types": "./dist/components/TimelineNode/index.d.ts",       "import": "./dist/components/timeline-node.js" }
+```
+
+> The exact set must equal `listComponents()` at implementation time. Generate it verbatim instead of hand-typing:
+> ```bash
+> node -e "import('./scripts/components/manifest.mjs').then(({listComponents})=>{for(const c of listComponents())console.log(JSON.stringify('./'+c.kebab)+': { \"types\": \"./dist/components/'+c.name+'/index.d.ts\", \"import\": \"./dist/components/'+c.kebab+'.js\" },')})"
+> ```
+
+- [ ] **Step 2: Write the exports freshness guard**
+
+```js
+// scripts/components/check-exports.mjs
+// Freshness guard: package.json `exports` must contain exactly one ./{kebab}
+// entry per manifest component, pointing at the right .js + .d.ts. Fails CI if
+// someone adds/removes a component without updating exports.
+import fs from 'node:fs';
+import path from 'node:path';
+import { listComponents, ROOT } from './manifest.mjs';
+
+const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+const exp = pkg.exports ?? {};
+const errors = [];
+const expected = new Map(
+  listComponents().map((c) => [
+    `./${c.kebab}`,
+    { types: `./dist/components/${c.name}/index.d.ts`, import: `./dist/components/${c.kebab}.js` },
+  ]),
+);
+
+for (const [key, want] of expected) {
+  const got = exp[key];
+  if (!got) { errors.push(`missing export "${key}"`); continue; }
+  if (got.import !== want.import) errors.push(`${key}: import is ${got.import}, expected ${want.import}`);
+  if (got.types !== want.types) errors.push(`${key}: types is ${got.types}, expected ${want.types}`);
+}
+
+// Catch stale component subpaths (a ./foo that maps into dist/components but is
+// not a current manifest component). Ignores ./icons/* and other reserved keys.
+for (const key of Object.keys(exp)) {
+  if (!key.startsWith('./') || key === '.' || key.startsWith('./icons') || key.startsWith('./themes')) continue;
+  const v = exp[key];
+  const target = typeof v === 'string' ? v : v.import ?? '';
+  if (target.startsWith('./dist/components/') && !expected.has(key) && key !== './brand') {
+    errors.push(`stale per-component export "${key}" — not in the manifest`);
+  }
+}
+
+if (errors.length) {
+  console.error('[check-exports] FAILED:\n  ' + errors.join('\n  '));
+  process.exit(1);
+}
+console.log(`[check-exports] OK — ${expected.size} per-component exports match the manifest`);
+```
+
+- [ ] **Step 3: Add the npm script + verify `files` covers `dist/components`**
+
+```jsonc
+"check-exports": "node scripts/components/check-exports.mjs",
+```
+Confirm `package.json` `files` still lists `"dist/components"` (it does today, line 54) — both the bundles and the `.d.ts` mirror publish under it. No change needed; assert with:
+```bash
+node -e "const f=require('./package.json').files;process.exit(f.includes('dist/components')?0:1)" && echo "OK: dist/components shipped"
+```
+
+- [ ] **Step 4: Run the guard**
+
+Run: `npm run check-exports`
+Expected: `[check-exports] OK — N per-component exports match the manifest`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json scripts/components/check-exports.mjs
+git commit -m "feat(pkg): add per-component subpath exports + freshness guard"
+```
+
+---
+
+### Task 7: RSC smoke test (server render) + documented Next validation
+
+**Files:**
+- Create: `scripts/components/smoke-rsc.mjs`
+- Create: `test/rsc-fixture/README.md`
+- Modify: `package.json` (script: `smoke-rsc`)
+
+**Interfaces:**
+- Consumes: built `dist/components/<kebab>.js` for `SERVER_SAFE`; `react`, `react-dom/server`.
+- Produces: `node scripts/components/smoke-rsc.mjs` renders each server-safe bundle to static markup in a **no-DOM** Node process and fails if any throws. Plus a documented Next.js RSC validation (acceptance evidence).
+
+- [ ] **Step 1: Write the server-render smoke**
+
+```js
+// scripts/components/smoke-rsc.mjs
+// Import each SERVER_SAFE bundle in a no-DOM Node process and render it to
+// static markup. A server-safe component must render without touching the DOM
+// or calling client-only APIs. (This catches load/render-time crashes; the full
+// RSC-graph guarantee is the Next.js fixture below + verify-directives.)
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { SERVER_SAFE, ROOT, toKebab } from './manifest.mjs';
+
+// Minimal valid props per server-safe component (extend as the allowlist grows).
+const PROPS = {
+  SectionHeading: { title: 'STATUS' },
+  EmptyState: { title: 'Nothing here' },
+  LabeledProgress: { label: 'Upload', value: 42 },
+};
+
+const errors = [];
+for (const name of SERVER_SAFE) {
+  const file = path.join(ROOT, 'dist/components', `${toKebab(name)}.js`);
+  try {
+    const mod = await import(pathToFileURL(file).href);
+    const Comp = mod[name] ?? mod.default;
+    if (!Comp) { errors.push(`${name}: no export found in ${toKebab(name)}.js`); continue; }
+    const html = renderToStaticMarkup(createElement(Comp, PROPS[name] ?? {}));
+    if (typeof html !== 'string' || html.length === 0) errors.push(`${name}: empty render`);
+  } catch (err) {
+    errors.push(`${name}: threw during server render — ${err.message}`);
+  }
+}
+
+if (errors.length) {
+  console.error('[smoke-rsc] FAILED:\n  ' + errors.join('\n  '));
+  process.exit(1);
+}
+console.log(`[smoke-rsc] OK — ${SERVER_SAFE.size} server-safe component(s) render without a DOM`);
+```
+
+- [ ] **Step 2: Add the npm script**
+
+```jsonc
+"smoke-rsc": "node scripts/components/smoke-rsc.mjs",
+```
+
+- [ ] **Step 3: Run after a build**
+
+Run: `npm run build && npm run smoke-rsc`
+Expected: `[smoke-rsc] OK — 3 server-safe component(s) render without a DOM`.
+
+- [ ] **Step 4: Document the full Next.js RSC validation**
+
+Create `test/rsc-fixture/README.md` with the manual acceptance procedure (kept as docs, not run in CI — avoids a Next.js install in CI):
+
+````markdown
+# RSC validation harness (DMNC-1130)
+
+Proves a Next.js **server** component can deep-import an eidotter
+pure-presentational component without the SSR crash, and that an interactive
+component imports as a client reference.
+
+## Option A — minimal Next fixture (local)
+
+```bash
+npx create-next-app@latest /tmp/eidotter-rsc --ts --app --no-tailwind --no-eslint --use-npm
+cd /tmp/eidotter-rsc
+npm install /path/to/eidotter   # or: npm install eidotter@<published>
+```
+
+`app/page.tsx` (a **server** component — no `'use client'`):
+
+```tsx
+import { SectionHeading } from 'eidotter/section-heading'; // server-safe
+import { EmptyState } from 'eidotter/empty-state';
+import 'eidotter/styles';
+import { ClientBits } from './client-bits';
+
+export default function Page() {
+  return (
+    <main>
+      <SectionHeading title="SERVER-RENDERED" />
+      <EmptyState title="No items" />
+      <ClientBits />
+    </main>
+  );
+}
+```
+
+`app/client-bits.tsx`:
+
+```tsx
+'use client';
+import { Button } from 'eidotter/button'; // interactive → client reference
+export function ClientBits() {
+  return <Button variant="primary" onPress={() => alert('ok')}>Execute</Button>;
+}
+```
+
+```bash
+npm run build && npm run start
+```
+
+**PASS criteria:** `next build` succeeds; the page renders `SectionHeading`/
+`EmptyState` HTML from the server; `Button` works on the client. Importing
+`eidotter/section-heading` from the server component must NOT error with
+"useState/createContext is not a function" or the React Server hooks error.
+
+**Negative control:** importing an interactive component
+(`import { Modal } from 'eidotter/modal'`) directly in `page.tsx` (a server
+component) is expected to be treated as a client reference (Next boundary),
+NOT crash the server render.
+
+## Option B — reuse steuerdash
+
+Point steuerdash at the local build (`npm install /path/to/eidotter` or a
+`file:` dep), then have it import the 3 server-used primitives via their
+subpaths from a server component and the 4 client-only primitives from client
+components. `next build` green = DMNC-854 part 3 unblocked.
+````
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/components/smoke-rsc.mjs test/rsc-fixture/README.md package.json
+git commit -m "test(build): add RSC server-render smoke + documented Next validation harness"
+```
+
+---
+
+### Task 8: CI wiring
+
+**Files:**
+- Modify: `.github/workflows/build.yml`
+
+**Interfaces:**
+- Consumes: the four guard scripts + the `build` chain.
+- Produces: CI fails on export drift, server-safe impurity, missing/misplaced directives, or a server-render crash.
+
+- [ ] **Step 1: Add a pre-build guard step (after "Lint (ESLint)", before "Build")**
+
+```yaml
+    - name: Check per-component exports + server-safe purity
+      run: |
+        npm run check-exports
+        npm run check-server-safe
+```
+
+- [ ] **Step 2: Add a post-build guard step (immediately after "Build", before "Run tests")**
+
+```yaml
+    - name: Verify per-component directives + RSC smoke
+      run: |
+        npm run verify-directives
+        npm run smoke-rsc
+```
+
+- [ ] **Step 3: Lint the workflow locally**
+
+Run: `node -e "require('js-yaml')" 2>/dev/null || true; python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/build.yml'))" && echo "YAML OK"`
+Expected: `YAML OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/build.yml
+git commit -m "ci: guard per-component exports, server-safe purity, directives, and RSC smoke"
+```
+
+---
+
+### Task 9: Consumer docs (README + CLAUDE.md)
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+- Consumes: the shipped subpaths.
+- Produces: consumer-facing deep-import / RSC guidance.
+
+- [ ] **Step 1: Add a "Deep imports (RSC-safe)" subsection to `README.md`**
+
+Insert after the "### Styles" block (around line 60):
+
+````markdown
+### Deep imports (RSC-safe)
+
+Every component is also importable on its own subpath. **Server Components** can
+import pure-presentational components directly; interactive components carry a
+`'use client'` boundary so they work as client references.
+
+```tsx
+// In a Next.js Server Component (no "use client"):
+import { SectionHeading } from 'eidotter/section-heading';
+import { EmptyState } from 'eidotter/empty-state';
+import { LabeledProgress } from 'eidotter/labeled-progress';
+
+// Interactive components (Button, Modal, Tabs, …) are client references —
+// import them inside a "use client" component or let Next treat the subpath
+// as a client boundary:
+import { Button } from 'eidotter/button';
+```
+
+- Deep imports are **ESM-only** (like `eidotter/icons/*`).
+- CSS is unchanged: still one `import 'eidotter/styles'`. Deep imports pull **no**
+  per-component CSS.
+- The barrel (`import { Button } from 'eidotter'`) is unchanged. Prefer one
+  import style per tree (mixing the barrel with deep imports can duplicate
+  react-aria).
+- Server-safe today: `section-heading`, `empty-state`, `labeled-progress`
+  (the verified pure-presentational set; expanding requires passing the
+  `check-server-safe` guard). All other subpaths are client references.
+````
+
+- [ ] **Step 2: Document the surface in `CLAUDE.md`**
+
+Add under "Current Component Status" (or a new "Per-component subpath exports" note near the Icon Library section):
+
+```markdown
+**Per-component subpath exports (v0.x, DMNC-1130):** Every component is deep-importable as `eidotter/<kebab-name>` (e.g. `eidotter/button`, `eidotter/section-heading`), in addition to the unchanged `.` barrel. Emitted by `npm run build-components` (a second Vite lib build: one ES bundle per component, react-aria externalized, all CSS imports stripped → CSS still ships once via `eidotter/styles`). Interactive components carry a `'use client'` directive (injected deterministically by `scripts/components/inject-use-client.mjs` from `scripts/components/manifest.mjs`); the verified pure-presentational allowlist (`SectionHeading`, `EmptyState`, `LabeledProgress`) ships without it, so RSC **server** components can import them. CI guards: `check-exports` (exports ↔ manifest), `check-server-safe` (allowlist purity), `verify-directives` (post-build), `smoke-rsc` (server render). To add a component to the server-safe set, add it to `SERVER_SAFE` in the manifest and ensure `check-server-safe` + `smoke-rsc` pass. `Brand` (legacy `./brand` barrel alias) and `Tokens` (Storybook-only) are excluded. Generated surface — edit the manifest, not `package.json` exports by hand (the freshness guard enforces parity).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md CLAUDE.md
+git commit -m "docs: document RSC-safe per-component deep imports (README + CLAUDE.md)"
+```
+
+---
+
+### Task 10: eidotter-adoption skill + steuerdash unblock note
+
+**Files:**
+- Modify: `~/.claude/skills/eidotter-adoption/SKILL.md` *(outside this repo — committed via the skill's own repo/mechanism, not this PR)*
+
+**Interfaces:**
+- Produces: adoption guidance for RSC consumers + the DMNC-854 part-3 unblock note.
+
+- [ ] **Step 1: Add an "RSC / Next.js deep imports" section to the skill**
+
+Append after the "Theme & adoption posture" section:
+
+```markdown
+## RSC / Next.js deep imports (eidotter >= <version>, DMNC-1130)
+
+For Next.js App Router consumers:
+
+- **Server Components** may import pure-presentational primitives by subpath:
+  `eidotter/section-heading`, `eidotter/empty-state`, `eidotter/labeled-progress`.
+  No `'use client'` needed on the importing file.
+- **Interactive** components (`eidotter/button`, `eidotter/modal`, `eidotter/select`,
+  `eidotter/ledger-row`, `eidotter/checklist-row`, `eidotter/copy-button`, …) carry a
+  `'use client'` boundary — use them inside a client component.
+- Still one stylesheet: `import 'eidotter/styles'`. Deep imports add no CSS.
+- Don't mix the `eidotter` barrel with deep imports in the same tree (react-aria
+  duplication). Pick one style.
+
+**Unblocks DMNC-854 part 3:** steuerdash can now drop all 7 local `src/components/ui/*`
+copies — the 3 server-used primitives via server-safe subpaths, the 4 client-only
+primitives via their `'use client'` subpaths — and delete its server-safe local barrel
+(the DMNC-864 workaround).
+```
+
+- [ ] **Step 2: Note in the PR description** that the skill file lives outside the repo and was updated separately (it is not part of this PR's diff). The repo-side acceptance is README + CLAUDE.md (Task 9).
+
+---
+
+## Verification / Acceptance (maps to spec acceptance criteria)
+
+| Acceptance criterion | Verified by |
+|---|---|
+| Main `.` barrel import unchanged | Main `vite build` untouched; `import { Button } from 'eidotter'` + `import 'eidotter/styles'` unchanged. Existing tests + a manual barrel import. |
+| Next server component imports a presentational component via subpath without SSR crash | Task 7 Next fixture (Option A) `next build` green; `smoke-rsc` server render; `check-server-safe`. |
+| Interactive one imports as a client reference | `'use client'` present (Task 4 `verify-directives`); Next fixture `ClientBits`. |
+| CSS delivered via `eidotter/styles` (single sheet); deep imports don't 404 on CSS | strip-CSS plugin (Task 2); `find dist/components -name '*.css'` empty. |
+| `'use client'` present in per-component interactive outputs | Task 3 injection + Task 4 guard. |
+| Smoke test / documented RSC verification | Task 7 (`smoke-rsc` + `test/rsc-fixture/README.md`). |
+| README/CLAUDE/skill import guidance updated | Tasks 9 + 10. |
+
+**Full local gate before PR:**
+```bash
+npm ci
+npm run check-server-safe
+npm run check-exports
+npm run build
+npm run verify-directives
+npm run smoke-rsc
+npm test -- --ci
+```
+
+---
+
+## Risks & Mitigations
+
+- **Misclassifying an interactive component as server-safe → RSC crash.** Mitigated by default-to-client + the `check-server-safe` source-graph guard + `smoke-rsc` + the conservative 3-item seed. Expanding the allowlist is gated.
+- **Rolldown directive handling differs from Rollup.** Sidestepped entirely: we inject the directive post-build deterministically rather than relying on the bundler.
+- **react-aria duplication when mixing barrel + deep imports.** Externalized react-aria in the per-component build (single consumer instance for deep imports); documented "pick one style" caveat. Pure-presentational deep imports never touch react-aria.
+- **`exports`/manifest drift as components are added.** `check-exports` fails CI on drift; the manifest is the single source of truth.
+- **`dist/components` `.d.ts` mirror vs kebab `.js` collision.** None (file vs PascalCase dir); `emptyOutDir: false` preserves the mirror.
+- **Published-package size.** Per-component bundles + shared chunks add to the tarball but are additive and tree-shakeable per import; the main bundle is unchanged. Acceptable for the RSC unblock.
+- **Second build adds CI/build time.** One extra Vite pass over small entries; bounded and parallel-friendly.
+
+## Out of Scope
+
+- Migrating the main bundle to `preserveModules` (Approach 2).
+- `require`/UMD deep imports (ESM-only, like icons).
+- A per-component CSS-splitting scheme (single sheet retained).
+- Auto-deriving the server-safe allowlist (kept explicit + guarded).
+- Repurposing the legacy `./brand` export.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** all five acceptance bullets map to tasks (table above). Both "unblocks" addressed: DMNC-854 part 3 (Task 10 note + server-safe trio + client subpaths), DMNC-864 follow-up (steuerdash drops the server-safe-barrel workaround).
+- **Placeholder scan:** every code step contains complete, runnable code; the exports list includes a generator command to produce it verbatim from the manifest.
+- **Type/name consistency:** `listComponents()` shape, `SERVER_SAFE`, `toKebab`, `ROOT`, and the `<kebab>.js` / `<Name>/index.d.ts` path conventions are used identically across manifest, vite config, and all four guard scripts.
+- **Known caveat:** the `eidotter-adoption` skill (Task 10) lives outside this repo, so it is not in the PR diff — called out explicitly in Task 10 Step 2.


### PR DESCRIPTION
## Summary

Planning-only PR for **[DMNC-1130](https://linear.app/lizomorf/issue/DMNC-1130/per-component-subpath-exports-preserving-use-client-rsc-safe-deep)** — adds a concrete implementation plan for **per-component subpath exports that preserve `'use client'`** (RSC-safe deep imports). No source/config changed; the only file added is the plan doc.

📄 `docs/plans/2026-06-20-dmnc-1130-plan.md`

## What the plan proposes (Approach 1 — additive, mirrors the icons pipeline)

- A second Vite/Rolldown lib build (`build-components`) emitting **one ES bundle per component** at `dist/components/<kebab>.js`, with **all CSS imports stripped** (CSS still ships once via `eidotter/styles`) and **react-aria externalized** (single consumer instance).
- **Deterministic `'use client'` injection** post-build (bundler-independent — Rolldown strips source directives, and source directives proved unreliable: only 9/45 components have one). Interactive components get the directive; a **verified pure-presentational allowlist** (`SectionHeading`, `EmptyState`, `LabeledProgress`) ships without it so RSC **server** components can import them.
- One `./{kebab}` `exports` entry per component; the **`.` barrel, `./icons`, UMD, and all existing exports are untouched** (back-compat).
- **CI guards:** `check-exports` (exports ↔ manifest), `check-server-safe` (static source-graph purity), `verify-directives` (post-build), `smoke-rsc` (no-DOM server render) + a documented Next.js / steuerdash RSC validation harness.

## Key research findings baked into the plan

- `grep -c "use client" dist/index.es.js` → `0` today (single bundle strips directives) — the SSR-crash root cause.
- Classification is subtle: a first-pass audit misclassified `Stat`/`TextScramble` (call `useTextScramble`) and `Brand`/`Logo` (call `useId`) as presentational → the plan defaults to client + a machine-verified server-safe allowlist.
- The 3 issue-named primitives are genuinely pure (only `React` + `cn`).
- `dist/components` is already in `package.json` `files`, and the tsc `.d.ts` mirror already lands there — per-component `types` reuse it (no new `.d.ts` generation).

## Unblocks

- **DMNC-854 part 3** — steuerdash drops all 7 local `src/components/ui/*` copies (server-used trio via server-safe subpaths; client-only four via `'use client'` subpaths).
- Follow-up to **DMNC-864** (retires the server-safe-barrel workaround).

> ⚠️ The plan doc lives under `docs/plans/` (force-added past `.gitignore`, matching prior DMNC planning PRs). `docs/` is Storybook build output, so this file is preserved in git history but may be wiped from a local `build-storybook`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)