### PR TITLE
docs(plans): DMNC-610 — Checkbox Astro island render-prop fix plan

### DIFF
--- a/docs/plans/2026-06-26-dmnc-610-plan.md
+++ b/docs/plans/2026-06-26-dmnc-610-plan.md
@@ -1,0 +1,307 @@
+---
+title: "fix: Resolve React Aria render-prop state update failure in Astro islands"
+date: 2026-06-26
+issue: DMNC-610
+type: fix
+component: Checkbox
+related: Switch
+---
+
+# fix: Resolve React Aria render-prop state update failure in Astro islands
+
+**Issue:** DMNC-610  
+**Component:** Checkbox (primary), Switch (structurally identical — same fix applies)
+
+---
+
+## Summary
+
+The Checkbox component's visual indicator (`[ ]` / `[X]` / `[-]`) never updates when the checkbox is clicked inside an Astro island, regardless of which `client:*` directive is used. The underlying cause is that React Aria Components' (RAC) render prop mechanism — `({ isSelected, isIndeterminate }) => ...` — does not re-render in Astro's island rendering context. The native hidden input does toggle (confirming React Aria receives the click), but the render prop children are never called with the updated state.
+
+The fix is to remove the dependency on RAC's render prop for visual state and instead drive visual rendering from a local `useState`, updated via the `onChange` callback that React Aria fires reliably. React Aria continues to own accessibility, keyboard handling, focus management, and ARIA attribute propagation.
+
+---
+
+## Problem Frame
+
+**Observed behavior:**  
+Clicking a `<Checkbox client:visible />` (or `client:load`, `client:only="react"`) in Astro toggles the native hidden `<input>` but leaves the visual `[ ]` unchanged. The `data-selected` attribute is never applied to the root label element.
+
+**Scope of failure:**  
+All Astro `client:*` directives fail, including `client:only="react"` (pure client-side, no SSR). This rules out SSR/hydration mismatch as the cause.
+
+**Storybook status:** Works correctly (pure client-side React, no Astro build pipeline involvement).
+
+---
+
+## Root Cause
+
+React Aria Components' render prop pattern uses an internal `useRenderProps` hook that memoizes the state object and passes it to function children. In Astro's island rendering context, this memoization or context propagation breaks: `useToggleState` updates its internal state (the hidden input reflects this), but the render prop function is not re-invoked with the new state object.
+
+The same pattern exists verbatim in the Switch component, which is expected to have the same failure mode.
+
+Key evidence:
+- `client:only="react"` skips SSR entirely — if this also fails, the issue is in client-side render lifecycle, not hydration reconciliation.
+- Native input toggles → React Aria's `onChange` fires and internal state changes.
+- `data-selected` is never set → the state change does not reach the DOM props layer that RAC manages.
+- Storybook works → the failure is Astro-build-pipeline-specific, not a raw React rendering issue.
+
+React Aria does not document this as a known Astro limitation. The `SSRProvider` mentioned in React Aria's docs is only required for React 16/17; React 18+ uses `React.useId` natively.
+
+---
+
+## Requirements
+
+- **R1:** Clicking a Checkbox in an Astro island must toggle the visual indicator between `[ ]` and `[X]`.
+- **R2:** The indeterminate state must render `[-]` when the `indeterminate` prop is set.
+- **R3:** Controlled mode (`checked` prop) must keep the visual synchronized with the prop value.
+- **R4:** Uncontrolled mode (`defaultChecked`) must visually reflect user toggles without a controlling parent.
+- **R5:** The `onChange` callback must still fire with the correct boolean value.
+- **R6:** All existing accessibility behavior (keyboard, focus ring, ARIA attributes, `data-*` state attributes on the root element) must be preserved.
+- **R7:** No breaking changes to the public API surface (`CheckboxProps`).
+
+---
+
+## Key Technical Decisions
+
+**KTD-1: Local `useState` for visual rendering instead of RAC render prop**
+
+Replace the `({ isSelected, isIndeterminate }) => ...` function children with static JSX that reads from a local `useState`. The local state is initialized from `defaultChecked` / `checked` and is updated on every `onChange` call. The `AriaCheckbox` component continues to own all a11y behavior; we only bypass its render prop mechanism for visual content.
+
+*Why:* React Aria's `onChange` fires reliably even when the render prop doesn't re-invoke. Driving visual state from a local `useState` → `onChange` cycle is a standard React pattern immune to Astro island context issues.
+
+*Trade-off:* Two sources of truth for `isSelected` exist briefly during a transition (local state vs. RAC internal state), but because `onChange` fires synchronously with the state change, they stay in lock-step. The controlled mode `useEffect` sync ensures the prop value always wins.
+
+**KTD-2: Use `useEffect` for controlled mode sync, not direct prop pass-through**
+
+When `checked` prop changes (controlled mode), a `useEffect` watching `checked` updates the local `visualSelected` state. This ensures the visual reflects the external prop even when changed outside of user interaction.
+
+*Why:* The prop change may not arrive via `onChange` (e.g., parent resets the value). `useEffect` catches all sources of controlled value change.
+
+**KTD-3: Preserve `AriaCheckbox` — do not rewrite with `@react-aria/checkbox` hooks**
+
+The fix does not replace `react-aria-components`'s `Checkbox` with lower-level `useCheckbox` + `useToggleState` hooks. Staying with RAC keeps the existing a11y contract, avoids a larger refactor, and allows the fix to be applied uniformly to Switch.
+
+**KTD-4: Fix Switch in the same change set**
+
+Switch has the identical render prop pattern. Applying the same fix to Switch prevents a follow-up DMNC ticket and keeps the two components consistent.
+
+---
+
+## High-Level Technical Design
+
+The state flow before and after the fix:
+
+```
+BEFORE (broken in Astro):
+  User click → RAC internal state (useToggleState) → render prop re-invoked?
+                                                     ↑ BREAKS HERE in Astro context
+                ↓
+        onChange fires (reliable)
+
+AFTER (fixed):
+  User click → RAC internal state (useToggleState) → [ignored for visual rendering]
+                ↓
+        onChange(newValue) → setVisualSelected(newValue) → React re-render → [X] / [ ]
+
+  Controlled prop change → useEffect([checked]) → setVisualSelected(checked)
+  Indeterminate prop change → useEffect([indeterminate]) → setVisualIndeterminate(indeterminate)
+```
+
+Data attributes on the root `<label>` element (`data-selected`, `data-hovered`, `data-focused`, `data-focus-visible`, `data-disabled`) are set by React Aria directly on the DOM node — NOT via the render prop — so CSS selectors targeting these attributes continue to work without change.
+
+---
+
+## Scope Boundaries
+
+### In scope
+- `src/components/Checkbox/components/Checkbox.tsx` — replace render prop with local state
+- `src/components/Checkbox/components/Checkbox.test.tsx` — add visual-toggle and controlled-sync tests
+- `src/components/Switch/components/Switch.tsx` — same fix (identical pattern)
+- `src/components/Switch/components/Switch.test.tsx` — same test additions
+- `solutions/ui-bugs/` — new solution doc capturing the root cause and fix pattern
+
+### Out of scope
+- Other React Aria Components (Tag, Input, Tabs, Modal) — investigated if affected but not fixed in this PR; they do not use the `({ isSelected }) =>` render prop pattern in the same way
+- Checkbox indeterminate-via-render-prop CSS classes (`eidotter-checkbox__box--indeterminate`) — these are replaced by the local state equivalent; no visual change to end users
+- Changes to the Storybook stories — Storybook already works; stories need no modification
+- Adding an Astro test harness or Playwright Astro integration test — deferred
+
+### Deferred to follow-up work
+- Audit remaining interactive RAC components (Tag group, Tabs) for the same render prop failure pattern — separate ticket after this fix ships
+- Astro integration test (Playwright) to prevent regression — requires adding `@astrojs/react` to the dev toolchain
+
+---
+
+## Open Questions
+
+None blocking implementation. The root cause is well-understood from the `client:only="react"` failure evidence.
+
+---
+
+## Implementation Units
+
+### U1. Fix Checkbox render prop — use local state for visual rendering
+
+**Goal:** Remove the RAC render prop dependency for visual rendering in `Checkbox.tsx`. Use local `useState` to track `visualSelected` and `visualIndeterminate`, updated via `onChange`.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7
+
+**Dependencies:** None
+
+**Files:**
+- `src/components/Checkbox/components/Checkbox.tsx` (modify)
+
+**Approach:**
+
+1. Import `useState`, `useEffect` from React.
+2. Add two state variables:
+   - `visualSelected`: initialized to `checked ?? defaultChecked ?? false`
+   - `visualIndeterminate`: initialized to `indeterminate ?? false`
+3. Add `useEffect` watching `checked` (defined/changed externally in controlled mode): when `checked !== undefined`, call `setVisualSelected(checked)`.
+4. Add `useEffect` watching `indeterminate`: keep `visualIndeterminate` in sync with the prop.
+5. Introduce `handleChange(val: boolean)` that calls `setVisualSelected(val)` then `onChange?.(val)`.
+6. Pass `onChange={handleChange}` to `AriaCheckbox` (instead of `onChange={onChange}` directly).
+7. Replace function-as-children with static JSX that reads `visualSelected` and `visualIndeterminate` instead of the destructured render prop parameters.
+
+The `isSelected` prop passed to `AriaCheckbox` remains `checked` (controlled) or is omitted (uncontrolled). `defaultSelected={defaultChecked}` stays in place for uncontrolled initialization of RAC's internal state.
+
+**Patterns to follow:** The React Aria canonical controlled example uses `useState` + `onChange={setSelection}` as shown in the React Aria docs — this unit brings Checkbox in line with that pattern while keeping the RAC wrapper.
+
+**Test scenarios:**
+- `Test expectation: covered in U2`
+
+**Verification:**
+- `[ ]` renders for unchecked initial state (same as before)
+- Click toggles visual to `[X]` (the previously broken case)
+- Click again toggles back to `[ ]`
+- Setting `checked={true}` renders `[X]` immediately
+- Changing `checked` from `false` to `true` in a parent's state update re-renders to `[X]`
+- Setting `indeterminate={true}` renders `[-]`
+- All existing tests pass without modification
+
+---
+
+### U2. Extend Checkbox test suite with visual toggle and controlled sync coverage
+
+**Goal:** Add test cases that would have caught the Astro regression — specifically that visual state updates on user interaction, and that controlled prop changes propagate to the visual.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** U1
+
+**Files:**
+- `src/components/Checkbox/components/Checkbox.test.tsx` (modify)
+
+**Approach:** Add tests using `userEvent.click` that assert the rendered bracket text changes after interaction. Also add a controlled mode test that re-renders with a different `checked` prop and confirms the visual updates.
+
+**Patterns to follow:** The existing test at line 27–32 (`calls onChange when clicked`) — extend the same `userEvent` pattern to also assert the visual state.
+
+**Test scenarios:**
+
+- **Happy path — uncontrolled toggle:** Render `<Checkbox label="Toggle" />`. Click the checkbox. Assert `[X]` is now in the document (was `[ ]`). Click again. Assert `[ ]` is back.
+- **Happy path — uncontrolled with defaultChecked:** Render `<Checkbox label="Pre-checked" defaultChecked />`. Assert `[X]` renders initially. Click. Assert `[ ]`.
+- **Controlled mode sync:** Render `<Checkbox label="Ctrl" checked={false} onChange={() => {}} />`. Assert `[ ]`. Re-render with `checked={true}`. Assert `[X]`.
+- **Indeterminate takes priority over selected:** Render `<Checkbox indeterminate checked label="Both" onChange={() => {}} />`. Assert `[-]`.
+- **onChange fires with correct new value:** Render uncontrolled, click, confirm `onChange` receives `true`. Click again — if `onChange` updates parent state causing `checked={true}`, click again confirms `onChange` receives `false`. (Existing test at line 27 covers the first part; the re-click case is new.)
+- **Disabled blocks visual change:** Click a `disabled` checkbox; assert visual stays `[ ]`.
+
+**Verification:** `npm run test -- --testPathPatterns="Checkbox"` passes all tests including the six new scenarios above.
+
+---
+
+### U3. Fix Switch render prop — same local-state pattern
+
+**Goal:** Apply the identical fix to `Switch.tsx`. Switch uses `({ isSelected }) => ...` as children of `AriaSwitch` — the same render prop mechanism that breaks in Astro islands.
+
+**Requirements:** Prevent the same Astro island failure in Switch (structurally equivalent to R1–R6 for Checkbox).
+
+**Dependencies:** U1 (establishes the pattern)
+
+**Files:**
+- `src/components/Switch/components/Switch.tsx` (modify)
+
+**Approach:** Mirror the U1 changes:
+1. Add `useState` for `visualSelected`, initialized from `checked ?? defaultChecked ?? false`.
+2. Add `useEffect` watching `checked` for controlled mode sync.
+3. Introduce `handleChange` that sets `visualSelected` then calls `onChange` or `onCheckedChange`.
+4. Replace function-as-children with static JSX using `visualSelected`.
+
+Switch does not have an `indeterminate` state, so no second state variable is needed.
+
+**Patterns to follow:** U1's Checkbox implementation.
+
+**Test scenarios:**
+- `Test expectation: covered in U4`
+
+**Verification:** All existing Switch tests pass. Visual track state (`eidotter-switch__track--checked`) toggles on click in a manual Astro test or by reviewing the state flow.
+
+---
+
+### U4. Extend Switch test suite with visual toggle coverage
+
+**Goal:** Mirror the Checkbox tests from U2 for Switch.
+
+**Requirements:** Parallel coverage for Switch.
+
+**Dependencies:** U3
+
+**Files:**
+- `src/components/Switch/components/Switch.test.tsx` (modify)
+
+**Approach:** Read existing Switch test file; add tests using `userEvent.click` that assert the CSS class `eidotter-switch__track--checked` is added/removed on toggle.
+
+**Test scenarios:**
+
+- **Uncontrolled toggle:** Render `<Switch label="Toggle" />`. Click. Assert `eidotter-switch__track--checked` class is present on the track span.
+- **Click again removes class:** Click a second time. Assert class is absent.
+- **Controlled mode sync:** Render `<Switch checked={false} onChange={() => {}} />`. Re-render with `checked={true}`. Assert `eidotter-switch__track--checked` is present.
+- **Disabled blocks visual change:** Click a `disabled` switch; assert `eidotter-switch__track--checked` is absent.
+
+**Verification:** `npm run test -- --testPathPatterns="Switch"` passes all tests including the four new scenarios above.
+
+---
+
+### U5. Add solution document for React Aria render-prop Astro island failure
+
+**Goal:** Capture the root cause, diagnostic pattern, and fix for future reference. Prevents re-investigation if the pattern surfaces in other components.
+
+**Requirements:** None (maintenance value only)
+
+**Dependencies:** U1, U3
+
+**Files:**
+- `solutions/ui-bugs/react-aria-render-prop-astro-island-2026-06-26.md` (create)
+
+**Approach:** Follow the existing solution doc format (YAML frontmatter + prose). Cover:
+- Problem pattern: RAC render prop children not re-rendering in Astro island context
+- Root cause: `useRenderProps` memoization breaks in Astro's build/render lifecycle
+- Diagnostic signature: `client:only="react"` also fails; native input toggles but `data-selected` never set
+- Fix: replace render prop with `useState` + `onChange` cycle
+- Affected components at time of writing: Checkbox (fixed in DMNC-610), Switch (fixed in DMNC-610)
+- Components to audit: Tag, Input, Tabs (use RAC but different render patterns — may or may not be affected)
+
+**Test scenarios:**
+- `Test expectation: none — documentation file, no tests`
+
+**Verification:** File exists at the correct path with accurate YAML frontmatter (`module: checkbox, switch`, `tags: react-aria, astro, island, hydration, render-prop`).
+
+---
+
+## Risks and Dependencies
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Controlled mode desync if `useEffect` fires after the render | Low | `useEffect` deps are stable prop references; controlled value always wins |
+| `onChange` firing from React Aria AND from our `handleChange` doubling calls | Not applicable | We pass `onChange={handleChange}` which replaces the direct prop — RAC calls our handler once |
+| Switch `defaultChecked` interaction with `useEffect` sync | Low | Initialize `visualSelected` from `checked ?? defaultChecked ?? false`; `useEffect` only updates when `checked` is defined (controlled mode) |
+| Future RAC upgrade fixes the render prop issue, leaving redundant local state | Low | Local state is cheap and correct; if RAC later fixes the propagation, the redundancy is harmless |
+
+---
+
+## Sources and Research
+
+- React Aria controlled Checkbox docs: https://react-aria.adobe.com/Checkbox — confirms `useState + onChange` as the canonical pattern for external state management
+- React Aria SSR docs: https://react-aria.adobe.com/SSRProvider — confirms `SSRProvider` is not needed for React 18+; not the root cause
+- DMNC-610 investigation notes: `client:only="react"` failure is the key diagnostic that isolates the cause to client-side render lifecycle, not SSR hydration
+- `solutions/developer-experience/figma-variable-binding-quirks-2026-05-08.md` — reference for solution doc format


### PR DESCRIPTION
## Summary

- Adds implementation plan for DMNC-610: React Aria Checkbox hydration failure in Astro islands
- Root cause: RAC render-prop children (`({ isSelected }) => ...`) do not re-render in Astro's island context; local `useState` + `onChange` cycle is the fix
- Plan covers Checkbox (primary), Switch (identical pattern), test extensions, and a solution doc

## What's in this PR

`docs/plans/2026-06-26-dmnc-610-plan.md` — Standard-depth implementation plan with:
- Root cause analysis (confirmed by `client:only="react"` also failing — not an SSR hydration issue)
- 5 implementation units (Checkbox fix → Checkbox tests → Switch fix → Switch tests → solution doc)
- Key technical decisions with rationale
- Test scenarios for each unit

## Test plan
- [ ] Review root cause analysis and confirm the `client:only` failure evidence holds
- [ ] Confirm scope (Switch included alongside Checkbox) is appropriate
- [ ] Proceed to `/ce-work` with the plan once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)