### PR TITLE
chore(release): eidotter v0.37.4 — Select/Dropdown component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eidotter",
-  "version": "0.37.3",
+  "version": "0.37.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eidotter",
-      "version": "0.37.3",
+      "version": "0.37.4",
       "license": "CC-BY-NC-4.0",
       "dependencies": {
         "pixelarticons": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.37.3",
+  "version": "0.37.4",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",


### PR DESCRIPTION
Release **v0.37.4**: bumps 0.37.3 → 0.37.4 to publish the new Select/Dropdown component (DMNC-593, #456) to npm.

Merging + cutting the `v0.37.4` GitHub Release triggers `publish.yml` (OIDC trusted publish).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>