### PR TITLE
docs(plan): eidotter consumer upgrade campaign runbook (DMNC-1065)

### DIFF
--- a/docs/plans/2026-06-21-dmnc-1065-plan.md
+++ b/docs/plans/2026-06-21-dmnc-1065-plan.md
@@ -1,0 +1,300 @@
+# eiDotter Consumer Upgrade Campaign Implementation Plan (DMNC-1065)
+
+> **For agentic workers:** This is a **multi-repo operational runbook**, not a single-repo code change. Each consumer is upgraded on its **own branch in its own repository** (most consumer repos are *not* checked out in the eidotter worktree). This document lives in the eidotter repo as the campaign's source-of-truth: the breaking-change matrix (Section B) and the per-consumer runbook (Section C + Tasks) are what each consumer session executes. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring every active eidotter consumer up to a single, current eidotter version, smoke-testing each across the version gap, so the portfolio also inherits the re-themeability delivered by the DMNC-1059 token sweep.
+
+**Architecture:** A reference matrix maps each version band to its breaking / behaviour-changing items. A generic per-repo runbook (re-baseline → bump → build → smoke-test → PR) is applied per consumer, parameterised by the band that consumer crosses and by the exact eidotter surface that consumer imports.
+
+**Tech Stack:** eidotter (React + TypeScript design system, currently `0.37.1`); consumers are a mix of Next.js, Vite, and React Native + web. Package manager: `npm` (all locally-inspected consumers use `package-lock.json`).
+
+---
+
+## ⚠️ Decision needed before execution: campaign target version
+
+The issue title and body say **"→ 0.29"**. Three facts discovered during planning make **0.37.1 the correct target instead**, and 0.29 actively wrong:
+
+1. **eidotter is already at `0.37.1`** (2026-06-21). `0.29` is eight minors stale.
+2. **The campaign's own stated benefit — re-themeability from the DMNC-1059 token sweep — does not exist at 0.29.** The full primitive→semantic-role migration landed in **`0.31.0`** (`## [0.31.0]`, "All component colour now routes through semantic roles"). The `0.30.0` entry only did a *partial* dead-fallback cleanup. Shipping consumers to 0.29 would deliver **none** of the re-theming the issue is explicitly sequencing the token sweep to unlock.
+3. **Several consumers have already drifted past 0.29 since the 2026-06-16 audit** (see Section A). Pinning them to 0.29 would be a *downgrade*.
+
+**Recommendation (this plan assumes it): target `0.37.1`.** If the operator insists on the literal `0.29`, treat `0.31.0` as the hard floor (anything below 0.31 fails the re-themeability goal) — but there is no upside to stopping below current latest, and 0.37.1 specifically unblocks steuerdash (see Task 2). This is the single campaign-level decision to confirm on the PR.
+
+## Note on this document's location
+
+The task specified `docs/plans/`. Two repo facts make that path fragile, so this file is **force-added** past `.gitignore`:
+- `.gitignore` line 52 (`plans/`) matches `docs/plans/` too — the file is git-ignored by default (`git add -f` used).
+- `docs/` is Storybook build output, **wiped on every `npm run build-storybook`** (CLAUDE.md). A future Storybook build will delete this file from the working tree (git history retains it).
+
+**If the operator wants this runbook to survive Storybook builds, relocate it** to a committed, Storybook-safe location — e.g. `solutions/developer-experience/` — or add a `!docs/plans/` negation to `.gitignore`. Left at the requested path per instruction; flagged here for transparency.
+
+---
+
+## Global Constraints
+
+- **Target version:** `eidotter@0.37.1` (see Decision above). Hard floor `0.31.0` if 0.29 is mandated.
+- **One repo, one branch, one PR.** Each consumer upgrade is isolated. Never bundle two consumers in one PR. The eidotter repo is **not** modified by this campaign (this plan doc is the only eidotter change).
+- **Smoke-test scope is the surface the consumer actually imports** — established by `grep -rhoE "from 'eidotter[^']*'" <src dirs>` at re-baseline, not by assumption. Do not test components the consumer doesn't use.
+- **`file:`-linked consumers are no-ops for version bumps.** `lifelines` (`file:../eidotter`) and `timeline` (`file:../../eidotter`) already resolve to eidotter HEAD; they need only a build + smoke-test against current, not a `package.json` edge bump.
+- **mgnt is NOT a consumer.** Confirmed: no `eidotter` reference in `mgnt` `package.json`/`src`/`app`. mgnt deliberately uses its own CGA `globals.css` (DMNC-1067). Remove it from the campaign; do not "upgrade" it.
+- **Preserve each repo's dependency-range style.** If a consumer pins caret (`^0.33.0`), keep caret (`^0.37.1`); if it pins exact, keep exact. Do not introduce `file:` links into published consumers.
+- **No `--no-verify`, no force-merges.** Each consumer PR goes green on that repo's own CI before merge.
+
+---
+
+## Section A — Reality reconciliation (audit snapshot vs on-disk 2026-06-21)
+
+The 2026-06-16 audit numbers in the issue are **5 days stale and have drifted**. Verified on-disk under `~/conductor/repos/` today:
+
+| Consumer | Issue says | On-disk now | Reality |
+|---|---|---|---|
+| tracker | 0.28 | `^0.28.0` (web only) | **Pending.** Lowest-risk: imports only `RetroEffects` + `eidotter/styles`. |
+| steuerdash | 0.20 (biggest gap) | **`^0.33.0`** | **Already upgraded past 0.29.** Real remaining work = graduate local `src/components/ui/` ports → eidotter imports (needs ≥0.37.1). See Task 2. |
+| rizomorf | done @ 0.29 | `^0.33.0` | Drifted up; re-confirm only. |
+| dmnc-online | done @ 0.29 | `^0.33.0` | Drifted up; re-confirm only. |
+| lifelines | (current) | `file:../eidotter` | HEAD-linked; build + smoke-test only. |
+| timeline | (current) | `file:../../eidotter` | HEAD-linked; build + smoke-test only. |
+| mgnt | 0.15 | **no eidotter dep** | **Not a consumer (DMNC-1067). Drop.** |
+| retroterm | 0.26 | not local | Execute in its own repo. |
+| calendar-365 | 0.24 | not local | Execute in its own repo. |
+| camp26-app | 0.24 | not local | Execute in its own repo. |
+| spacewar_landing | 0.22 | not local (≠ `spacewar-atv`, the tvOS game, which has no eidotter dep) | Execute in its own repo. |
+| Pomodoke | 0.15 | not local | Execute in its own repo. Highest risk. |
+| uxdmncde | 0.15 | not local | Execute in its own repo. Highest risk. |
+
+**Task 0 of execution is always a per-repo re-baseline** — never trust the audit number; re-read the consumer's `package.json` and import surface first.
+
+---
+
+## Section B — Cross-version watch-items matrix
+
+Only the items a consumer's band actually crosses matter. Bands are cumulative (a 0.15→0.37 upgrade crosses every row).
+
+| Landed in | Item | Breaking? | What to check in the consumer |
+|---|---|---|---|
+| **0.18 / 0.19** | Icon library swap `@untitledui-pro/icons` → `pixelarticons`; old SVG spritesheet removed | **Yes, if `<Icon>` used** | Only 12 public names exist: `Info, Warning, Error, Done, Check, Close, Chevron Up, Chevron Down, App, Cancel, Fullscreen, Add`. Any other name renders nothing. `Close` is a custom pixel-X; `Cancel` is a minus glyph (minimize semantics). |
+| 0.19 | `<Nav>` MENU text trigger (was hamburger); warm-tinted neutrals; `<Header>` added | Visual | Mobile nav trigger now reads "MENU". |
+| 0.20 | InlineLink, DosFigure, CmdPalette added | Additive | none |
+| **0.22** | Primary font → **Perfect DOS VGA 437** (`--typography-font-family-primary`) | Visual + override risk | If the consumer overrides `--typography-font-family-primary` or `@font-face`s its own, re-verify. Glyph metrics differ from Flexi/JetBrains. |
+| **0.22** | `<TimelineContainer>` no longer paints its own background | **Behaviour change** | Consumers relying on the implicit dark backdrop must wrap the timeline in a host element that sets `bg-dos-bg-primary`. |
+| 0.22.1 | `use-sync-external-store` externalised | Build fix | If a Vite consumer previously failed building eidotter ESM, this is the floor that fixes it. |
+| **0.22.2** | Perfect DOS VGA 437 **Win variant** (Latin-1 glyphs) | **Yes for non-ASCII** | German/accented content (ä ö ü ß) renders as wrong glyphs below 0.22.2. Any consumer with German copy must be ≥0.22.2 (0.37.1 satisfies). |
+| 0.23 | `<Footer linkComponent>` | Additive | none |
+| 0.24 | AIText / `data-provenance` | Additive | none |
+| **0.25** | **`eidotter/tailwind.preset.enhanced` REMOVED** | **Yes** | `grep -rn "tailwind.preset.enhanced"` in the consumer's tailwind config; switch to `require('eidotter/tailwind.preset')`. |
+| **0.26** | **Tailwind v4 build** of `dist/eidotter.css` | Conditional | Consumers on **Tailwind v3** that pipe vendor CSS through PostCSS (Next.js) break on `@layer` unless **≥0.26.1** (layer-flatten fix). 0.37.1 satisfies. Preset still works on TW 3 *and* 4. |
+| 0.27 | `<Skeleton>` added; `<Logo>` restyled (0.27.1, "Foundation Logomark"); sticky retro `<Header>` opacity fix | Additive + visual | Logo mark looks different (dotted ring). |
+| 0.28 / 0.29 | `<RetroEffects boot>` / `bootOnce` | Additive | Opt-in; no change unless adopted. |
+| 0.30 | a11y/behaviour fixes: InlineExpand height-clip, Timeline `[+]` zoom-in wired, Lightbox keyframes moved to shared sheet, mobile Nav `inert`/focus-trap | Fixes | Net-positive; re-verify InlineExpand/Lightbox/Nav if used. |
+| **0.31** | **Colour-system rationalization (DMNC-922/1059): all component colour routes through `--color-semantic-*`; default amber-mono theme bundled into `eidotter/styles`** | **Re-theme + subtle behaviour** | The campaign payoff: components now re-theme via `data-theme`. **Functional colours (`success/error/warning/info`, destructive Button) are amber-mono by default**; honest red/green/cyan appear only under colour themes. A consumer that relied on honest red/green leaking through the default theme will now see amber-mono. Visual no-op under amber-mono otherwise (Chromatic-verified upstream). Timeline dot `content-box` fix lands here too. |
+| 0.32 / 0.33 | `eidotter/shadcn.css` shim; light theme (`eidotter/themes/light.css`) | Additive, opt-in | none unless adopted. |
+| 0.34 | TimelineContainer `mode="master-detail"`; `<Button>` now emits stable `eidotter-btn` block class; Badge `info` → honest `text-info` cyan | Additive + minor visual | Badge `info` shifts toward cyan under colour themes (amber-mono unchanged). New `.eidotter-btn` override hook (note: `.eidotter-button` was never real). |
+| 0.35 | `<EmptyState>`, `<SectionHeading>` added | Additive | steuerdash port targets (Task 2). |
+| 0.36 | `<LabeledProgress>`, `<LedgerRow>`, `<Select>`, `<CopyButton>`, `<ChecklistRow>` added; 0.36.1 inline-code-in-AI legibility fix | Additive | steuerdash port targets (Task 2). Resolves the issue's "eidotter#349 Select + Progress glyph fixes" note — the div-bar `<LabeledProgress>` exists precisely because block-fill `<Progress>` `█`/`░` overruns the track in some fonts. |
+| **0.37 / 0.37.1** | Per-component RSC subpath exports `eidotter/components/<Name>`; **`tailwind-merge` moved to runtime `dependency`** | Additive + Next fix | Next.js **server-component** consumers can deep-import presentational primitives. 0.37.1 fixes `Module not found: tailwind-merge` for those deep imports. This is the floor that "unblocks steuerdash dropping its local server-primitive copies." |
+
+---
+
+## Section C — Generic per-consumer runbook (the template every Task instantiates)
+
+Run inside the **consumer's** repo, on a fresh branch. Replace `<consumer>` and `<band>` per Task.
+
+- [ ] **Step 1 — Re-baseline (never trust the audit number).**
+  ```bash
+  cd <consumer-repo>
+  git switch -c chore/eidotter-0.37.1
+  grep -m1 '"eidotter"' package.json                      # actual current version / link style
+  grep -rhoE "from 'eidotter[^']*'" src app 2>/dev/null | sort -u   # exact import surface
+  grep -rhoE "import .*from 'eidotter'" -A0 src app | grep -oE '\{[^}]*\}' | tr ',' '\n' | sort -u  # named symbols
+  grep -rn "tailwind.preset" tailwind.config.* 2>/dev/null # preset.enhanced check (0.25)
+  cat package.json | grep -E '"next"|"vite"|"tailwindcss"|"react"' # framework + TW major
+  ```
+  Record: current version, link style, framework, Tailwind major, and the **list of components/CSS imported**. The smoke-test in Step 5 covers exactly that list.
+
+- [ ] **Step 2 — Bump (skip for `file:`-linked repos).**
+  ```bash
+  npm install eidotter@0.37.1        # preserve caret vs exact: use --save-exact only if the repo pins exact
+  ```
+  For `file:`-linked repos (lifelines, timeline): no bump — just `npm install` to refresh the link, then go to Step 4.
+
+- [ ] **Step 3 — Apply band-specific breaking fixes** from Section B for the rows `<band>` crosses. Common ones:
+  - `0.25` crossed → replace `eidotter/tailwind.preset.enhanced` with `eidotter/tailwind.preset`.
+  - `0.26` crossed **and** Tailwind v3 + Next → 0.37.1 already ≥0.26.1, no action; just confirm the build doesn't error on `@layer`.
+  - `0.22` crossed **and** `<TimelineContainer>` used → wrap it in a `bg-dos-bg-primary` host.
+  - `0.18/0.19` crossed **and** `<Icon>` used → verify every `name=` is one of the 12 valid names.
+
+- [ ] **Step 4 — Build / typecheck.**
+  ```bash
+  npm run build        # Next: next build | Vite: tsc + vite build
+  # if a separate typecheck script exists:
+  npm run typecheck 2>/dev/null || npx tsc --noEmit
+  ```
+  Expected: clean build. A `Module not found: tailwind-merge` means a deep `eidotter/components/*` import on <0.37.1 — confirm 0.37.1 installed.
+
+- [ ] **Step 5 — Smoke-test the imported surface (visual + console).** Run the app (`npm run dev` / framework run skill) and verify, for each symbol recorded in Step 1:
+  - Renders without console errors or hydration warnings.
+  - **Fonts:** Perfect DOS VGA 437 loads (DOS glyphs, not serif fallback); accented chars correct if the app has non-English copy.
+  - **Theme:** with the app's `data-theme` (default amber-mono), colours are a visual no-op vs before; if the consumer uses a colour theme, functional colours now render honestly (intended).
+  - **CRT/boot:** if `RetroEffects`/`boot`/`bootOnce` used, the turn-on plays (and, for `bootOnce`, is suppressed on in-site navigation).
+  - **Timeline:** dots sit on the axis; background is present (Step 3 host wrap if needed).
+  - Capture a before/after screenshot of the main surface for the PR.
+
+- [ ] **Step 6 — Commit + PR (in the consumer repo).**
+  ```bash
+  git add package.json package-lock.json <any source fixes>
+  git commit -m "chore(deps): upgrade eidotter <old> → 0.37.1"
+  git push -u origin chore/eidotter-0.37.1
+  gh pr create --title "chore: upgrade eidotter to 0.37.1" --body "<band crossed, fixes applied, screenshots, smoke-test notes>"
+  ```
+
+- [ ] **Step 7 — Record outcome** in the DMNC-1065 rollup (Task 9): old version, new version, breaking fixes applied, PR link, smoke-test result.
+
+---
+
+## Task 1: tracker (0.28 → 0.37.1) — lowest risk, local
+
+**Repo:** `~/conductor/repos/tracker` (React Native + web variant; `package-lock.json`).
+**Surface (verified):** `src/components/CRTOverlay.web.tsx` only — `import 'eidotter/styles'` + `import { RetroEffects } from 'eidotter'`. The native bundle imports no eidotter (intentional). **No other eidotter symbol is used.**
+**Band crossed:** 0.28 → 0.37.1. Material rows for *this* surface: 0.31 (bundled amber-mono theme + semantic-role CSS — visual no-op under amber-mono), 0.29 (`bootOnce` available). RetroEffects API is backward-compatible across the whole band.
+
+- [ ] Run runbook Steps 1–7 with `<band>` = "0.28→0.37.1, RetroEffects + styles only".
+- [ ] Step 3: nothing to fix — no `<Icon>`, no `<TimelineContainer>`, no Tailwind preset, no font override expected. Confirm via the Step 1 grep.
+- [ ] Step 5 focus: the **web** CRT overlay only. Verify the CRT/scanline effect still renders and `dist/eidotter.css` (now Tailwind-v4-built + amber-mono-bundled) doesn't regress the overlay. Native bundle is unaffected — do not test it.
+- [ ] Optional value-add (confirm with operator): adopt `bootOnce` if the web shell wants the once-per-tab turn-on (matches rizomorf/betamorf adoption noted in the issue).
+
+**Done when:** web build is green, CRT overlay renders unchanged, PR opened.
+
+---
+
+## Task 2: steuerdash (0.33 → 0.37.1 + graduate local ports) — highest value, local
+
+**Repo:** `~/conductor/repos/steuerdash` (Next.js, `next.config.ts`, `package-lock.json`, currently `^0.33.0`).
+**Why this is the real steuerdash work:** the audit's "0.20 → 0.29" is obsolete. steuerdash is already at 0.33. Its `src/components/ui/` holds **local port-candidates**, each header-tagged `// eidotter:<Name> — port candidate DMNC-xxx`:
+`SectionHeading` (DMNC-855), `EmptyState` (859), `Select` (860), `CopyButton` (858), `ChecklistRow` (856), `LedgerRow` (857), `LabeledProgress` (861) — **plus `tone.ts`**. eidotter **0.35** shipped EmptyState + SectionHeading and **0.36** shipped the other five. **Every port-candidate has graduated upstream.** `0.37.1` then moved `tailwind-merge` to a runtime dependency specifically so Next server components can deep-import these without `Module not found` — the changelog names this as "unblocks steuerdash dropping its local server-primitive copies (DMNC-854 part 3)."
+
+**Band crossed:** 0.33 → 0.37.1: rows 0.34 (Button `eidotter-btn` block class; Badge `info` honest cyan — steuerdash is the honest-functional-colour consumer that surfaced DMNC-1111), 0.35/0.36 (the ports), 0.36.1 (inline-code-in-AI legibility — relevant if steuerdash renders AI-marked prose with inline `<code>`), 0.37/0.37.1 (per-component RSC exports + tailwind-merge fix).
+
+- [ ] **Step 1 (re-baseline):** in addition to the standard grep, list current local-port usages:
+  ```bash
+  grep -rn "from '@/components/ui/\(Select\|EmptyState\|SectionHeading\|LedgerRow\|CopyButton\|ChecklistRow\|LabeledProgress\)'" src app
+  ```
+  Record every import site — each becomes a swap target.
+- [ ] **Step 2:** `npm install eidotter@0.37.1`.
+- [ ] **Step 3 (graduation — the core task):** for each graduated component, swap the local import for the eidotter one. Two valid import styles:
+  - Client components: `import { Select, EmptyState, SectionHeading, LedgerRow, CopyButton, ChecklistRow, LabeledProgress } from 'eidotter'`.
+  - **Server components:** deep-import per component, e.g. `import { SectionHeading } from 'eidotter/components/SectionHeading'` (PascalCase) — presentational primitives (SectionHeading, EmptyState, LabeledProgress, LedgerRow) render on the server; interactive ones (Select, CopyButton, ChecklistRow) carry `'use client'` and resolve as client references. This is exactly what 0.37 enables.
+  - **Before deleting any `src/components/ui/<Name>.tsx`, diff its props/behaviour against the eidotter component.** The ports were generalised on the way into eidotter (e.g. LedgerRow dropped money-specific currency formatting — pass a pre-formatted `value`; CopyButton/ChecklistRow default to **English** aria-labels where the steuerdash source was German). Adapt call sites for any prop/locale delta; keep `tone.ts` if eidotter has no equivalent (the file note says ChecklistRow tones don't map to a Badge counterpart).
+  - Delete each local port only once its eidotter replacement compiles and renders identically.
+- [ ] **Step 4 (build):** `npm run build`. Watch specifically for `Module not found: Can't resolve 'tailwind-merge'` (would mean <0.37.1) and any RSC `'use client'` boundary error on the interactive components.
+- [ ] **Step 5 (smoke-test):** verify each swapped surface in the running app — value rows, checklist toggles (keyboard-operable), copy buttons (`[cp]`→`[OK]`), the labelled progress bars (fill width-accurate, no glyph overrun — the reason LabeledProgress is a div-bar), empty states, section headings. Confirm Badge `info` (if used) reads as intended under steuerdash's theme. Confirm any AI-marked prose with inline `<code>` is legible (0.36.1).
+- [ ] **Step 6/7:** commit "chore(deps): eidotter 0.33→0.37.1 + graduate local ui/ ports to eidotter (DMNC-854 pt3)", PR, record.
+
+**Done when:** local `src/components/ui/` port-candidates are removed (or explicitly retained with a noted reason), `next build` is green, the swapped surfaces render correctly, PR opened. **This closes the issue's steuerdash sub-thread** ("re-check #349 Select + Progress glyph fixes, may let its ui/ port-candidates graduate") — they graduate.
+
+---
+
+## Task 3: retroterm (0.26 → 0.37.1) — remote
+
+**Repo:** not in this worktree — execute in retroterm's own repo (likely its own conductor `claude-ready` session).
+**Band crossed:** 0.26 → 0.37.1. Font swap (0.22) and Tailwind v4 (0.26) are **already absorbed** at 0.26, so the live rows are: 0.27 (Logo restyle/Skeleton), **0.31 (semantic-role re-theming — the payoff)**, 0.34 (Button block class, Badge info), 0.36.1, 0.37. Expected surface for a "retro terminal" app: `Terminal`, `CommandPrompt`, `RetroEffects`, possibly `Header`/`Nav`. Terminal/CommandPrompt are the BEM-legacy components (px bitmap sizing) — unaffected by the Tailwind-side token sweep.
+
+- [ ] Run runbook Steps 1–7 in retroterm's repo with `<band>` = "0.26→0.37.1".
+- [ ] Step 3: check the 0.27.1 sticky retro `<Header>` fix if a sticky header is used; verify Logo restyle is acceptable if `<Logo>`/brand is shown.
+- [ ] Step 5 focus: Terminal window chrome, CommandPrompt focus ring (0.30 added `:focus-visible`), RetroEffects, and theme switching if retroterm exposes CGA modes (now driven by the bundled themes since 0.31).
+
+**Risk:** low–medium. No font/Tailwind-major migration in-band.
+
+---
+
+## Task 4: calendar-365 (0.24 → 0.37.1) — remote
+
+**Repo:** not local — execute in its own repo.
+**Band crossed:** 0.24 → 0.37.1. **Live breaking rows:** **0.25 (preset.enhanced removed)**, **0.26 (Tailwind v4 — ensure the consumer's TW major; ≥0.26.1 satisfied by 0.37.1)**, 0.27 (Logo/Skeleton), **0.31 (re-theming)**, 0.34, 0.36.1, 0.37.
+
+- [ ] Run runbook Steps 1–7 with `<band>` = "0.24→0.37.1".
+- [ ] Step 1 must capture the **Tailwind major** and whether `tailwind.preset.enhanced` is imported — both are the likely breakers in this band.
+- [ ] Step 3: migrate `preset.enhanced` → `preset`; if Tailwind v3 + Next, confirm no `@layer` build error (0.26.1 floor met).
+- [ ] Step 5: standard, scoped to imported surface.
+
+**Risk:** medium (preset + Tailwind-build rows).
+
+---
+
+## Task 5: camp26-app (0.24 → 0.37.1) — remote
+
+**Repo:** not local — execute in its own repo. **Same band and same breaking rows as Task 4** (0.25 preset.enhanced, 0.26 Tailwind v4, 0.31 re-theming).
+
+- [ ] Run runbook Steps 1–7 with `<band>` = "0.24→0.37.1", applying the Task 4 breaking-fix checklist (preset.enhanced swap; Tailwind-build sanity; re-theming visual diff).
+
+**Risk:** medium.
+
+---
+
+## Task 6: spacewar_landing (0.22 → 0.37.1) — remote
+
+**Repo:** not local — execute in its own repo. **This is the landing-page repo, not `spacewar-atv`** (the tvOS SpriteKit game, which consumes Swift tokens, not the npm package — do not touch it).
+**Band crossed:** 0.22 → 0.37.1. **Live rows:** **0.22.2 (Latin-1 font fix — relevant if any non-ASCII copy)**, 0.23/0.24 (additive), **0.25 (preset.enhanced removed)**, **0.26 (Tailwind v4)**, 0.27.1 (Logo restyle), **0.31 (re-theming)**, 0.34, 0.37.
+
+- [ ] Run runbook Steps 1–7 with `<band>` = "0.22→0.37.1".
+- [ ] Step 3: preset.enhanced swap; Tailwind-build sanity; if `<TimelineContainer>` appears, apply the 0.22 background-host wrap; verify Logo restyle is acceptable on the landing brand mark.
+- [ ] Step 5: pay attention to the brand/hero (Logo restyle) and any German/accented copy (Latin-1).
+
+**Risk:** medium.
+
+---
+
+## Task 7: Pomodoke (0.15 → 0.37.1) — remote, highest risk
+
+**Repo:** not local — execute in its own repo. ~A year behind; **expect breaking-API risk** (issue's own warning).
+**Band crossed:** 0.15 → 0.37.1 — crosses **every** Section B row, including the two biggest legacy hazards:
+- **0.18/0.19 Icon swap** (`@untitledui-pro/icons` → pixelarticons; spritesheet removed): any `<Icon name=...>` outside the 12 valid names breaks.
+- **0.22 font swap + TimelineContainer background change**, **0.25 preset.enhanced removal**, **0.26 Tailwind v4**, **0.31 re-theming**.
+
+- [ ] Run runbook Steps 1–7 with `<band>` = "0.15→0.37.1 (full band)".
+- [ ] **Step 1 must be thorough** — enumerate every `<Icon name=...>` value, every `<TimelineContainer>` usage, the Tailwind major, preset import style, and any `--typography-font-family-*` / `@font-face` overrides.
+- [ ] **Step 3 checklist (all likely to fire):**
+  - Icon: map every `name=` to the 12 valid names; replace/remove invalid ones.
+  - TimelineContainer: wrap in a `bg-dos-bg-primary` host.
+  - Tailwind: preset.enhanced → preset; confirm v4 build (≥0.26.1).
+  - Font: re-verify any font override against Perfect DOS VGA 437.
+- [ ] **Step 4–5:** budget for iteration; build will likely fail first pass on Icon names and/or the preset import. Smoke-test the full imported surface.
+
+**Risk:** high. Consider doing this one **after** Tasks 4/5/6 so their preset/Tailwind learnings transfer.
+
+---
+
+## Task 8: uxdmncde (0.15 → 0.37.1) — remote, highest risk
+
+**Repo:** not local — execute in its own repo. **Identical band and hazard profile to Task 7** (full 0.15→0.37.1; Icon swap, font swap, Tailwind v4, preset.enhanced, re-theming).
+
+- [ ] Run runbook Steps 1–7 with `<band>` = "0.15→0.37.1 (full band)", applying the **Task 7 Step-3 checklist verbatim** (Icon name audit; TimelineContainer host wrap; preset.enhanced→preset; Tailwind v4 build; font-override re-verify).
+
+**Risk:** high. Sequence after Task 7 so the legacy-band fixes are already proven.
+
+---
+
+## Task 9: Re-confirm the "done" set + campaign rollup + tracking
+
+These are already at/above target but drifted since the audit — verify, don't re-upgrade unnecessarily.
+
+- [ ] **rizomorf** (`^0.33.0`) and **dmnc-online** (`^0.33.0`): optionally bump 0.33 → 0.37.1 for portfolio uniformity (band 0.33→0.37.1: ports + RSC exports, all additive — low risk). At minimum, record current version in the rollup. Decide with operator whether "current" means "latest" for this campaign.
+- [ ] **lifelines** (`file:../eidotter`) and **timeline** (`file:../../eidotter`): no bump. Run a build + smoke-test against current eidotter HEAD to confirm no HEAD-vs-published drift broke them; record result.
+- [ ] **dmnctech, eidotter-home, betamorf** (issue says done): re-confirm their on-disk version in their own repos; record.
+- [ ] **mgnt:** record as **N/A — not a consumer (DMNC-1067)**; remove from the campaign tracker so it stops re-appearing in audits.
+- [ ] Build the **campaign status table** (consumer | old → new | breaking fixes | PR | smoke result) and post it to DMNC-1065.
+- [ ] Update the eidotter consumer-audit digest (`digests/eidotter-consumer-audit`) source so the next audit reflects: mgnt excluded; steuerdash port-graduation done; target = current latest, not a frozen 0.29.
+- [ ] **Update auto-memory:** add a `project` memory noting (a) the campaign target is "current latest (0.37.1+), not the frozen 0.29 — re-themeability needs ≥0.31", and (b) steuerdash's `ui/` ports graduated to eidotter 0.35/0.36 and were dropped at 0.37.1. Link `[[mgnt-ds-status]]`.
+
+**Done when:** every consumer has a recorded final state (upgraded-with-PR, already-current, file-linked, or N/A), DMNC-1065 carries the status table, and the audit source no longer lists mgnt or a stale 0.29 target.
+
+---
+
+## Self-Review
+
+**1. Spec coverage** — every consumer named in the issue is accounted for: tracker (T1), retroterm (T3), calendar-365 (T4), camp26-app (T5), spacewar_landing (T6), steuerdash (T2), mgnt (dropped, T9), Pomodoke (T7), uxdmncde (T8); plus the "done"/drifted set and file-linked repos (T9). The issue's two explicit sub-notes are handled: the DMNC-1059 re-themeability sequencing → the Decision section + Section B row 0.31; the steuerdash "#349 Select+Progress / ui port graduation" → Task 2.
+
+**2. Placeholder scan** — no "TBD"/"handle edge cases"/"similar to Task N" placeholders; the two high-risk legacy tasks (7,8) each carry the explicit Step-3 checklist rather than cross-referencing. Commands are concrete (`grep`, `npm install eidotter@0.37.1`, `npm run build`, `gh pr create`).
+
+**3. Consistency** — single target version (`0.37.1`) used throughout; version-band rows in Section B are the single source the per-consumer Tasks point back to; component/port names match the changelog (SectionHeading/EmptyState @0.35; Select/CopyButton/ChecklistRow/LedgerRow/LabeledProgress @0.36; per-component RSC exports + tailwind-merge @0.37/0.37.1).
+
+**Known limitation (not a placeholder):** Tasks 3–8 operate on repos not present in this worktree, so their re-baseline (runbook Step 1) is mandatory and may reveal a surface/framework that shifts the band-fix list — the runbook is built to surface that per-repo rather than assume it. Tasks 1 and 2 (tracker, steuerdash) are fully grounded in verified on-disk inspection.


### PR DESCRIPTION
## Summary

Planning deliverable for **[DMNC-1065](https://linear.app/lizomorf/issue/DMNC-1065/eidotter-consumer-upgrade-campaign-029)** — the eidotter consumer upgrade campaign. Adds one runbook document; **no source/config changes**.

📄 `docs/plans/2026-06-21-dmnc-1065-plan.md`

## The one decision to confirm: target version

The issue says **"→ 0.29"**. Planning found 0.29 is the wrong target:

1. **eidotter is already at `0.37.1`** — 0.29 is 8 minors stale.
2. **The re-themeability the issue sequences the token sweep (DMNC-1059) to unlock only fully landed in `0.31.0`** — 0.29 delivers *none* of it. 0.30 was a partial cleanup.
3. **Consumers have drifted past 0.29 since the 2026-06-16 audit** — pinning them to 0.29 would be a downgrade.

➡️ **Plan recommends targeting `0.37.1`** (hard floor 0.31 if 0.29 is mandated). 0.37.1 also specifically unblocks steuerdash.

## Key findings (audit was 5 days stale)

| | Finding |
|---|---|
| **steuerdash** | Already at **0.33** (not 0.20). Its `src/components/ui/` local ports (SectionHeading, EmptyState, Select, CopyButton, ChecklistRow, LedgerRow, LabeledProgress) **all graduated to eidotter 0.35/0.36** and can be dropped at 0.37.1 (which moved `tailwind-merge` to a runtime dep precisely to unblock this). This closes the issue's steuerdash sub-thread. |
| **mgnt** | **Not an eidotter consumer** (DMNC-1067) — zero references in `package.json`/`src`. Dropped from the campaign. |
| **tracker** | Imports only `RetroEffects` + `eidotter/styles` (web variant). Confirmed low-risk. |
| **rizomorf / dmnc-online** | Already at 0.33 (issue listed them done @ 0.29). |
| **lifelines / timeline** | `file:`-linked to eidotter HEAD — build + smoke-test only, no bump. |

## What the plan contains

- **Section A** — audit-vs-on-disk reconciliation table.
- **Section B** — cross-version watch-items matrix (0.15→0.37.1): Icon swap (0.18/19), font swaps (0.22), `tailwind.preset.enhanced` removal (0.25), Tailwind v4 (0.26), TimelineContainer background change (0.22), the 0.31 semantic-role re-theming, RSC exports (0.37).
- **Section C** — generic per-consumer runbook (re-baseline → bump → build → smoke-test → PR).
- **Tasks 1–9** — per-consumer, risk-ranked (tracker/steuerdash fully grounded in on-disk inspection; the rest carry a mandatory per-repo re-baseline).

## Note on file location

`docs/plans/` is caught by the `plans/` `.gitignore` rule and is wiped on every `npm run build-storybook`, so the file is **force-added** and flagged in-doc for relocation (e.g. `solutions/`) if it should survive Storybook builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)