### PR TITLE
docs(plan): Table component implementation plan (DMNC-594)

### DIFF
--- a/docs/plans/2026-06-26-dmnc-594-plan.md
+++ b/docs/plans/2026-06-26-dmnc-594-plan.md
@@ -1,0 +1,1707 @@
+# Table Component Implementation Plan (DMNC-594)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a DOS-themed `<Table>` data-display component to eidotter with sorting, filtering, pagination, and row selection, built on React Aria Components' Table primitives and styled with eidotter Tailwind tokens + phosphor/scanline CSS.
+
+**Architecture:** A single **data-driven** `<Table columns={...} data={...} />` component (the most-requested shape for the `mgnt`/`steuerdash` dashboards) that internally renders React Aria Components (RAC) `Table/TableHeader/Column/TableBody/Row/Cell`. RAC supplies all keyboard nav, focus, `aria-sort`, selection semantics, and roles for free. Sort/filter/paginate are **managed client-side by default** over the supplied `data`, with controlled props + `onChange` callbacks and per-dimension `manual*` flags for server-side data. DOS aesthetic (scanline row striping, phosphor hover glow) lives in `Table.css`; everything else is `dos-*` Tailwind utilities + `cn()`.
+
+**Tech Stack:** React 18, TypeScript, `react-aria-components` `^1.16.0` (already a dependency), Tailwind v4 preset (`dos-*` utilities), Jest + React Testing Library + `@testing-library/user-event`, Storybook.
+
+## Global Constraints
+
+- **No new design tokens.** Use only existing tokens/utilities. Token JSON is frozen for this work; `build.yml` fails if `tokens.css`/`theme.*.css`/`tailwind.preset.cjs` drift. Reuse: `--effects-scanline-light` (`rgba(255,176,0,0.05)`), `--effects-scanline-dark` (`rgba(255,176,0,0.02)`), `--shadow-glow-sm`, `--color-cga-amber-glow`, `--color-semantic-*`, `--duration-*`.
+- **No hardcoded hex / no arbitrary Tailwind colors / no `rgba()` borders / no `rounded-full|xl|2xl`.** Use `bg-dos-*`, `text-dos-*`, `border-dos-*`, `shadow-dos-*`, `rounded-dos-sm`. In `Table.css`, raw `var(--*)` references to declared tokens are allowed (that is how phosphor effects are expressed).
+- **`text-dos-text-secondary` only on amber/light backgrounds** (it resolves to near-black `#020003`). Header band uses it because the header sits on an amber/brand fill.
+- **`'use client'` is mandatory** at the top of `Table.tsx` (it uses hooks + RAC + `on*` handlers). `scripts/sync-client-directives.mjs --check` is a CI gate; run `node scripts/sync-client-directives.mjs` to apply.
+- **Every animation needs `@media (prefers-reduced-motion: reduce)` and glow neutralization under `@media (prefers-contrast: high)`.** Animate only `transform`/`opacity`/`box-shadow`/`text-shadow` — never layout props.
+- **80% Jest coverage threshold** (branches/functions/lines/statements) is enforced globally.
+- **CI order that must stay green** (`.github/workflows/build.yml`): token freshness → `npm run lint-tokens` → `npm run lint` (max-warnings 0) → `sync-client-directives --check` → `npm run build` (emits `dist/components/Table/index.{js,d.ts}`) → `node scripts/assert-rsc-safety.mjs` → `npm test -- --ci` → `npm run build-storybook` → `npm run test-a11y` (axe).
+- **No forwardRef on `Table`.** It is a generic function component (`function Table<T extends object>(props)`); forwardRef erases generics and RAC's `<Table>` root needs no exposed ref for these use cases. (Eidotter precedent: `Select` is a plain `React.FC`.)
+- **V.37 class conventions:** stable block class `eidotter-table`, BEM elements `eidotter-table__*`, modifiers `eidotter-table--*`. Variant CSS prefixed to avoid consumer collisions.
+
+---
+
+## Reference Facts (read before starting)
+
+- **RAC selection pattern:** with `selectionMode` set, RAC renders selection via a `<Checkbox slot="selection" />` placed in a header `<Column>` (select-all) and in each `<Row>`'s first `<Cell>`. We use **RAC's own `Checkbox`** (imported from `react-aria-components`) styled with eidotter classes — it is the documented, reliable path and avoids coupling to eidotter `<Checkbox>`'s internal prop forwarding. (Reusing eidotter `<Checkbox>` is a possible future refactor; only do it after confirming it forwards `slot`.)
+- **RAC sort pattern:** `<Table sortDescriptor onSortChange>` + `<Column allowsSorting>`. RAC sets `aria-sort` on the `<th>` and exposes `{ allowsSorting, sortDirection }` via `Column`'s render-function children. RAC does **not** sort data — we sort in `onSortChange`/derivation. `SortDescriptor = { column: Key; direction: 'ascending' | 'descending' }`.
+- **RAC collections need keys:** wrap each visible row as `{ id: getRowId(row), row }` and pass that array to `<TableBody items={...}>`; never clobber the consumer's data shape.
+- **Pagination is a sibling footer**, not part of the RAC collection — we render the current slice and own `page`/`pageSize` state. Page-size uses eidotter `<Select>` (`value`/`options`/`onChange`/`aria-label`). Prev/Next/page buttons use eidotter `<Button>`.
+- **Sort indicator** uses eidotter `<Icon name="Chevron Up" | "Chevron Down" />` (valid pixelarticons names).
+- **Existing data-display siblings** for tone/structure reference: `src/components/Tabs/`, `src/components/FilterBar/`, `src/components/LedgerRow/`.
+- **Path alias:** `@` → `./src`. `cn` lives at `src/utils/cn.ts` (`import { cn } from '../../../utils/cn'`).
+
+> **Note on plan location:** This file lives under `docs/plans/` per the task instruction so it can be committed and PR'd. Be aware `docs/` is wiped on every `npm run build-storybook` (CLAUDE.md). The plan's permanent home in git is this PR's history; do not rely on the working-tree copy surviving a Storybook build.
+
+---
+
+## File Structure
+
+```
+src/components/Table/
+├── index.ts                          # Create — public API barrel: export * from './components'
+├── components/
+│   ├── index.ts                      # Create — re-export Table + types
+│   ├── Table.tsx                     # Create — 'use client'; generic data-driven component
+│   ├── Table.css                     # Create — scanline striping + phosphor hover glow + a11y media queries
+│   ├── tableUtils.ts                 # Create — pure helpers: getCellValue/defaultFilter/applyFilter/applySort/paginate/getPageCount
+│   ├── tableUtils.test.ts            # Create — unit tests for the pure helpers
+│   ├── Table.test.tsx                # Create — component tests (render/sort/filter/paginate/select/aesthetic)
+│   └── Table.stories.tsx             # Create — Storybook stories + registry link
+src/index.ts                          # Modify — add Table value export (~line 47 region) + type exports (~line 121 region)
+src/components/registry.ts            # Modify — add `Table` entry to componentRegistry (after `Switch`/alphabetical-ish, near other entries)
+```
+
+**Scope decision (YAGNI):** v1 ships only the data-driven API. A composition API (`Table.Header`/`Table.Row`/`Table.Cell`) is explicitly **out of scope** — note it as a future enhancement in the registry changelog, do not build it now.
+
+---
+
+## Public Type Surface (defined in Task 1, consumed by later tasks)
+
+```ts
+import type { Selection, SortDescriptor } from 'react-aria-components';
+
+export type { Selection, SortDescriptor };
+
+export type TableSize = 'sm' | 'md' | 'lg' | 'small' | 'medium' | 'large';
+export type TableAlign = 'left' | 'center' | 'right';
+export type RowKey = string | number;
+
+export interface TableColumn<T> {
+  /** Unique column id. Also used as `SortDescriptor.column` and as the default data accessor key. */
+  id: string;
+  /** Header content. */
+  header: React.ReactNode;
+  /** Marks the primary cell of each row for screen readers (exactly one column should set this). */
+  isRowHeader?: boolean;
+  /** Enable click-to-sort on this column. */
+  allowsSorting?: boolean;
+  /** Cell text alignment. Default 'left'. */
+  align?: TableAlign;
+  /** Fixed column width (CSS length or px number). */
+  width?: string | number;
+  /** Extract the raw value used for sorting/filtering/default rendering. Default: `row[id]`. */
+  accessor?: (row: T) => React.ReactNode;
+  /** Custom cell renderer. Falls back to the accessor value. (renderCell output is NOT used for filtering/sorting.) */
+  renderCell?: (row: T) => React.ReactNode;
+  /** Custom sort comparator for this column. Default: numeric/date/locale-string aware. */
+  sortComparator?: (a: T, b: T) => number;
+}
+
+export interface TableProps<T extends object> {
+  columns: TableColumn<T>[];
+  data: T[];
+  /** Stable row id. Default: `row.id`. */
+  getRowId?: (row: T) => RowKey;
+
+  /** Presentation */
+  size?: TableSize;          // default 'md'
+  striped?: boolean;         // default true — scanline row striping
+  title?: React.ReactNode;   // card header band title
+  description?: React.ReactNode;
+  caption?: React.ReactNode; // visually-hidden <caption> fallback when no title
+  emptyState?: React.ReactNode; // default 'No data'
+  className?: string;
+  'aria-label'?: string;
+
+  /** Sorting */
+  sortDescriptor?: SortDescriptor;        // controlled
+  defaultSortDescriptor?: SortDescriptor; // uncontrolled initial
+  onSortChange?: (descriptor: SortDescriptor) => void;
+  manualSort?: boolean;                   // true = consumer pre-sorted `data`
+
+  /** Filtering */
+  filterable?: boolean;                   // default false — show search input
+  filterValue?: string;                   // controlled
+  defaultFilterValue?: string;            // uncontrolled initial
+  onFilterChange?: (value: string) => void;
+  filterPlaceholder?: string;             // default 'Filter…'
+  filterFn?: (row: T, query: string, columns: TableColumn<T>[]) => boolean;
+  manualFilter?: boolean;                 // true = consumer pre-filtered `data`
+
+  /** Pagination */
+  pagination?: boolean;                   // default false — show footer
+  page?: number;                          // controlled, 1-based
+  defaultPage?: number;                   // uncontrolled initial, default 1
+  onPageChange?: (page: number) => void;
+  pageSize?: number;                      // controlled
+  defaultPageSize?: number;               // default 10
+  onPageSizeChange?: (size: number) => void;
+  pageSizeOptions?: number[];             // default [10, 25, 50]
+  manualPagination?: boolean;             // true = `data` is the current page already
+  rowCount?: number;                      // total rows when manualPagination (for page-count math)
+
+  /** Selection */
+  selectionMode?: 'none' | 'single' | 'multiple'; // default 'none'
+  selectedKeys?: Selection;               // controlled
+  defaultSelectedKeys?: Selection;        // uncontrolled initial
+  onSelectionChange?: (keys: Selection) => void;
+}
+```
+
+---
+
+### Task 1: Scaffold the data-driven Table (columns + data render only)
+
+**Files:**
+- Create: `src/components/Table/index.ts`
+- Create: `src/components/Table/components/index.ts`
+- Create: `src/components/Table/components/Table.tsx`
+- Create: `src/components/Table/components/Table.css`
+- Modify: `src/index.ts` (add Table value + type exports)
+- Modify: `src/components/registry.ts` (add `Table` entry)
+- Test: `src/components/Table/components/Table.test.tsx`
+
+**Interfaces:**
+- Produces: `Table<T>`, and the full type surface above (`TableColumn`, `TableProps`, `TableSize`, `TableAlign`, `RowKey`, re-exported `Selection`/`SortDescriptor`). Later tasks consume `getCellValue`/processing from Task 2 and extend `Table.tsx`.
+
+- [ ] **Step 1: Write the failing test**
+
+`src/components/Table/components/Table.test.tsx`:
+
+```tsx
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { Table, type TableColumn } from './Table';
+
+interface Person { id: string; name: string; age: number; }
+const people: Person[] = [
+  { id: '1', name: 'Ada', age: 36 },
+  { id: '2', name: 'Linus', age: 54 },
+];
+const columns: TableColumn<Person>[] = [
+  { id: 'name', header: 'Name', isRowHeader: true },
+  { id: 'age', header: 'Age', align: 'right' },
+];
+
+describe('Table — rendering', () => {
+  it('renders a grid with column headers and cell values', () => {
+    render(<Table aria-label="People" columns={columns} data={people} />);
+    expect(screen.getByRole('grid', { name: 'People' })).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Age')).toBeInTheDocument();
+    expect(screen.getByText('Ada')).toBeInTheDocument();
+    expect(screen.getByText('54')).toBeInTheDocument();
+  });
+
+  it('emits the stable eidotter-table block class', () => {
+    const { container } = render(<Table aria-label="People" columns={columns} data={people} />);
+    expect(container.querySelector('.eidotter-table')).toBeInTheDocument();
+  });
+
+  it('uses accessor when provided', () => {
+    const cols: TableColumn<Person>[] = [
+      { id: 'name', header: 'Name', isRowHeader: true, accessor: (r) => r.name.toUpperCase() },
+    ];
+    render(<Table aria-label="People" columns={cols} data={people} />);
+    expect(screen.getByText('ADA')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when data is empty', () => {
+    render(<Table aria-label="People" columns={columns} data={[]} emptyState="Nothing here" />);
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- --testPathPatterns="Table"`
+Expected: FAIL — `Cannot find module './Table'`.
+
+- [ ] **Step 3: Write `Table.css` (base only — striping/glow added in Task 7)**
+
+`src/components/Table/components/Table.css`:
+
+```css
+.eidotter-table-wrap {
+  container: eidotter-table / inline-size;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.eidotter-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--typography-font-family-body, monospace);
+  color: var(--color-semantic-text-primary);
+}
+
+.eidotter-table__th,
+.eidotter-table__td {
+  text-align: left;
+  border-bottom: 1px solid var(--color-semantic-border-default);
+  white-space: nowrap;
+}
+
+.eidotter-table__th {
+  font-family: var(--typography-font-family-primary, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-semantic-text-secondary);
+  background-color: var(--color-semantic-background-brand-dim);
+}
+
+.eidotter-table__td--right,
+.eidotter-table__th--right { text-align: right; }
+.eidotter-table__td--center,
+.eidotter-table__th--center { text-align: center; }
+
+.eidotter-table__empty {
+  text-align: center;
+  color: var(--color-semantic-text-muted);
+  padding: var(--spacing-6, 24px);
+}
+```
+
+- [ ] **Step 4: Write `Table.tsx` (minimal data-driven render)**
+
+`src/components/Table/components/Table.tsx`:
+
+```tsx
+'use client';
+
+import React from 'react';
+import {
+  Table as AriaTable,
+  TableHeader as AriaTableHeader,
+  TableBody as AriaTableBody,
+  Column as AriaColumn,
+  Row as AriaRow,
+  Cell as AriaCell,
+  type Selection,
+  type SortDescriptor,
+} from 'react-aria-components';
+import { cn } from '../../../utils/cn';
+import './Table.css';
+
+export type { Selection, SortDescriptor };
+export type TableSize = 'sm' | 'md' | 'lg' | 'small' | 'medium' | 'large';
+export type TableAlign = 'left' | 'center' | 'right';
+export type RowKey = string | number;
+
+export interface TableColumn<T> {
+  id: string;
+  header: React.ReactNode;
+  isRowHeader?: boolean;
+  allowsSorting?: boolean;
+  align?: TableAlign;
+  width?: string | number;
+  accessor?: (row: T) => React.ReactNode;
+  renderCell?: (row: T) => React.ReactNode;
+  sortComparator?: (a: T, b: T) => number;
+}
+
+export interface TableProps<T extends object> {
+  columns: TableColumn<T>[];
+  data: T[];
+  getRowId?: (row: T) => RowKey;
+  size?: TableSize;
+  striped?: boolean;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  caption?: React.ReactNode;
+  emptyState?: React.ReactNode;
+  className?: string;
+  'aria-label'?: string;
+  // (sorting / filtering / pagination / selection props added in later tasks)
+}
+
+const sizePadding: Record<string, string> = {
+  sm: 'px-2 py-1 text-dos-text-xs',
+  md: 'px-3 py-2 text-dos-text-sm',
+  lg: 'px-4 py-3 text-dos-text-md',
+};
+
+function normalizeSize(size: TableSize = 'md'): 'sm' | 'md' | 'lg' {
+  if (size === 'small') return 'sm';
+  if (size === 'medium') return 'md';
+  if (size === 'large') return 'lg';
+  return size;
+}
+
+function alignClass(prefix: string, align: TableAlign = 'left'): string {
+  return align === 'right' ? `${prefix}--right` : align === 'center' ? `${prefix}--center` : '';
+}
+
+function getCellValue<T>(row: T, col: TableColumn<T>): React.ReactNode {
+  if (col.accessor) return col.accessor(row);
+  return (row as Record<string, unknown>)[col.id] as React.ReactNode;
+}
+
+function renderCellContent<T>(row: T, col: TableColumn<T>): React.ReactNode {
+  if (col.renderCell) return col.renderCell(row);
+  return getCellValue(row, col);
+}
+
+/**
+ * DOS-themed data table built on React Aria Components.
+ * Provides accessible sorting, filtering, pagination, and row selection
+ * with authentic CGA scanline striping and phosphor hover glow.
+ *
+ * Generic over the row type `T`; not a forwardRef component (generics + RAC root).
+ */
+export function Table<T extends object>(props: TableProps<T>) {
+  const {
+    columns,
+    data,
+    getRowId = (row: T) => (row as { id: RowKey }).id,
+    size = 'md',
+    striped = true,
+    title,
+    description,
+    caption,
+    emptyState = 'No data',
+    className,
+    'aria-label': ariaLabel,
+  } = props;
+
+  const sz = normalizeSize(size);
+  const pad = sizePadding[sz];
+
+  const keyedRows = data.map((row) => ({ id: getRowId(row), row }));
+  const isEmpty = keyedRows.length === 0;
+
+  return (
+    <div className="eidotter-table-wrap">
+      {(title || description) && (
+        <div className="eidotter-table__header-band bg-dos-bg-brand-dim border border-dos-border-default px-3 py-2">
+          {title && <div className="font-dos uppercase text-dos-text-secondary">{title}</div>}
+          {description && <div className="text-dos-text-muted text-dos-text-xs">{description}</div>}
+        </div>
+      )}
+      <AriaTable
+        aria-label={ariaLabel}
+        className={cn('eidotter-table', striped && 'eidotter-table--striped', `eidotter-table--${sz}`, className)}
+      >
+        <AriaTableHeader>
+          {columns.map((col) => (
+            <AriaColumn
+              key={col.id}
+              id={col.id}
+              isRowHeader={col.isRowHeader}
+              className={cn('eidotter-table__th', alignClass('eidotter-table__th', col.align), pad)}
+              style={col.width != null ? { width: col.width } : undefined}
+            >
+              {col.header}
+            </AriaColumn>
+          ))}
+        </AriaTableHeader>
+        <AriaTableBody
+          items={keyedRows}
+          renderEmptyState={() => <span className="eidotter-table__empty">{emptyState}</span>}
+        >
+          {(entry) => (
+            <AriaRow className="eidotter-table__tr">
+              {columns.map((col) => (
+                <AriaCell
+                  key={col.id}
+                  className={cn('eidotter-table__td', alignClass('eidotter-table__td', col.align), pad)}
+                >
+                  {renderCellContent(entry.row, col)}
+                </AriaCell>
+              ))}
+            </AriaRow>
+          )}
+        </AriaTableBody>
+      </AriaTable>
+      {caption && !title && <span className="sr-only">{caption}</span>}
+      {isEmpty && null /* empty handled by renderEmptyState */}
+    </div>
+  );
+}
+
+Table.displayName = 'Table';
+
+export { getCellValue };
+```
+
+> Note: RAC renders `role="grid"` on `<Table>` and accepts `className` as a string here (no render-prop needed). If a future RAC type requires the render-prop form for `className`, switch to `className={() => '...'}`; the string form is valid in `^1.16.0`.
+
+- [ ] **Step 5: Write the barrels**
+
+`src/components/Table/components/index.ts`:
+
+```ts
+export { Table } from './Table';
+export type {
+  TableProps,
+  TableColumn,
+  TableSize,
+  TableAlign,
+  RowKey,
+  Selection,
+  SortDescriptor,
+} from './Table';
+```
+
+`src/components/Table/index.ts`:
+
+```ts
+export * from './components';
+```
+
+- [ ] **Step 6: Wire root exports in `src/index.ts`**
+
+Add the value export beside the other component exports (near line 47, after `export { Select } from './components/Select';`):
+
+```ts
+export { Table } from './components/Table';
+```
+
+Add the type export beside the other type exports (near line 121, after `export type { SelectProps, SelectOption } from './components/Select';`):
+
+```ts
+export type { TableProps, TableColumn, TableSize, TableAlign, RowKey } from './components/Table';
+```
+
+- [ ] **Step 7: Register in `src/components/registry.ts`**
+
+Add this entry to the `componentRegistry` object (place near the other entries; object key order is not significant):
+
+```ts
+  Table: {
+    origin: 'eidotter',
+    consumers: ['steuerdash'],
+    since: '0.38.0',
+    originNote: 'Data table on React Aria Components — managed sort/filter/pagination/selection + DOS scanline striping and phosphor hover glow. Data-driven API only (composition API is a future enhancement).',
+    variants: {
+      'striped:true':  { description: 'Scanline row striping (default)', since: '0.38.0' },
+      'striped:false': { description: 'Flat rows, no striping', since: '0.38.0' },
+      'size:sm':       { description: 'Compact density for dense dashboards', since: '0.38.0' },
+      'size:md':       { description: 'Standard row height (default)', since: '0.38.0' },
+      'size:lg':       { description: 'Roomy rows / touch targets', since: '0.38.0' },
+      'selectionMode:single':   { description: 'Single-row selection with checkbox', since: '0.38.0' },
+      'selectionMode:multiple': { description: 'Multi-row selection with select-all', since: '0.38.0' },
+    },
+    platforms: {
+      react:   { path: 'src/components/Table', status: 'canonical' },
+      swiftui: { status: 'planned' },
+    },
+    changelog: [
+      { version: '0.38.0', type: 'added', description: 'Initial Table — columns/data API, managed sorting/filtering/pagination/row-selection, scanline striping, phosphor hover glow' },
+    ],
+  },
+```
+
+> Verify the `since`/version against the current `package.json` `version` at implementation time; bump the `0.38.0` placeholders to the actual next-minor if it differs.
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `npm run test -- --testPathPatterns="Table"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 9: Lint + client-directive sync + typecheck the new files**
+
+Run: `node scripts/sync-client-directives.mjs --check && npm run lint`
+Expected: no errors; `Table.tsx` already carries `'use client'`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/components/Table src/index.ts src/components/registry.ts
+git commit -m "feat(Table): scaffold data-driven Table on React Aria Components"
+```
+
+---
+
+### Task 2: Pure processing helpers (sort / filter / paginate)
+
+**Files:**
+- Create: `src/components/Table/components/tableUtils.ts`
+- Test: `src/components/Table/components/tableUtils.test.ts`
+
+**Interfaces:**
+- Consumes: `TableColumn<T>`, `getCellValue` (from Task 1; re-import the value extractor or duplicate the tiny helper — prefer importing from `./Table`). To avoid a circular import (`Table.tsx` will import these utils), **move `getCellValue` into `tableUtils.ts`** and re-export it from `Table.tsx`.
+- Produces:
+  - `getCellValue<T>(row, col): React.ReactNode`
+  - `defaultFilterFn<T>(row, query, columns): boolean`
+  - `applyFilter<T>(rows, query, columns, filterFn?): T[]`
+  - `defaultComparator(a: unknown, b: unknown): number`
+  - `applySort<T>(rows, descriptor, columns): T[]`
+  - `paginate<T>(rows, page, pageSize): T[]`
+  - `getPageCount(total, pageSize): number`
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/components/Table/components/tableUtils.test.ts`:
+
+```ts
+import {
+  defaultFilterFn,
+  applyFilter,
+  applySort,
+  paginate,
+  getPageCount,
+  defaultComparator,
+} from './tableUtils';
+import type { TableColumn } from './Table';
+
+interface Row { id: string; name: string; age: number; }
+const rows: Row[] = [
+  { id: '1', name: 'Ada', age: 36 },
+  { id: '2', name: 'Linus', age: 54 },
+  { id: '3', name: 'Grace', age: 85 },
+];
+const cols: TableColumn<Row>[] = [
+  { id: 'name', header: 'Name' },
+  { id: 'age', header: 'Age' },
+];
+
+describe('defaultComparator', () => {
+  it('orders numbers numerically', () => {
+    expect(defaultComparator(2, 10)).toBeLessThan(0);
+  });
+  it('orders strings case-insensitively with locale numeric awareness', () => {
+    expect(defaultComparator('apple', 'Banana')).toBeLessThan(0);
+  });
+  it('sorts nullish values last', () => {
+    expect(defaultComparator(null, 1)).toBeGreaterThan(0);
+    expect(defaultComparator(1, null)).toBeLessThan(0);
+  });
+});
+
+describe('defaultFilterFn / applyFilter', () => {
+  it('matches a substring across columns, case-insensitively', () => {
+    expect(defaultFilterFn(rows[0], 'ad', cols)).toBe(true);
+    expect(defaultFilterFn(rows[0], 'zzz', cols)).toBe(false);
+  });
+  it('returns all rows for empty query', () => {
+    expect(applyFilter(rows, '', cols)).toHaveLength(3);
+  });
+  it('filters by numeric column value', () => {
+    expect(applyFilter(rows, '54', cols)).toEqual([rows[1]]);
+  });
+});
+
+describe('applySort', () => {
+  it('sorts ascending by a column', () => {
+    const out = applySort(rows, { column: 'age', direction: 'ascending' }, cols);
+    expect(out.map((r) => r.age)).toEqual([36, 54, 85]);
+  });
+  it('sorts descending by a column', () => {
+    const out = applySort(rows, { column: 'name', direction: 'descending' }, cols);
+    expect(out.map((r) => r.name)).toEqual(['Linus', 'Grace', 'Ada']);
+  });
+  it('is a no-op when descriptor column is unknown', () => {
+    const out = applySort(rows, { column: 'missing', direction: 'ascending' }, cols);
+    expect(out).toEqual(rows);
+  });
+  it('does not mutate the input array', () => {
+    const copy = [...rows];
+    applySort(rows, { column: 'age', direction: 'ascending' }, cols);
+    expect(rows).toEqual(copy);
+  });
+});
+
+describe('paginate / getPageCount', () => {
+  it('returns the requested page slice (1-based)', () => {
+    expect(paginate(rows, 2, 2)).toEqual([rows[2]]);
+  });
+  it('computes page count, minimum 1', () => {
+    expect(getPageCount(0, 10)).toBe(1);
+    expect(getPageCount(21, 10)).toBe(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- --testPathPatterns="tableUtils"`
+Expected: FAIL — `Cannot find module './tableUtils'`.
+
+- [ ] **Step 3: Implement `tableUtils.ts`**
+
+`src/components/Table/components/tableUtils.ts`:
+
+```ts
+import type { SortDescriptor } from 'react-aria-components';
+import type { TableColumn } from './Table';
+
+export function getCellValue<T>(row: T, col: TableColumn<T>): React.ReactNode {
+  if (col.accessor) return col.accessor(row);
+  return (row as Record<string, unknown>)[col.id] as React.ReactNode;
+}
+
+/** Coerce a cell value to a comparable/searchable scalar. */
+function toScalar(value: unknown): string | number | null {
+  if (value == null) return null;
+  if (typeof value === 'number') return value;
+  if (value instanceof Date) return value.getTime();
+  return String(value);
+}
+
+export function defaultComparator(a: unknown, b: unknown): number {
+  const av = toScalar(a);
+  const bv = toScalar(b);
+  if (av == null && bv == null) return 0;
+  if (av == null) return 1;   // nullish sorts last (ascending)
+  if (bv == null) return -1;
+  if (typeof av === 'number' && typeof bv === 'number') return av - bv;
+  return String(av).localeCompare(String(bv), undefined, { numeric: true, sensitivity: 'base' });
+}
+
+export function defaultFilterFn<T>(row: T, query: string, columns: TableColumn<T>[]): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return columns.some((col) => {
+    const v = getCellValue(row, col);
+    return String(v ?? '').toLowerCase().includes(q);
+  });
+}
+
+export function applyFilter<T>(
+  rows: T[],
+  query: string,
+  columns: TableColumn<T>[],
+  filterFn: (row: T, query: string, columns: TableColumn<T>[]) => boolean = defaultFilterFn,
+): T[] {
+  if (!query.trim()) return rows;
+  return rows.filter((row) => filterFn(row, query, columns));
+}
+
+export function applySort<T>(
+  rows: T[],
+  descriptor: SortDescriptor | undefined,
+  columns: TableColumn<T>[],
+): T[] {
+  if (!descriptor) return rows;
+  const col = columns.find((c) => c.id === descriptor.column);
+  if (!col) return rows;
+  const dir = descriptor.direction === 'descending' ? -1 : 1;
+  const compare = col.sortComparator
+    ? col.sortComparator
+    : (a: T, b: T) => defaultComparator(getCellValue(a, col), getCellValue(b, col));
+  // copy first — never mutate the caller's array
+  return [...rows].sort((a, b) => compare(a, b) * dir);
+}
+
+export function getPageCount(total: number, pageSize: number): number {
+  return Math.max(1, Math.ceil(total / Math.max(1, pageSize)));
+}
+
+export function paginate<T>(rows: T[], page: number, pageSize: number): T[] {
+  const start = (Math.max(1, page) - 1) * pageSize;
+  return rows.slice(start, start + pageSize);
+}
+```
+
+- [ ] **Step 4: De-duplicate `getCellValue`**
+
+In `Table.tsx`, delete the local `getCellValue` definition and import it instead:
+
+```ts
+import { getCellValue } from './tableUtils';
+```
+
+Keep the existing `export { getCellValue };` line in `Table.tsx` so the barrel re-export path is unchanged (or re-export from the util). Run `npm run lint` to confirm no unused-import or duplicate-symbol errors.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm run test -- --testPathPatterns="tableUtils|Table"`
+Expected: PASS (Task 1 + Task 2 suites green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Table/components/tableUtils.ts src/components/Table/components/tableUtils.test.ts src/components/Table/components/Table.tsx
+git commit -m "feat(Table): add pure sort/filter/paginate helpers"
+```
+
+---
+
+### Task 3: Sorting (RAC sortDescriptor + indicator icon)
+
+**Files:**
+- Modify: `src/components/Table/components/Table.tsx`
+- Modify: `src/components/Table/components/Table.css`
+- Test: `src/components/Table/components/Table.test.tsx`
+
+**Interfaces:**
+- Consumes: `applySort` (Task 2), RAC `SortDescriptor`.
+- Produces: controlled/uncontrolled sort behavior on `<Table>`; visible sorted order; `onSortChange` callback fires `{ column, direction }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Table.test.tsx`:
+
+```tsx
+import { fireEvent } from '@testing-library/react';
+
+describe('Table — sorting', () => {
+  const sortable: TableColumn<Person>[] = [
+    { id: 'name', header: 'Name', isRowHeader: true, allowsSorting: true },
+    { id: 'age', header: 'Age', align: 'right', allowsSorting: true },
+  ];
+
+  it('sorts ascending then descending on header activation (uncontrolled)', () => {
+    render(<Table aria-label="People" columns={sortable} data={people} />);
+    const ageHeader = screen.getByRole('columnheader', { name: /Age/ });
+    fireEvent.click(ageHeader);
+    let rows = screen.getAllByRole('row').slice(1); // drop header row
+    expect(within(rows[0]).getByText('36')).toBeInTheDocument();
+    fireEvent.click(ageHeader);
+    rows = screen.getAllByRole('row').slice(1);
+    expect(within(rows[0]).getByText('54')).toBeInTheDocument();
+  });
+
+  it('sets aria-sort on the active sortable header', () => {
+    render(<Table aria-label="People" columns={sortable} data={people} />);
+    const ageHeader = screen.getByRole('columnheader', { name: /Age/ });
+    fireEvent.click(ageHeader);
+    expect(ageHeader).toHaveAttribute('aria-sort', 'ascending');
+  });
+
+  it('calls onSortChange in controlled mode', () => {
+    const onSortChange = jest.fn();
+    render(
+      <Table
+        aria-label="People"
+        columns={sortable}
+        data={people}
+        sortDescriptor={{ column: 'name', direction: 'ascending' }}
+        onSortChange={onSortChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('columnheader', { name: /Age/ }));
+    expect(onSortChange).toHaveBeenCalledWith(
+      expect.objectContaining({ column: 'age' }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- --testPathPatterns="Table"`
+Expected: FAIL — clicking the header does not reorder rows (no sort wired yet).
+
+- [ ] **Step 3: Wire sorting in `Table.tsx`**
+
+Add imports and props:
+
+```tsx
+import React, { useState } from 'react';
+import { Icon } from '../../Icon';
+import { applySort } from './tableUtils';
+```
+
+Extend `TableProps<T>` with:
+
+```ts
+  sortDescriptor?: SortDescriptor;
+  defaultSortDescriptor?: SortDescriptor;
+  onSortChange?: (descriptor: SortDescriptor) => void;
+  manualSort?: boolean;
+```
+
+Inside the component body, after destructuring:
+
+```tsx
+  const [internalSort, setInternalSort] = useState<SortDescriptor | undefined>(
+    props.defaultSortDescriptor,
+  );
+  const isSortControlled = props.sortDescriptor !== undefined;
+  const sortDescriptor = isSortControlled ? props.sortDescriptor : internalSort;
+
+  const handleSortChange = (descriptor: SortDescriptor) => {
+    if (!isSortControlled) setInternalSort(descriptor);
+    props.onSortChange?.(descriptor);
+  };
+
+  // derive sorted rows (skip when manualSort: consumer pre-sorted)
+  const sortedData = props.manualSort ? data : applySort(data, sortDescriptor, columns);
+```
+
+Replace the `keyedRows` source to use `sortedData` (it will be further chained in Tasks 4–5):
+
+```tsx
+  const processed = sortedData;            // Tasks 4–5 wrap filter/paginate around this
+  const keyedRows = processed.map((row) => ({ id: getRowId(row), row }));
+```
+
+Pass sort props to `<AriaTable>`:
+
+```tsx
+      <AriaTable
+        aria-label={ariaLabel}
+        sortDescriptor={sortDescriptor}
+        onSortChange={handleSortChange}
+        className={cn('eidotter-table', striped && 'eidotter-table--striped', `eidotter-table--${sz}`, className)}
+      >
+```
+
+Make sortable columns render the indicator. Replace the `<AriaColumn>` children with a render function:
+
+```tsx
+            <AriaColumn
+              key={col.id}
+              id={col.id}
+              isRowHeader={col.isRowHeader}
+              allowsSorting={col.allowsSorting}
+              className={cn('eidotter-table__th', alignClass('eidotter-table__th', col.align), pad)}
+              style={col.width != null ? { width: col.width } : undefined}
+            >
+              {({ allowsSorting, sortDirection }) => (
+                <span className="eidotter-table__th-content">
+                  <span>{col.header}</span>
+                  {allowsSorting && (
+                    <span aria-hidden className="eidotter-table__sort">
+                      {sortDirection === 'ascending' ? (
+                        <Icon name="Chevron Up" size="S" />
+                      ) : sortDirection === 'descending' ? (
+                        <Icon name="Chevron Down" size="S" />
+                      ) : (
+                        <span className="eidotter-table__sort--idle">▲▼</span>
+                      )}
+                    </span>
+                  )}
+                </span>
+              )}
+            </AriaColumn>
+```
+
+- [ ] **Step 4: Add sort-indicator CSS**
+
+Append to `Table.css`:
+
+```css
+.eidotter-table__th-content {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2, 8px);
+}
+
+.eidotter-table__th[aria-sort]:not([aria-sort='none']) {
+  color: var(--color-semantic-text-secondary);
+  text-shadow: 0 0 4px var(--color-cga-amber-glow);
+}
+
+.eidotter-table__sort {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1;
+}
+
+.eidotter-table__sort--idle {
+  opacity: 0.35;
+  font-size: 0.6em;
+  letter-spacing: -0.15em;
+}
+
+@media (prefers-contrast: high) {
+  .eidotter-table__th[aria-sort]:not([aria-sort='none']) { text-shadow: none; text-decoration: underline; }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm run test -- --testPathPatterns="Table"`
+Expected: PASS (sorting suite green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Table/components/Table.tsx src/components/Table/components/Table.css src/components/Table/components/Table.test.tsx
+git commit -m "feat(Table): client-side sorting with RAC sortDescriptor + phosphor indicator"
+```
+
+---
+
+### Task 4: Filtering (search input + managed filter)
+
+**Files:**
+- Modify: `src/components/Table/components/Table.tsx`
+- Test: `src/components/Table/components/Table.test.tsx`
+
+**Interfaces:**
+- Consumes: `applyFilter`, `defaultFilterFn` (Task 2), eidotter `<Input>`.
+- Produces: a search field above the table when `filterable`; visible rows reflect the query; `onFilterChange` fires; controlled `filterValue` supported.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Table.test.tsx`:
+
+```tsx
+import userEvent from '@testing-library/user-event';
+
+describe('Table — filtering', () => {
+  it('shows a search box and filters rows (uncontrolled)', async () => {
+    const user = userEvent.setup();
+    render(<Table aria-label="People" columns={columns} data={people} filterable />);
+    const search = screen.getByrole('searchbox');
+    await user.type(search, 'lin');
+    expect(screen.getByText('Linus')).toBeInTheDocument();
+    expect(screen.queryByText('Ada')).not.toBeInTheDocument();
+  });
+
+  it('does not render a search box unless filterable', () => {
+    render(<Table aria-label="People" columns={columns} data={people} />);
+    expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
+  });
+
+  it('calls onFilterChange in controlled mode', async () => {
+    const user = userEvent.setup();
+    const onFilterChange = jest.fn();
+    render(
+      <Table aria-label="People" columns={columns} data={people}
+        filterable filterValue="" onFilterChange={onFilterChange} />,
+    );
+    await user.type(screen.getByRole('searchbox'), 'a');
+    expect(onFilterChange).toHaveBeenCalledWith('a');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- --testPathPatterns="Table"`
+Expected: FAIL — no `searchbox` rendered.
+
+- [ ] **Step 3: Wire filtering**
+
+Add to `Table.tsx`:
+
+```tsx
+import { applyFilter } from './tableUtils';
+```
+
+Extend `TableProps<T>`:
+
+```ts
+  filterable?: boolean;
+  filterValue?: string;
+  defaultFilterValue?: string;
+  onFilterChange?: (value: string) => void;
+  filterPlaceholder?: string;
+  filterFn?: (row: T, query: string, columns: TableColumn<T>[]) => boolean;
+  manualFilter?: boolean;
+```
+
+In the component body:
+
+```tsx
+  const [internalFilter, setInternalFilter] = useState(props.defaultFilterValue ?? '');
+  const isFilterControlled = props.filterValue !== undefined;
+  const filterValue = isFilterControlled ? props.filterValue! : internalFilter;
+
+  const handleFilterChange = (value: string) => {
+    if (!isFilterControlled) setInternalFilter(value);
+    props.onFilterChange?.(value);
+  };
+```
+
+Update the processing chain (filter BEFORE sort so sort order is stable on the visible set):
+
+```tsx
+  const filteredData = props.manualFilter
+    ? data
+    : applyFilter(data, filterValue, columns, props.filterFn);
+  const sortedData = props.manualSort ? filteredData : applySort(filteredData, sortDescriptor, columns);
+  const processed = sortedData;            // Task 5 wraps pagination around this
+```
+
+Render a search box above the `<AriaTable>` (use a native `type="search"` input styled with eidotter classes to guarantee `role="searchbox"` and avoid coupling to `<Input>`'s internal role; this mirrors `Select`'s native-element approach):
+
+```tsx
+      {props.filterable && (
+        <div className="eidotter-table__toolbar px-1 py-2">
+          <input
+            type="search"
+            value={filterValue}
+            onChange={(e) => handleFilterChange(e.target.value)}
+            placeholder={props.filterPlaceholder ?? 'Filter…'}
+            aria-label={props.filterPlaceholder ?? 'Filter rows'}
+            className={cn(
+              'eidotter-table__filter font-dos px-2 py-1 w-full max-w-xs',
+              'bg-dos-bg-secondary text-dos-text-primary border border-dos-border-default',
+              'focus:border-dos-border-focus focus:outline-none',
+            )}
+            style={{ fontSize: 'var(--typography-font-size-text-xs)' }}
+          />
+        </div>
+      )}
+```
+
+> A search query that empties the visible set must show the empty state — already handled by `renderEmptyState`. Reset to page 1 on filter change is added in Task 5.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test -- --testPathPatterns="Table"`
+Expected: PASS (filtering suite green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Table/components/Table.tsx src/components/Table/components/Table.test.tsx
+git commit -m "feat(Table): managed filtering with search box"
+```
+
+---
+
+### Task 5: Pagination (footer with page controls + page size)
+
+**Files:**
+- Modify: `src/components/Table/components/Table.tsx`
+- Modify: `src/components/Table/components/Table.css`
+- Test: `src/components/Table/components/Table.test.tsx`
+
+**Interfaces:**
+- Consumes: `paginate`, `getPageCount` (Task 2), eidotter `<Button>`, eidotter `<Select>`.
+- Produces: a footer when `pagination`; visible rows limited to the current page; Prev/Next + page-size controls; `onPageChange`/`onPageSizeChange` callbacks; controlled `page`/`pageSize`; `manualPagination` + `rowCount` support.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Table.test.tsx`:
+
+```tsx
+const many: Person[] = Array.from({ length: 25 }, (_, i) => ({
+  id: String(i + 1), name: `Person ${i + 1}`, age: 20 + i,
+}));
+
+describe('Table — pagination', () => {
+  it('limits rows to the page size and navigates pages', async () => {
+    const user = userEvent.setup();
+    render(<Table aria-label="People" columns={columns} data={many} pagination defaultPageSize={10} />);
+    expect(screen.getAllByRole('row').slice(1)).toHaveLength(10);
+    expect(screen.getByText('Person 1')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(screen.getByText('Person 11')).toBeInTheDocument();
+    expect(screen.queryByText('Person 1')).not.toBeInTheDocument();
+  });
+
+  it('disables Prev on the first page', () => {
+    render(<Table aria-label="People" columns={columns} data={many} pagination defaultPageSize={10} />);
+    expect(screen.getByRole('button', { name: /prev/i })).toBeDisabled();
+  });
+
+  it('changes page size via the select', async () => {
+    const user = userEvent.setup();
+    render(<Table aria-label="People" columns={columns} data={many} pagination defaultPageSize={10} pageSizeOptions={[10, 25]} />);
+    await user.selectOptions(screen.getByRole('combobox', { name: /rows per page/i }), '25');
+    expect(screen.getAllByRole('row').slice(1)).toHaveLength(25);
+  });
+
+  it('resets to page 1 when the filter changes', async () => {
+    const user = userEvent.setup();
+    render(<Table aria-label="People" columns={columns} data={many} pagination filterable defaultPageSize={10} />);
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await user.type(screen.getByRole('searchbox'), 'Person 2');
+    // page reset → first match visible
+    expect(screen.getByText('Person 2')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- --testPathPatterns="Table"`
+Expected: FAIL — all 25 rows render; no Prev/Next buttons.
+
+- [ ] **Step 3: Wire pagination**
+
+Add imports:
+
+```tsx
+import { Button } from '../../Button';
+import { Select } from '../../Select';
+import { paginate, getPageCount } from './tableUtils';
+```
+
+Extend `TableProps<T>`:
+
+```ts
+  pagination?: boolean;
+  page?: number;
+  defaultPage?: number;
+  onPageChange?: (page: number) => void;
+  pageSize?: number;
+  defaultPageSize?: number;
+  onPageSizeChange?: (size: number) => void;
+  pageSizeOptions?: number[];
+  manualPagination?: boolean;
+  rowCount?: number;
+```
+
+In the component body:
+
+```tsx
+  const [internalPage, setInternalPage] = useState(props.defaultPage ?? 1);
+  const isPageControlled = props.page !== undefined;
+  const page = isPageControlled ? props.page! : internalPage;
+
+  const [internalPageSize, setInternalPageSize] = useState(props.defaultPageSize ?? 10);
+  const isPageSizeControlled = props.pageSize !== undefined;
+  const pageSize = isPageSizeControlled ? props.pageSize! : internalPageSize;
+
+  const setPage = (next: number) => {
+    if (!isPageControlled) setInternalPage(next);
+    props.onPageChange?.(next);
+  };
+```
+
+Make filter/page-size changes reset to page 1 — update `handleFilterChange` and add a page-size handler:
+
+```tsx
+  const handleFilterChange = (value: string) => {
+    if (!isFilterControlled) setInternalFilter(value);
+    if (!isPageControlled) setInternalPage(1);
+    props.onFilterChange?.(value);
+    props.onPageChange?.(1);
+  };
+
+  const handlePageSizeChange = (size: number) => {
+    if (!isPageSizeControlled) setInternalPageSize(size);
+    if (!isPageControlled) setInternalPage(1);
+    props.onPageSizeChange?.(size);
+    props.onPageChange?.(1);
+  };
+```
+
+Compute page math and the final visible slice. `processed` (from Task 4) is the filtered+sorted set:
+
+```tsx
+  const totalRows = props.manualPagination ? (props.rowCount ?? data.length) : processed.length;
+  const pageCount = props.pagination ? getPageCount(totalRows, pageSize) : 1;
+  const clampedPage = Math.min(page, pageCount);
+  const visibleData =
+    props.pagination && !props.manualPagination
+      ? paginate(processed, clampedPage, pageSize)
+      : processed;
+
+  const keyedRows = visibleData.map((row) => ({ id: getRowId(row), row }));
+```
+
+> Replace the earlier `const keyedRows = processed.map(...)` line from Task 3/4 with this `visibleData`-based version.
+
+Render the footer after `</AriaTable>`:
+
+```tsx
+      {props.pagination && (
+        <div className="eidotter-table__footer flex items-center justify-between gap-3 px-3 py-2 border border-dos-border-default border-t-0">
+          <div className="flex items-center gap-2 text-dos-text-muted text-dos-text-xs">
+            <span>Rows per page</span>
+            <Select
+              aria-label="Rows per page"
+              value={String(pageSize)}
+              options={(props.pageSizeOptions ?? [10, 25, 50]).map((n) => ({ value: String(n), label: String(n) }))}
+              onChange={(v) => handlePageSizeChange(Number(v))}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-dos-text-muted text-dos-text-xs">
+              Page {clampedPage} of {pageCount}
+            </span>
+            <Button size="sm" variant="secondary" isDisabled={clampedPage <= 1} onPress={() => setPage(clampedPage - 1)} aria-label="Previous page">
+              Prev
+            </Button>
+            <Button size="sm" variant="secondary" isDisabled={clampedPage >= pageCount} onPress={() => setPage(clampedPage + 1)} aria-label="Next page">
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+```
+
+> Verify eidotter `<Button>`'s disabled prop name (`isDisabled` for React Aria) and press handler (`onPress`) against `src/components/Button/components/Button.tsx` before finalizing; adjust if the wrapper exposes `disabled`/`onClick`.
+
+- [ ] **Step 4: Add footer CSS (optional polish)**
+
+Append to `Table.css`:
+
+```css
+.eidotter-table__footer { background-color: var(--color-semantic-background-secondary); }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm run test -- --testPathPatterns="Table"`
+Expected: PASS (pagination suite green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Table/components/Table.tsx src/components/Table/components/Table.css src/components/Table/components/Table.test.tsx
+git commit -m "feat(Table): paginated footer with page controls and page size"
+```
+
+---
+
+### Task 6: Row selection (checkboxes + select-all)
+
+**Files:**
+- Modify: `src/components/Table/components/Table.tsx`
+- Modify: `src/components/Table/components/Table.css`
+- Test: `src/components/Table/components/Table.test.tsx`
+
+**Interfaces:**
+- Consumes: RAC `Checkbox`, `Selection` type.
+- Produces: selection column when `selectionMode !== 'none'`; per-row + select-all checkboxes; controlled/uncontrolled `selectedKeys`; `onSelectionChange` fires; selected rows get `data-selected` styling.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Table.test.tsx`:
+
+```tsx
+describe('Table — selection', () => {
+  it('renders no selection checkboxes by default', () => {
+    render(<Table aria-label="People" columns={columns} data={people} />);
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+
+  it('selects a row and fires onSelectionChange (multiple)', async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = jest.fn();
+    render(
+      <Table aria-label="People" columns={columns} data={people}
+        selectionMode="multiple" onSelectionChange={onSelectionChange} />,
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    // first checkbox is select-all; second is row 1
+    await user.click(checkboxes[1]);
+    expect(onSelectionChange).toHaveBeenCalled();
+  });
+
+  it('select-all toggles every row', async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = jest.fn();
+    render(
+      <Table aria-label="People" columns={columns} data={people}
+        selectionMode="multiple" onSelectionChange={onSelectionChange} />,
+    );
+    await user.click(screen.getAllByRole('checkbox')[0]);
+    const arg = onSelectionChange.mock.calls.at(-1)?.[0];
+    // RAC reports 'all' or a Set of every row key
+    expect(arg === 'all' || (arg instanceof Set && arg.size === people.length)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- --testPathPatterns="Table"`
+Expected: FAIL — no checkboxes rendered.
+
+- [ ] **Step 3: Wire selection**
+
+Add import:
+
+```tsx
+import { Checkbox as AriaCheckbox } from 'react-aria-components';
+```
+
+Extend `TableProps<T>`:
+
+```ts
+  selectionMode?: 'none' | 'single' | 'multiple';
+  selectedKeys?: Selection;
+  defaultSelectedKeys?: Selection;
+  onSelectionChange?: (keys: Selection) => void;
+```
+
+In the component body:
+
+```tsx
+  const selectionMode = props.selectionMode ?? 'none';
+  const [internalSelected, setInternalSelected] = useState<Selection>(
+    props.defaultSelectedKeys ?? new Set(),
+  );
+  const isSelectionControlled = props.selectedKeys !== undefined;
+  const selectedKeys = isSelectionControlled ? props.selectedKeys! : internalSelected;
+
+  const handleSelectionChange = (keys: Selection) => {
+    if (!isSelectionControlled) setInternalSelected(keys);
+    props.onSelectionChange?.(keys);
+  };
+```
+
+Define a small styled selection checkbox (place above the component or as a module-level helper):
+
+```tsx
+function SelectionCheckbox({ slot }: { slot?: 'selection' }) {
+  return (
+    <AriaCheckbox slot={slot} className="eidotter-table__checkbox">
+      {({ isSelected, isIndeterminate }) => (
+        <span
+          aria-hidden
+          className={cn(
+            'eidotter-table__checkbox-box',
+            (isSelected || isIndeterminate) && 'eidotter-table__checkbox-box--on',
+          )}
+        >
+          {isIndeterminate ? '–' : isSelected ? '×' : ''}
+        </span>
+      )}
+    </AriaCheckbox>
+  );
+}
+```
+
+Pass selection props to `<AriaTable>`:
+
+```tsx
+      <AriaTable
+        aria-label={ariaLabel}
+        sortDescriptor={sortDescriptor}
+        onSortChange={handleSortChange}
+        selectionMode={selectionMode === 'none' ? undefined : selectionMode}
+        selectedKeys={selectionMode === 'none' ? undefined : selectedKeys}
+        onSelectionChange={selectionMode === 'none' ? undefined : handleSelectionChange}
+        className={cn('eidotter-table', striped && 'eidotter-table--striped', `eidotter-table--${sz}`, className)}
+      >
+```
+
+Prepend a selection `<Column>` to the header (only when selecting). In the header map, render this before the column map:
+
+```tsx
+        <AriaTableHeader>
+          {selectionMode !== 'none' && (
+            <AriaColumn className="eidotter-table__th eidotter-table__th--select w-0">
+              {selectionMode === 'multiple' ? <SelectionCheckbox slot="selection" /> : <span className="sr-only">Select</span>}
+            </AriaColumn>
+          )}
+          {columns.map((col) => ( /* unchanged */ ))}
+        </AriaTableHeader>
+```
+
+Prepend a selection `<Cell>` to each row:
+
+```tsx
+          {(entry) => (
+            <AriaRow className="eidotter-table__tr">
+              {selectionMode !== 'none' && (
+                <AriaCell className="eidotter-table__td eidotter-table__td--select w-0">
+                  <SelectionCheckbox slot="selection" />
+                </AriaCell>
+              )}
+              {columns.map((col) => ( /* unchanged */ ))}
+            </AriaRow>
+          )}
+```
+
+- [ ] **Step 4: Add checkbox + selected-row CSS**
+
+Append to `Table.css`:
+
+```css
+.eidotter-table__checkbox { cursor: pointer; display: inline-flex; }
+
+.eidotter-table__checkbox-box {
+  width: 14px;
+  height: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-semantic-border-default);
+  background-color: var(--color-semantic-background-primary);
+  color: var(--color-semantic-text-accent);
+  font-family: var(--typography-font-family-primary, monospace);
+  line-height: 1;
+}
+
+.eidotter-table__checkbox-box--on {
+  border-color: var(--color-semantic-border-brand);
+  box-shadow: 0 0 6px var(--color-cga-amber-glow);
+}
+
+.eidotter-table__tr[data-selected] {
+  background-color: var(--color-semantic-background-accent);
+  color: var(--color-semantic-text-secondary);
+}
+
+@media (prefers-contrast: high) {
+  .eidotter-table__checkbox-box--on { box-shadow: none; }
+  .eidotter-table__tr[data-selected] { outline: 2px solid var(--color-semantic-border-focus); }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm run test -- --testPathPatterns="Table"`
+Expected: PASS (selection suite green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Table/components/Table.tsx src/components/Table/components/Table.css src/components/Table/components/Table.test.tsx
+git commit -m "feat(Table): row selection with select-all and phosphor checkbox"
+```
+
+---
+
+### Task 7: DOS aesthetic — scanline striping, hover glow, density, a11y media queries
+
+**Files:**
+- Modify: `src/components/Table/components/Table.css`
+- Test: `src/components/Table/components/Table.test.tsx`
+
+**Interfaces:**
+- Produces: `eidotter-table--striped` scanline striping, row hover phosphor glow, `prefers-reduced-motion` / `prefers-contrast` handling. No TS API change.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Table.test.tsx`:
+
+```tsx
+describe('Table — aesthetic', () => {
+  it('applies the striped modifier by default', () => {
+    const { container } = render(<Table aria-label="People" columns={columns} data={people} />);
+    expect(container.querySelector('.eidotter-table--striped')).toBeInTheDocument();
+  });
+
+  it('omits the striped modifier when striped={false}', () => {
+    const { container } = render(<Table aria-label="People" columns={columns} data={people} striped={false} />);
+    expect(container.querySelector('.eidotter-table--striped')).not.toBeInTheDocument();
+  });
+
+  it('applies the size modifier', () => {
+    const { container } = render(<Table aria-label="People" columns={columns} data={people} size="sm" />);
+    expect(container.querySelector('.eidotter-table--sm')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- --testPathPatterns="Table"`
+Expected: FAIL on the `striped={false}` assertion if the class is unconditionally applied — confirm current behavior, then proceed (the class wiring already exists from Task 1, so these may pass; if so, treat this step as a regression guard and continue to Step 3 for the CSS).
+
+- [ ] **Step 3: Add striping + hover glow CSS**
+
+Append to `Table.css`:
+
+```css
+/* Scanline row striping — even rows get the light amber band, odd rows the dark */
+.eidotter-table--striped .eidotter-table__tr:nth-child(odd) .eidotter-table__td {
+  background-color: var(--effects-scanline-dark);
+}
+.eidotter-table--striped .eidotter-table__tr:nth-child(even) .eidotter-table__td {
+  background-color: var(--effects-scanline-light);
+}
+
+/* Phosphor hover glow on the row */
+.eidotter-table__tr {
+  transition: box-shadow var(--duration-fast, 100ms) ease-out,
+              background-color var(--duration-fast, 100ms) ease-out;
+}
+.eidotter-table__tr[data-hovered] .eidotter-table__td,
+.eidotter-table__tr:hover .eidotter-table__td {
+  background-color: var(--color-semantic-background-secondary);
+  box-shadow: inset 0 0 12px var(--color-cga-amber-glow);
+}
+
+/* Selected wins over hover/stripe */
+.eidotter-table--striped .eidotter-table__tr[data-selected] .eidotter-table__td {
+  background-color: var(--color-semantic-background-accent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .eidotter-table__tr { transition: none; }
+}
+
+@media (prefers-contrast: high) {
+  .eidotter-table__tr[data-hovered] .eidotter-table__td,
+  .eidotter-table__tr:hover .eidotter-table__td { box-shadow: none; }
+  .eidotter-table--striped .eidotter-table__tr .eidotter-table__td { background-color: transparent; }
+  .eidotter-table__th, .eidotter-table__td { border-bottom-width: 2px; }
+}
+```
+
+- [ ] **Step 4: Run tests + lint-tokens to verify no token drift**
+
+Run: `npm run test -- --testPathPatterns="Table" && npm run lint-tokens`
+Expected: tests PASS; `lint-tokens` reports no unresolved token/class references.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Table/components/Table.css src/components/Table/components/Table.test.tsx
+git commit -m "feat(Table): scanline striping + phosphor hover glow with a11y fallbacks"
+```
+
+---
+
+### Task 8: Storybook stories + final verification
+
+**Files:**
+- Create: `src/components/Table/components/Table.stories.tsx`
+- Test: full suite + build + a11y
+
+**Interfaces:**
+- Consumes: everything above + `componentRegistry['Table']` (Task 1).
+- Produces: documented stories; green CI-equivalent local run.
+
+- [ ] **Step 1: Write `Table.stories.tsx`**
+
+`src/components/Table/components/Table.stories.tsx`:
+
+```tsx
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Table, type TableColumn } from './Table';
+import { componentRegistry } from '@/components/registry';
+
+interface Invoice {
+  id: string;
+  client: string;
+  amount: number;
+  status: 'PAID' | 'DUE' | 'OVERDUE';
+  date: string;
+}
+
+const data: Invoice[] = [
+  { id: 'INV-001', client: 'Aperture', amount: 1200, status: 'PAID', date: '2026-01-04' },
+  { id: 'INV-002', client: 'Black Mesa', amount: 880, status: 'DUE', date: '2026-02-11' },
+  { id: 'INV-003', client: 'Cyberdyne', amount: 4300, status: 'OVERDUE', date: '2026-02-28' },
+  { id: 'INV-004', client: 'Tyrell', amount: 90, status: 'PAID', date: '2026-03-15' },
+  { id: 'INV-005', client: 'Weyland', amount: 2750, status: 'DUE', date: '2026-03-22' },
+];
+
+const columns: TableColumn<Invoice>[] = [
+  { id: 'id', header: 'Invoice', isRowHeader: true, allowsSorting: true },
+  { id: 'client', header: 'Client', allowsSorting: true },
+  { id: 'amount', header: 'Amount', align: 'right', allowsSorting: true, renderCell: (r) => `$${r.amount.toLocaleString()}` },
+  { id: 'status', header: 'Status', allowsSorting: true },
+  { id: 'date', header: 'Date', allowsSorting: true },
+];
+
+const meta = {
+  title: 'Components/Table',
+  component: Table,
+  parameters: {
+    layout: 'padded',
+    backgrounds: { default: 'dos', values: [{ name: 'dos', value: '#000000' }] },
+    projectMeta: componentRegistry['Table'],
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Table<Invoice>>;
+
+export default meta;
+type Story = StoryObj<typeof Table<Invoice>>;
+
+export const Default: Story = {
+  args: { 'aria-label': 'Invoices', columns, data },
+};
+
+export const Sortable: Story = {
+  args: { 'aria-label': 'Invoices', columns, data, defaultSortDescriptor: { column: 'amount', direction: 'descending' } },
+};
+
+export const Filterable: Story = {
+  args: { 'aria-label': 'Invoices', columns, data, filterable: true, filterPlaceholder: 'Search invoices…' },
+};
+
+export const Paginated: Story = {
+  args: {
+    'aria-label': 'Invoices',
+    columns,
+    data: Array.from({ length: 23 }, (_, i) => ({
+      id: `INV-${String(i + 1).padStart(3, '0')}`,
+      client: ['Aperture', 'Black Mesa', 'Cyberdyne', 'Tyrell', 'Weyland'][i % 5],
+      amount: (i + 1) * 137,
+      status: (['PAID', 'DUE', 'OVERDUE'] as const)[i % 3],
+      date: `2026-04-${String((i % 28) + 1).padStart(2, '0')}`,
+    })),
+    pagination: true,
+    defaultPageSize: 10,
+  },
+};
+
+export const Selectable: Story = {
+  args: { 'aria-label': 'Invoices', columns, data, selectionMode: 'multiple' },
+};
+
+export const Unstriped: Story = {
+  args: { 'aria-label': 'Invoices', columns, data, striped: false },
+};
+
+export const Compact: Story = {
+  args: { 'aria-label': 'Invoices', columns, data, size: 'sm' },
+};
+
+export const Empty: Story = {
+  args: { 'aria-label': 'Invoices', columns, data: [], emptyState: 'NO RECORDS FOUND' },
+};
+
+export const Everything: Story = {
+  args: {
+    'aria-label': 'Invoices',
+    title: 'INVOICES',
+    description: 'Sortable, filterable, paginated, selectable.',
+    columns,
+    data,
+    filterable: true,
+    pagination: true,
+    selectionMode: 'multiple',
+    defaultPageSize: 5,
+  },
+};
+```
+
+- [ ] **Step 2: Build Storybook to verify stories compile**
+
+Run: `npm run build-storybook`
+Expected: build succeeds; Table stories present. (This wipes `docs/`; the committed plan file is preserved in git history, not the working tree — see the plan-location note.)
+
+- [ ] **Step 3: Run the full local CI-equivalent gauntlet**
+
+Run each; all must pass:
+
+```bash
+node scripts/sync-client-directives.mjs --check
+npm run lint
+npm run lint-tokens
+npm run test -- --testPathPatterns="Table|tableUtils" --coverage --collectCoverageFrom='src/components/Table/**/*.{ts,tsx}'
+npm run build
+node scripts/assert-rsc-safety.mjs
+```
+
+Expected:
+- `sync-client-directives --check`: clean (Table is client, directive present).
+- `lint` / `lint-tokens`: no errors.
+- Table coverage ≥ 80% on all four metrics. If any line is uncovered, add a focused test (e.g. controlled `page`, `manualPagination` + `rowCount`, `single` selection mode, custom `sortComparator`).
+- `build`: emits `dist/components/Table/index.js` + `index.d.ts`.
+- `assert-rsc-safety`: Table client chain resolves; `.` barrel stays directive-free; `react-aria-components` is a declared dependency.
+
+- [ ] **Step 4: Run the full test suite once to confirm no regressions**
+
+Run: `npm test -- --ci`
+Expected: PASS, including `src/styles/package-exports.test.ts` (Table dir auto-joins the wildcard parity check).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Table/components/Table.stories.tsx
+git commit -m "docs(Table): Storybook stories covering sort/filter/paginate/select/striping"
+```
+
+---
+
+## Self-Review (completed against the spec)
+
+**Spec coverage:**
+- "Pull UTI Table source as reference" → done in research (UTI is a RAC-based, composition + data-driven Table; we mirror the RAC foundation and the card/header/footer split — see Reference Facts). No UTI code imported (license rule honored).
+- "Implement with eidotter Tailwind tokens" → Tasks 1, 3–7 use only `dos-*` utilities + declared `var(--*)` tokens; Global Constraints forbid hex/arbitrary/rgba.
+- "sorting" → Task 3. "filtering" → Task 4. "pagination" → Task 5. "row selection" → Task 6.
+- "DOS aesthetic: scanline row striping, phosphor glow on hover" → Task 7 (`--effects-scanline-light/dark`, inset `--color-cga-amber-glow`).
+- "Add Storybook stories, tests" → tests in every task; stories in Task 8.
+- "Register in registry.ts" → Task 1, Step 7.
+
+**Placeholder scan:** Two intentional verify-then-adapt notes remain (Button `isDisabled`/`onPress` prop names; RAC `className` string vs render-prop form). Both name the exact file to check and the fallback — they are decision points, not "implement later" gaps. The eidotter-`<Checkbox>`-vs-RAC-`Checkbox` decision is resolved (use RAC `Checkbox`).
+
+**Type consistency:** `TableColumn`/`TableProps`/`getCellValue`/`applySort`/`applyFilter`/`paginate`/`getPageCount` names are identical across Tasks 1–8. `getCellValue` is defined once in `tableUtils.ts` (Task 2) and re-exported from `Table.tsx`. Processing chain order is fixed: filter → sort → paginate, with `processed` = filtered+sorted and `visibleData` = paginated.
+
+**Risk notes for the implementer:**
+- RAC's `<Table>` typing for `className`/`style` on `Column`/`Cell`/`Row` may want the render-prop form in strict mode; the string form shown is valid in `^1.16.0` but switch to `() => '…'` if `tsc` objects.
+- Generic Storybook typing (`Meta<typeof Table<Invoice>>`) can be finicky; if Storybook's types reject the generic, type `meta` as `Meta<typeof Table>` and cast args.
+- Keep all new CSS classes referenced by `lint-tokens`-safe tokens only; do not introduce a new `--*` variable.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/plans/2026-06-26-dmnc-594-plan.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — dispatch a fresh subagent per task (Tasks 1–8), review between tasks, fast iteration.
+2. **Inline Execution** — execute tasks in-session with checkpoints after each task.
+
+This is a planning-only deliverable (per DMNC-594 workflow); implementation happens in a follow-up PR.


### PR DESCRIPTION
## Summary

Planning-only deliverable for **DMNC-594 — New component: Table**. This PR adds a single implementation-plan document; **no source/tests/config are modified**.

The plan specifies a DOS-themed `<Table>` data-display component:

- **Built on React Aria Components** `Table/TableHeader/Column/TableBody/Row/Cell` (already a dependency) — free keyboard nav, `aria-sort`, selection semantics, roles.
- **Data-driven API** (`<Table columns={...} data={...} />`) — the shape the `mgnt`/`steuerdash` dashboards want. Composition API is explicitly out of scope for v1.
- **Managed sorting / filtering / pagination / row-selection** by default over the supplied `data`, with controlled props + `onChange` callbacks and per-dimension `manual*` flags for server-side data.
- **DOS aesthetic:** scanline row striping (`--effects-scanline-light/dark`), inset phosphor hover glow (`--color-cga-amber-glow`), all with `prefers-reduced-motion` / `prefers-contrast` fallbacks.
- **TDD task breakdown** (8 bite-sized tasks) with exact file paths, complete code, and every CI guardrail accounted for (token freshness, `lint-tokens`, `'use client'` sync, RSC safety, 80% coverage, package-exports parity, axe).

UTI was used as a **pattern reference only** (RAC-based Table + card/header/footer split) — no UTI code is imported, per the license rule.

## What's in this PR

- `docs/plans/2026-06-26-dmnc-594-plan.md`

## Reviewer notes

- ⚠️ **Path caveat:** `docs/plans/` is matched by the global `plans/` `.gitignore` rule (intended for the repo-root local-only plans dir) and `docs/` is wiped on every `npm run build-storybook`. The file was **force-added** so it lands in this review PR; its permanent home is this PR's git history. If you'd prefer a tracked, storybook-safe location, `solutions/` is the convention — happy to relocate.
- Two intentional "verify-then-adapt" notes remain in the plan (eidotter `<Button>` `isDisabled`/`onPress` prop names; RAC `className` string vs render-prop form) — each names the exact file to check and a fallback.

## Next step

Implementation happens in a **follow-up PR** that executes the plan task-by-task.

Linear: [DMNC-594](https://linear.app/lizomorf/issue/DMNC-594/new-component-table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
