### PR TITLE
docs(icon,input): fix doc/code drift — Icon Close glyph, Input token table (DMNC-1064)

### DIFF
--- a/src/components/Icon/components/IconDocs.mdx
+++ b/src/components/Icon/components/IconDocs.mdx
@@ -22,7 +22,7 @@ art glyphs match eidotter's DOS aesthetic — no further styling needed.
 | `Warning` | Alert diamond | `WarningDiamond` |
 | `Error` | Alert square | `SquareAlert` |
 | `Done` / `Check` | Checkmark | `Check` |
-| `Close` | Slashed circle (see note below) | `Cancel` |
+| `Close` | Custom pixel-art ✕ mark | custom `PixelX` |
 | `Chevron Up` | Chevron pointing up | `ChevronUp` |
 | `Chevron Down` | Chevron pointing down | `ChevronDown` |
 | `App` | DOS window frame | `WindowFrame` |
@@ -30,7 +30,7 @@ art glyphs match eidotter's DOS aesthetic — no further styling needed.
 | `Fullscreen` | Expand — Terminal maximize control | `Expand` |
 | `Add` | Plus | `Plus` |
 
-> **Visual note on `Close`:** pixelarticons v2 has no plain X/Close glyph. The `Close` name maps to pixelarticons' `Cancel` component, which renders as a slashed circle (the idiomatic DOS dismissal symbol). Earlier versions of eidotter rendered a line-art X via `@untitledui-pro/icons` — consumers upgrading from pre-v0.19 will see a visible shape change on any dismiss/close button. No prop API change.
+> **Visual note on `Close`:** pixelarticons v2 has no standalone X/close glyph, so `Close` renders a custom pixel-art ✕ mark (the `PixelX` component, defined inline in `Icon.tsx`). Visually it renders as a pixel-grid diagonal cross, not the slashed circle that the pixelarticons `Cancel` component would produce.
 
 > **Visual note on `Cancel`:** despite the name, this renders a minus glyph intended for the Terminal window's minimize control — **not** an abort/cancel action. Use `Close` for dismissal. A future release may rename `Cancel` → `Minimize` for clarity.
 

--- a/src/components/Input/components/InputDocs.mdx
+++ b/src/components/Input/components/InputDocs.mdx
@@ -42,8 +42,7 @@ on focus to maintain validation visibility. Sets `aria-invalid="true"` automatic
 
 ### Disabled
 
-Reduced opacity (0.5), `not-allowed` cursor. Background remains
-`--color-semantic-background-primary` to keep the dormant terminal feel.
+Reduced opacity (0.5), `not-allowed` cursor. Background stays transparent to keep the dormant terminal feel.
 
 ### Placeholder
 
@@ -101,17 +100,15 @@ Works seamlessly with native forms and form libraries:
 
 | Token | Purpose |
 |-------|---------|
-| `--color-semantic-background-primary` | Input background |
-| `--color-semantic-text-primary` | Input text color |
+| `--color-semantic-text-brand` | Input and label text color |
+| `--color-semantic-text-muted` | Description text color |
+| `--color-semantic-text-error` | Error message text color |
 | `--color-semantic-text-disabled` | Placeholder text color |
 | `--color-semantic-border-default` | Default border |
 | `--color-semantic-border-focus` | Focus border |
 | `--color-semantic-status-error` | Error variant border |
 | `--shadow-glow-sm` | Focus phosphor glow |
-| `--border-width-medium` | Border thickness |
 | `--typography-font-family-primary` | DOS monospace font |
-| `--typography-font-size-text-md` | Input font size |
-| `--spacing-2` | Input padding |
 | `--duration-normal` | Border transition (200ms) |
 | `--duration-slow` | Glow transition (400ms) |
 


### PR DESCRIPTION
## Summary

- **Icon**: `Close` description was "slashed circle (Cancel)" in the table and note. Code has used a custom `PixelX` pixel-art ✕ mark since v0.19.0, not pixelarticons `Cancel`. Updated the table row and visual note; trimmed changelog language and SVG internals from the consumer-facing note.
- **Input**: Token table had 4 phantom entries (`--color-semantic-background-primary`, `--color-semantic-text-primary`, `--border-width-medium`, `--spacing-2`) — none consumed by the component. Added 2 missing real tokens (`--color-semantic-text-muted`, `--color-semantic-text-error`). Fixed Disabled state prose that referenced the phantom background token.

Closes DMNC-1064.

## Test plan

- [ ] `src/components/Icon/components/IconDocs.mdx` — table row and visual note match `Icon.tsx` `ICON_MAP` (line 48: `'Close': PixelX`)
- [ ] `src/components/Input/components/InputDocs.mdx` — every token in the table has a corresponding `var(--*)` reference in `Input.css` or a `dos-*` Tailwind class in `Input.tsx`
- [ ] Storybook build passes (docs-only change, no runtime impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)