### PR TITLE
fix(rsc): make tailwind-merge a runtime dependency (0.37.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.37.0] - 2026-06-21
+## [0.37.1] - 2026-06-21
+
+### Fixed
+- **`tailwind-merge` is now a runtime `dependency` (was devDependency).** The per-component subpath exports from 0.37.0 (`eidotter/components/<Name>`) are unbundled ESM, so their transitive `import { twMerge } from 'tailwind-merge'` (via `dist/utils/cn.js`) must resolve in the **consumer's** `node_modules`. It was only a devDependency, which the `.` barrel bundled but the per-component exports don't — so a consumer deep-importing a component hit `Module not found: Can't resolve 'tailwind-merge'` (caught by steuerdash's `next build` during DMNC-854 part 3). Moved to `dependencies`; the `.` barrel still bundles it, so existing barrel consumers are unaffected. CI now asserts every external specifier in the per-component emit is a declared `dependencies`/`peerDependencies` entry, so this class of gap can't recur.
 
 ### Added
 - **Per-component subpath exports preserving `'use client'` — RSC-safe deep imports (DMNC-1130).** New `eidotter/components/<Name>` import path (PascalCase, matching the component) lets Next.js **server components** deep-import a single component without the DMNC-864 SSR crash: presentational primitives (SectionHeading, EmptyState, LabeledProgress, …) render on the server, while interactive components (Button, Tabs, Modal, …) carry `'use client'` and resolve as client references. CSS still ships once via `eidotter/styles`; the `.` barrel is unchanged (still the default for client apps). Backed by an additive per-component ESM build pass (`tsconfig.components.json` + `scripts/finalize-component-emit.mjs`, mirroring the icons pipeline) that leaves the Vite `.` bundle untouched. `'use client'` is now **source-of-truth** on interactive component sources (classifier-driven via `scripts/sync-client-directives.mjs`; CI-guarded). Import-only (no `require`), like `./icons/*`. Unblocks steuerdash dropping its local server-primitive copies (DMNC-854 part 3).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",
@@ -167,7 +167,6 @@
     "remark-gfm": "^4.0.1",
     "storybook": "^10.2.7",
     "style-dictionary": "^5.1.1",
-    "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.3.0",
     "tailwindcss-react-aria-components": "^2.0.1",
     "ts-jest": "^29.4.0",
@@ -180,6 +179,7 @@
     "pixelarticons": "^2.1.0",
     "react-aria": "^3.47.0",
     "react-aria-components": "^1.16.0",
-    "react-stately": "^3.45.0"
+    "react-stately": "^3.45.0",
+    "tailwind-merge": "^3.5.0"
   }
 }

--- a/scripts/assert-rsc-safety.mjs
+++ b/scripts/assert-rsc-safety.mjs
@@ -12,6 +12,11 @@
  *      consumers see no behavioral change.
  *   3. Node's native ESM resolver loads a server (SectionHeading) and a client
  *      (Button) re-export chain end-to-end — proves the extension rewrite holds.
+ *   4. Every EXTERNAL (bare) import in the per-component emit is a declared
+ *      `dependencies`/`peerDependencies` entry. The unbundled per-component
+ *      modules resolve their imports in the CONSUMER's node_modules, so any
+ *      external they reference must be a real runtime dep — not a devDependency
+ *      the `.` barrel happens to bundle. (Caught the 0.37.0 `tailwind-merge` gap.)
  *
  * A full Next.js RSC fixture is intentionally out of scope here; steuerdash's Next
  * build (DMNC-854 part 3) is the real-world server-import acceptance test.
@@ -23,6 +28,7 @@ import { classifyComponents } from './lib/client-components.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const DIST_COMPONENTS = join(ROOT, 'dist', 'components');
+const SWEEP_DIRS = ['components', 'utils', 'hooks'].map((d) => join(ROOT, 'dist', d));
 const DIRECTIVE_RE = /^\s*(['"])use client\1/;
 const errors = [];
 
@@ -82,11 +88,47 @@ async function assertResolves(name) {
 await assertResolves('SectionHeading'); // server
 await assertResolves('Button'); // client
 
+// 4. Every external (bare) import in the per-component emit is a declared dep.
+const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
+const declared = new Set([
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.peerDependencies ?? {}),
+]);
+/** bare specifier → package name (handles @scope/pkg and pkg/subpath). */
+const pkgName = (spec) =>
+  spec.startsWith('@') ? spec.split('/').slice(0, 2).join('/') : spec.split('/')[0];
+
+function emittedJs(dir) {
+  if (!existsSync(dir)) return [];
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...emittedJs(full));
+    else if (entry.endsWith('.js')) out.push(full);
+  }
+  return out;
+}
+
+const undeclared = new Set();
+for (const file of SWEEP_DIRS.flatMap(emittedJs)) {
+  const src = readFileSync(file, 'utf8');
+  for (const m of src.matchAll(/\bfrom\s*['"]([^.'"][^'"]*)['"]/g)) {
+    const spec = m[1];
+    if (spec.startsWith('node:')) continue;
+    const name = pkgName(spec);
+    if (!declared.has(name)) undeclared.add(name);
+  }
+}
+for (const name of undeclared) {
+  errors.push(`external '${name}' used in per-component emit but not in dependencies/peerDependencies`);
+}
+
 if (errors.length > 0) {
   console.error(`[assert-rsc-safety] FAILED:\n  ${errors.join('\n  ')}`);
   process.exit(1);
 }
 console.log(
   `[assert-rsc-safety] OK — ${checked} emitted leaves match classification; ` +
-    `. barrel directive-free; server + client chains resolve under Node ESM.`,
+    `. barrel directive-free; server + client chains resolve under Node ESM; ` +
+    `all per-component externals are declared deps.`,
 );


### PR DESCRIPTION
## Hotfix for 0.37.0

The 0.37.0 per-component subpath exports (`eidotter/components/<Name>`) are **unbundled** ESM. Their transitive `import { twMerge } from 'tailwind-merge'` (via `dist/utils/cn.js`) must resolve in the **consumer's** `node_modules` — but `tailwind-merge` was only a **devDependency**. The `.` barrel bundles it (so barrel consumers were fine), but the per-component exports don't, so a consumer deep-importing a component hit:

```
Module not found: Can't resolve 'tailwind-merge'
```

Surfaced by **steuerdash's `next build`** during DMNC-854 part 3 (the first real consumer of the per-component exports).

## Fix
- Move `tailwind-merge` `devDependencies` → `dependencies`. The `.` barrel still bundles it, so existing barrel consumers are unaffected; per-component consumers now get it installed.
- **`scripts/assert-rsc-safety.mjs` now asserts every external specifier in the per-component emit is a declared `dependencies`/`peerDependencies` entry** — this class of gap can't recur (verified it flags `tailwind-merge` under the pre-fix dep set).
- Bumps to **0.37.1** (bundled hotfix release).

Verified: clean build; `assert-rsc-safety` green; the new dep-check would have caught the original gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)