### PR TITLE
fix(timeline): replace min-h-[200px] arbitrary value with CSS custom property (DMNC-883)

### DIFF
--- a/src/components/TimelineContainer/components/TimelineContainer.css
+++ b/src/components/TimelineContainer/components/TimelineContainer.css
@@ -1,7 +1,9 @@
 /* TimelineContainer — main orchestrator component */
 
 .eidotter-timeline-container {
+  --sizing-timeline-min-height: 200px;
   container: timeline / inline-size;
+  min-height: var(--sizing-timeline-min-height);
 }
 
 .eidotter-timeline-container:focus-visible {

--- a/src/components/TimelineContainer/components/TimelineContainer.tsx
+++ b/src/components/TimelineContainer/components/TimelineContainer.tsx
@@ -350,7 +350,7 @@ export const TimelineContainer: React.FC<TimelineContainerProps> = ({
       ref={containerRef}
       {...props}
       className={cn(
-        'font-dos text-dos-text-brand p-4 min-h-[200px]',
+        'font-dos text-dos-text-brand p-4',
         'eidotter-timeline-container',
         isStatic && 'eidotter-timeline-container--static',
         isFeed && 'eidotter-timeline-container--feed',


### PR DESCRIPTION
## Summary

- Removes `min-h-[200px]` Tailwind arbitrary value from `TimelineContainer` root `className`
- Declares `--sizing-timeline-min-height: 200px` as a CSS custom property on `.eidotter-timeline-container`
- Uses `min-height: var(--sizing-timeline-min-height)` in the same CSS rule

Spotted in PR #323 review (kept out of scope there). Addresses both convention drifts noted in DMNC-883:
1. `text-cga-amber` → semantic token (already done by the bg-removal PR; `text-dos-text-brand` was in place)
2. `min-h-[200px]` → named CSS custom property with consumer-override capability

The custom property approach keeps the token-ref lint green (declared before referenced in the same file) and gives consumers a named override hook without requiring a new global design token.

## Test plan

- [x] `npm run test -- --testPathPatterns="TimelineContainer"` — 138 tests pass
- [x] `node scripts/lint-token-refs.mjs` — clean
- [x] `npm run lint` — clean
- [x] Pre-existing failing tests (`icon barrels`, `package-exports`) confirmed pre-existing (same failures without this diff)

Fixes: DMNC-883

🤖 Generated with [Claude Code](https://claude.com/claude-code)