### PR TITLE
chore(release): eidotter v0.37.3 — RetroEffects CRT boot FOUC fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eidotter",
-  "version": "0.37.2",
+  "version": "0.37.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eidotter",
-      "version": "0.37.2",
+      "version": "0.37.3",
       "license": "CC-BY-NC-4.0",
       "dependencies": {
         "pixelarticons": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.37.2",
+  "version": "0.37.3",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",


### PR DESCRIPTION
Release **v0.37.3**: bumps 0.37.2 → 0.37.3 to publish the RetroEffects CRT boot FOUC fix (DMNC-1184, #457).

Merging + cutting the `v0.37.3` GitHub Release triggers `publish.yml` (OIDC trusted publish to npm).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>