### PR TITLE
fix(CommandPrompt): render placeholder fully + clean cursor when empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eidotter",
-  "version": "0.37.1",
+  "version": "0.37.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eidotter",
-      "version": "0.37.1",
+      "version": "0.37.2",
       "license": "CC-BY-NC-4.0",
       "dependencies": {
         "pixelarticons": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.37.1",
+  "version": "0.37.2",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",

--- a/src/components/CommandPrompt/components/CommandPrompt.css
+++ b/src/components/CommandPrompt/components/CommandPrompt.css
@@ -64,6 +64,14 @@
   display: none;
 }
 
+/* When a placeholder is showing (empty input), the placeholder fills the line —
+   hide the trailing block cursor so it doesn't dangle after the hint text.
+   The block returns as soon as the user types. Inputs without a placeholder
+   are unaffected (:placeholder-shown never matches). */
+.command-prompt__input:placeholder-shown + .command-prompt__cursor {
+  display: none;
+}
+
 /* High contrast mode support — no font-weight override: Perfect DOS VGA 437
    is single-weight. Emphasis comes from thicker borders and outlines. */
 @media (prefers-contrast: high) {

--- a/src/components/CommandPrompt/components/CommandPrompt.tsx
+++ b/src/components/CommandPrompt/components/CommandPrompt.tsx
@@ -93,7 +93,7 @@ export const CommandPrompt: React.FC<CommandPromptProps> = ({
           placeholder={placeholder}
           disabled={disabled}
           aria-label="Command input"
-          size={value.length || 1}
+          size={value.length || placeholder?.length || 1}
         />
         <span className="command-prompt__cursor" aria-hidden="true">█</span>
       </div>


### PR DESCRIPTION
## Problem
`CommandPrompt`'s input auto-sizes to its content (`size={value.length || 1}`), so an **empty** input is ~1ch wide and any `placeholder` is clipped to a single character (renders as a "Tt"-ish artifact). Consumers therefore can't use the placeholder as a hint — dmnc.tech had to render the hint as a separate line below the prompt.

There's also a cursor quirk: the fake block cursor (`█`) sits after the content, so with a placeholder it would dangle at the end of the hint.

## Fix (backwards-compatible)
- `size={value.length || placeholder?.length || 1}` — an empty input sizes to its placeholder, so the placeholder renders fully.
- `.command-prompt__input:placeholder-shown + .command-prompt__cursor { display: none }` — hide the trailing block cursor while the placeholder is showing; it returns as soon as the user types.

Consumers **without** a placeholder are unchanged: `:placeholder-shown` never matches and `size` falls back to `value.length || 1`.

## Verification
- `npx jest src/components/CommandPrompt` → 19/19 pass.
- End-to-end browser verification in a consumer (dmnc.tech) pending the local build (in progress).

## Consumers
First consumer: dmnc.tech (replacing a below-prompt hint line with a real placeholder). Benefits any surface using `CommandPrompt` with a placeholder (eidotter-home, etc.).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>