### PR TITLE
feat(inline-expand): add Google Favicons API as favicon fallback (DMNC-1080)

### DIFF
--- a/src/components/InlineExpand/components/InlineExpand.stories.tsx
+++ b/src/components/InlineExpand/components/InlineExpand.stories.tsx
@@ -145,16 +145,17 @@ export const WithSources: Story = {
 };
 
 export const WithBrokenFavicon: Story = {
+  name: 'Favicon Fallback Chain',
   render: () => (
     <p style={{ color: 'var(--color-semantic-text-primary)', maxWidth: '600px', lineHeight: '1.6' }}>
       Learn about{' '}
       <InlineExpand
         defaultExpanded
-        content="Phosphor displays use a coating that glows when struck by an electron beam."
+        content="Phosphor displays use a coating that glows when struck by an electron beam. Favicons follow a 3-stage fallback: explicit URL → Google Favicons API → [→] text."
         sources={[
-          { title: 'Working Source', url: 'https://example.com', favicon: 'https://example.com/favicon.ico' },
-          { title: 'Broken Favicon', url: 'https://example.org', favicon: 'https://invalid.example/broken.ico' },
-          { title: 'No Favicon', url: 'https://example.net' },
+          { title: 'Working Favicon', url: 'https://example.com', favicon: 'https://example.com/favicon.ico' },
+          { title: 'Broken Favicon (→ Google fallback)', url: 'https://example.org', favicon: 'https://invalid.example/broken.ico' },
+          { title: 'No Favicon (→ Google fallback)', url: 'https://example.net' },
         ]}
       >
         phosphor displays

--- a/src/components/InlineExpand/components/InlineExpand.test.tsx
+++ b/src/components/InlineExpand/components/InlineExpand.test.tsx
@@ -267,11 +267,12 @@ describe('InlineExpand', () => {
       expect(items).toHaveLength(2);
     });
 
-    it('renders fallback icon when favicon is not provided', () => {
+    it('uses Google Favicons API when no favicon is provided', () => {
       render(<InlineExpand {...defaultProps} defaultExpanded sources={[testSources[1]]} />);
-      const fallbackIcon = screen.getByRole('region').querySelector('.eidotter-inline-expand__source-icon');
-      expect(fallbackIcon).toHaveTextContent('[→]');
-      expect(fallbackIcon).toHaveAttribute('aria-hidden', 'true');
+      const img = screen.getByRole('region').querySelector('.eidotter-inline-expand__source-favicon') as HTMLImageElement;
+      expect(img).toBeInTheDocument();
+      expect(img.src).toContain('google.com/s2/favicons');
+      expect(img.src).toContain('developer.mozilla.org');
     });
 
     it('renders favicon when provided', () => {
@@ -283,13 +284,34 @@ describe('InlineExpand', () => {
       expect(favicon).toHaveAttribute('decoding', 'async');
     });
 
-    it('hides favicon on error and shows fallback', () => {
+    it('tries Google Favicons after primary favicon error', () => {
       render(<InlineExpand {...defaultProps} defaultExpanded sources={[testSources[0]]} />);
-      const favicon = screen.getByRole('region').querySelector('.eidotter-inline-expand__source-favicon') as HTMLImageElement;
-      fireEvent.error(favicon);
-      // After error, fallback icon should appear
+      const primaryImg = screen.getByRole('region').querySelector('.eidotter-inline-expand__source-favicon') as HTMLImageElement;
+      expect(primaryImg.src).toBe('https://en.wikipedia.org/favicon.ico');
+      fireEvent.error(primaryImg);
+      // After primary error, Google Favicons should be the new src
+      const googleImg = screen.getByRole('region').querySelector('.eidotter-inline-expand__source-favicon') as HTMLImageElement;
+      expect(googleImg.src).toContain('google.com/s2/favicons');
+      expect(googleImg.src).toContain('en.wikipedia.org');
+    });
+
+    it('shows [→] fallback when Google Favicons also fails', () => {
+      render(<InlineExpand {...defaultProps} defaultExpanded sources={[testSources[0]]} />);
+      const primaryImg = screen.getByRole('region').querySelector('.eidotter-inline-expand__source-favicon') as HTMLImageElement;
+      fireEvent.error(primaryImg);
+      const googleImg = screen.getByRole('region').querySelector('.eidotter-inline-expand__source-favicon') as HTMLImageElement;
+      fireEvent.error(googleImg);
       const fallbackIcon = screen.getByRole('region').querySelector('.eidotter-inline-expand__source-icon');
-      expect(fallbackIcon).toBeInTheDocument();
+      expect(fallbackIcon).toHaveTextContent('[→]');
+      expect(fallbackIcon).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('shows [→] when Google Favicons also fails for no-favicon source', () => {
+      render(<InlineExpand {...defaultProps} defaultExpanded sources={[testSources[1]]} />);
+      const googleImg = screen.getByRole('region').querySelector('.eidotter-inline-expand__source-favicon') as HTMLImageElement;
+      fireEvent.error(googleImg);
+      const fallbackIcon = screen.getByRole('region').querySelector('.eidotter-inline-expand__source-icon');
+      expect(fallbackIcon).toHaveTextContent('[→]');
     });
 
     it('sanitizes javascript: URLs', () => {
@@ -301,14 +323,16 @@ describe('InlineExpand', () => {
       expect(link).not.toHaveAttribute('href');
     });
 
-    it('sanitizes javascript: favicon URLs', () => {
+    it('sanitizes javascript: favicon URLs by falling back to Google Favicons', () => {
       const maliciousSources: InlineExpandSource[] = [
         { title: 'Evil', url: 'https://example.com', favicon: 'javascript:alert(1)' },
       ];
       render(<InlineExpand {...defaultProps} defaultExpanded sources={maliciousSources} />);
-      // Should show fallback icon, not img
-      expect(screen.getByRole('region').querySelector('.eidotter-inline-expand__source-favicon')).toBeNull();
-      expect(screen.getByRole('region').querySelector('.eidotter-inline-expand__source-icon')).toBeInTheDocument();
+      // Invalid favicon URL skips to Google Favicons API — no javascript: src ever set
+      const img = screen.getByRole('region').querySelector('.eidotter-inline-expand__source-favicon') as HTMLImageElement;
+      expect(img).toBeInTheDocument();
+      expect(img.src).toContain('google.com/s2/favicons');
+      expect(img.src).not.toContain('javascript');
     });
   });
 });

--- a/src/components/InlineExpand/components/InlineExpand.tsx
+++ b/src/components/InlineExpand/components/InlineExpand.tsx
@@ -4,12 +4,21 @@ import { cn } from '../../../utils/cn';
 import { isSafeUrl } from '../../../utils/isSafeUrl';
 import './InlineExpand.css';
 
+function getGoogleFaviconUrl(sourceUrl: string): string | null {
+  try {
+    const { hostname } = new URL(sourceUrl);
+    return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(hostname)}&sz=32`;
+  } catch {
+    return null;
+  }
+}
+
 export interface InlineExpandSource {
   /** Link text displayed as accessible label */
   title: string;
   /** URL — must be a valid absolute URL (http, https, or mailto) */
   url: string;
-  /** Optional favicon URL; falls back to generic link icon */
+  /** Optional favicon URL. Falls back to Google Favicons API for the domain, then to a [→] text icon. */
   favicon?: string;
 }
 
@@ -72,7 +81,9 @@ export const InlineExpand: React.FC<InlineExpandProps> = ({
   ...props
 }) => {
   const [internalExpanded, setInternalExpanded] = useState(defaultExpanded);
-  const [failedFavicons, setFailedFavicons] = useState<Set<string>>(new Set());
+  // Tracks the current fallback stage per source URL:
+  // undefined = try primary; 'google' = primary failed, try Google Favicons; 'icon' = both failed
+  const [faviconFallbacks, setFaviconFallbacks] = useState<Record<string, 'google' | 'icon'>>({});
   const hasBeenExpanded = useRef(defaultExpanded);
   const contentId = useId();
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -147,19 +158,44 @@ export const InlineExpand: React.FC<InlineExpandProps> = ({
                   rel="noopener noreferrer"
                   aria-label={`${source.title} (opens external website)`}
                 >
-                  {hasBeenExpanded.current && source.favicon && isSafeUrl(source.favicon) && !failedFavicons.has(source.url) ? (
-                    <img
-                      className="eidotter-inline-expand__source-favicon"
-                      src={source.favicon}
-                      alt=""
-                      width={16}
-                      height={16}
-                      decoding="async"
-                      onError={() => setFailedFavicons(prev => new Set(prev).add(source.url))}
-                    />
-                  ) : (
-                    <span className="eidotter-inline-expand__source-icon" aria-hidden="true">[→]</span>
-                  )}
+                  {(() => {
+                    if (!hasBeenExpanded.current) {
+                      return <span className="eidotter-inline-expand__source-icon" aria-hidden="true">[→]</span>;
+                    }
+                    const stage = faviconFallbacks[source.url];
+                    if (stage === 'icon') {
+                      return <span className="eidotter-inline-expand__source-icon" aria-hidden="true">[→]</span>;
+                    }
+                    const hasPrimary = !!source.favicon && isSafeUrl(source.favicon);
+                    if (!stage && hasPrimary) {
+                      return (
+                        <img
+                          className="eidotter-inline-expand__source-favicon"
+                          src={source.favicon}
+                          alt=""
+                          width={16}
+                          height={16}
+                          decoding="async"
+                          onError={() => setFaviconFallbacks(prev => ({ ...prev, [source.url]: 'google' }))}
+                        />
+                      );
+                    }
+                    const googleUrl = getGoogleFaviconUrl(source.url);
+                    if (googleUrl) {
+                      return (
+                        <img
+                          className="eidotter-inline-expand__source-favicon"
+                          src={googleUrl}
+                          alt=""
+                          width={16}
+                          height={16}
+                          decoding="async"
+                          onError={() => setFaviconFallbacks(prev => ({ ...prev, [source.url]: 'icon' }))}
+                        />
+                      );
+                    }
+                    return <span className="eidotter-inline-expand__source-icon" aria-hidden="true">[→]</span>;
+                  })()}
                   <span className="eidotter-inline-expand__source-title">{source.title}</span>
                 </a>
               </span>


### PR DESCRIPTION
## Summary

- Adds a 3-stage favicon fallback to `InlineExpand` source citations: explicit `favicon` URL → Google Favicons API → `[→]` text icon
- Sources without a `favicon` prop now automatically attempt Google's Favicons service, resolving favicons for most well-known domains without any extra configuration
- Merges the UX win from rizomorf's custom `InlineExpand` re-implementation into eidotter's accessible, controlled-mode version — rizomorf can now drop its fork and import from eidotter

## Changes

**`InlineExpand.tsx`**
- Replace `failedFavicons: Set<string>` with `faviconFallbacks: Record<string, 'google' | 'icon'>` tracking per-source stage
- Add `getGoogleFaviconUrl()` module-level helper (extracts hostname, returns `https://www.google.com/s2/favicons?domain=<host>&sz=32`)
- Render IIFE in JSX walks the 3 stages; falls through to `[→]` only after both attempts fail

**`InlineExpand.test.tsx`**
- 5 new/updated tests covering: Google Favicons as initial src, primary-error fallback to Google, double-failure to `[→]`, and javascript: favicon sanitization (now correctly shows Google fallback, not `[→]`)
- 43 tests total, all passing

**`InlineExpand.stories.tsx`**
- `WithBrokenFavicon` renamed "Favicon Fallback Chain" with updated content describing the 3-stage flow

## Behaviour unchanged
- `hasBeenExpanded.current` lazy-load guard — no HTTP requests before first open
- `isSafeUrl()` gate on the primary `favicon` prop
- React Aria trigger, keyboard nav, controlled/uncontrolled mode, `inert`-based content hiding

## Test plan

- [ ] Run `npm run test -- --testPathPatterns=InlineExpand` → 43 tests pass
- [ ] Open Storybook → `Components/InlineExpand/Favicon Fallback Chain` story — broken-favicon source should show Google Favicons icon after load failure
- [ ] Verify no-favicon source shows a Google Favicons icon (not `[→]`) for real domains

Linear: DMNC-1080

🤖 Generated with [Claude Code](https://claude.com/claude-code)