### PR TITLE
fix(a11y): motion purity + high-contrast glow neutralization (DMNC-1062)

### DIFF
--- a/src/components/Accordion/components/Section.css
+++ b/src/components/Accordion/components/Section.css
@@ -93,6 +93,11 @@
   .eidotter-section__header:focus-visible {
     box-shadow: 0 0 0 3px var(--color-semantic-border-focus);
   }
+
+  .eidotter-section--active .eidotter-section__header,
+  .eidotter-section__header:active {
+    text-shadow: none;
+  }
 }
 
 /* Reduced motion */

--- a/src/components/Checkbox/components/Checkbox.css
+++ b/src/components/Checkbox/components/Checkbox.css
@@ -53,7 +53,7 @@
   /* Neutralize phosphor glow on checked state — thicker focus outline
      and the checkmark itself carry the signal. */
   .eidotter-checkbox__box,
-  .eidotter-checkbox__box--checked { box-shadow: none; }
+  .eidotter-checkbox__box--checked { text-shadow: none; }
 }
 @media (prefers-reduced-motion: reduce) {
   .eidotter-checkbox__box { transition: none; }

--- a/src/components/DosFigure/components/DosFigure.css
+++ b/src/components/DosFigure/components/DosFigure.css
@@ -149,8 +149,8 @@
 }
 
 @keyframes dos-figure-pin-pulse {
-  0%, 100% { box-shadow: 0 0 6px var(--color-cga-amber-glow); }
-  50%      { box-shadow: 0 0 12px var(--color-cga-amber-glow); }
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.5; }
 }
 
 /* Caption — below the frame */
@@ -184,6 +184,9 @@
     display: none;
   }
   .eidotter-dos-figure__subject {
+    text-shadow: none;
+  }
+  .eidotter-dos-figure__pin {
     text-shadow: none;
   }
   .eidotter-dos-figure__pin-dot {

--- a/src/components/InlineExpand/components/InlineExpand.css
+++ b/src/components/InlineExpand/components/InlineExpand.css
@@ -63,13 +63,11 @@
   grid-template-rows: 0fr;
   visibility: hidden;
   opacity: 0;
-  filter: blur(1px) brightness(0.5);
   transform: translateY(-0.2rem);
   transition:
     grid-template-rows var(--duration-fast, 100ms) ease-in,
     opacity var(--duration-fast, 100ms) ease-in,
     visibility var(--duration-fast, 100ms),
-    filter var(--duration-fast, 100ms) ease-in,
     transform var(--duration-fast, 100ms) ease-in;
 }
 
@@ -80,18 +78,16 @@
   overflow: clip;
 }
 
-/* Expanded content — phosphor warm-up + Swift Out easing */
+/* Expanded content — Swift Out easing */
 .eidotter-inline-expand--expanded .eidotter-inline-expand__content {
   visibility: visible;
   opacity: 1;
-  filter: blur(0) brightness(1);
   transform: translateY(0);
   grid-template-rows: 1fr;
   transition:
     grid-template-rows var(--duration-normal, 200ms) cubic-bezier(0.175, 0.885, 0.32, 1.1),
     opacity var(--duration-normal, 200ms) cubic-bezier(0.175, 0.885, 0.32, 1.1),
     visibility var(--duration-normal, 200ms),
-    filter var(--duration-normal, 200ms) cubic-bezier(0.175, 0.885, 0.32, 1.1),
     transform var(--duration-normal, 200ms) cubic-bezier(0.175, 0.885, 0.32, 1.1);
 }
 
@@ -181,6 +177,10 @@
 @media (prefers-contrast: high) {
   .eidotter-inline-expand__trigger {
     text-decoration-thickness: 2px;
+  }
+
+  .eidotter-inline-expand__trigger:hover {
+    text-shadow: none;
   }
 
   .eidotter-inline-expand__trigger:focus-visible {

--- a/src/components/Notification/components/Notification.css
+++ b/src/components/Notification/components/Notification.css
@@ -10,14 +10,14 @@
 
 /* Phosphor enter */
 @keyframes notification-enter {
-  from { opacity: 0; filter: blur(4px) brightness(0.3); transform: translateY(-8px); }
-  to { opacity: 1; filter: blur(0) brightness(1); transform: translateY(0); }
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 /* Phosphor exit */
 @keyframes notification-exit {
-  from { opacity: 1; filter: blur(0) brightness(1); transform: scale(1); }
-  to { opacity: 0; filter: blur(2px) brightness(0.5); transform: scale(0.95); }
+  from { opacity: 1; transform: scale(1); }
+  to { opacity: 0; transform: scale(0.95); }
 }
 
 .eidotter-notification--closing {

--- a/src/components/Progress/components/Progress.css
+++ b/src/components/Progress/components/Progress.css
@@ -68,7 +68,6 @@
   color: var(--color-semantic-text-brand);
   white-space: nowrap;
   clip-path: inset(0 calc(100% - var(--fill-pct, 0) * 1%) 0 0);
-  transition: clip-path var(--duration-slow, 300ms) ease-out;
 }
 
 .eidotter-progress__empty {

--- a/src/components/RetroEffects/components/RetroEffects.css
+++ b/src/components/RetroEffects/components/RetroEffects.css
@@ -77,16 +77,17 @@
 /* Power-off animation - CRT collapse to horizontal line
    Exit starts at scale(0.95) per design-craft spec for visible shrink */
 @keyframes retro-power-off {
-  0% { transform: scale(0.95); filter: blur(2px); opacity: 1; }
-  50% { transform: scaleY(0.005) scaleX(1); filter: blur(0); opacity: 1; }
-  100% { transform: scaleY(0) scaleX(0); filter: blur(0); opacity: 0; }
+  0% { transform: scale(0.95); opacity: 1; }
+  50% { transform: scaleY(0.005) scaleX(1); opacity: 1; }
+  100% { transform: scaleY(0) scaleX(0); opacity: 0; }
 }
 
-/* Power-on animation - CRT warm up from horizontal line */
+/* Power-on animation - CRT warm up from horizontal line.
+   Opacity ramp from 0 → 1 simulates phosphor warming up (compositor-only). */
 @keyframes retro-power-on {
-  0% { transform: scaleY(0) scaleX(0); filter: blur(4px) brightness(0.3); opacity: 1; }
-  50% { transform: scaleY(0.02) scaleX(1); filter: blur(2px) brightness(0.6); opacity: 1; }
-  100% { transform: scaleY(1) scaleX(1); filter: blur(0) brightness(1); opacity: 1; }
+  0% { transform: scaleY(0) scaleX(0); opacity: 0; }
+  50% { transform: scaleY(0.02) scaleX(1); opacity: 0.8; }
+  100% { transform: scaleY(1) scaleX(1); opacity: 1; }
 }
 
 /* Power state modifiers */

--- a/src/components/TimelineNode/components/TimelineNode.css
+++ b/src/components/TimelineNode/components/TimelineNode.css
@@ -19,7 +19,7 @@
   z-index: 1;
   background: var(--color-semantic-background-brand-dim);
   border: 2px solid var(--color-semantic-border-brand-dim);
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
   flex-shrink: 0;
   animation: eidotter-timeline-node-enter var(--duration-fast, 100ms) ease-out;
 }

--- a/src/styles/keyframes.css
+++ b/src/styles/keyframes.css
@@ -32,12 +32,10 @@
 @keyframes modal-crt-enter {
   from {
     opacity: 0;
-    filter: blur(4px) brightness(0.3);
     transform: scale(0.95);
   }
   to {
     opacity: 1;
-    filter: blur(0) brightness(1);
     transform: scale(1);
   }
 }
@@ -45,12 +43,10 @@
 @keyframes modal-crt-exit {
   from {
     opacity: 1;
-    filter: blur(0) brightness(1);
     transform: scale(1);
   }
   to {
     opacity: 0;
-    filter: blur(2px) brightness(0.5);
     transform: scale(0.95);
   }
 }


### PR DESCRIPTION
## Summary

From the 2026-06-16 compliance audit — two sweeps: remove non-compositor animation properties and ensure high-contrast glow is always neutralized.

**Non-compositor animation** (`filter`/`box-shadow`/`clip-path`/`transition: all` removed):
- `keyframes.css` — `modal-crt-enter`/`exit`: removed `filter: blur/brightness`, kept opacity + scale
- `Notification.css` — `notification-enter`/`exit`: same fix
- `RetroEffects.css` — `retro-power-on`/`off`: removed filter, power-on uses opacity ramp (0→0.8→1) to simulate phosphor warm-up
- `DosFigure.css` — `dos-figure-pin-pulse`: box-shadow pulse → opacity pulse (compositor-only)
- `Progress.css` — removed `transition: clip-path`; fill snaps, edge char still animates via `transform: translateX`
- `TimelineNode.css` — `transition: all` → explicit `background-color, border-color, box-shadow`
- `InlineExpand.css` — removed `filter: blur/brightness` from content expand/collapse transitions

**High-contrast glow neutralization** (missing `text-shadow: none` rules):
- `InlineExpand.css` — trigger `:hover` text-shadow not neutralized → added
- `Section.css` — active state `text-shadow` not neutralized → added
- `DosFigure.css` — pin label `text-shadow` not neutralized (only `__subject` was covered) → added
- `Checkbox.css` — high-contrast block used `box-shadow: none` but glow is `text-shadow` → corrected

## Test plan

- [ ] Modal, Lightbox, CmdPalette enter/exit animations still feel smooth (opacity + scale only now)
- [ ] Notification toast enter/exit animates correctly
- [ ] RetroEffects power-on warm-up uses opacity ramp; power-off collapses correctly
- [ ] DosFigure pin dots pulse (opacity) rather than glow-pulse — still visually distinct
- [ ] Progress fill updates snap cleanly; edge `__transition` char still moves smoothly
- [ ] TimelineNode hover/active transitions work as before
- [ ] InlineExpand content reveals/hides via opacity + translateY only (no blur)
- [ ] In `prefers-contrast: high` mode: InlineExpand trigger hover, Accordion active header, DosFigure pin label, and Checkbox checked state all show no glow
- [ ] Checkbox `__box--checked` phosphor glow is absent in high-contrast mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)