### PR TITLE
fix(nav): sanitize href at every nav link boundary via shared isSafeHref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Storybook: `article` unsafe-`href` story (DMNC-1281 follow-up).** New `ArticleUnsafeHref` story pins the read-more sanitization contract visually: an entry whose `href` uses an unsafe scheme (`javascript:` etc.) fails `isSafeHref` and renders **no anchor at all** — not a disabled link, not a `#` fallback — shown expanded next to a safe-`href` entry for contrast. Completes the story matrix for the `article` entry kind shipped in 0.38.0 (thumbnail overflow / expanded / no-images / unsafe-href).
 
+### Fixed
+- **URL-safety hardening at every nav link boundary (todos 001–003 + Breadcrumb follow-up).** `<Breadcrumb>`, `<Nav>`, `<Footer>`, and `<Header brandHref>` previously rendered author-supplied `href`s verbatim — an `href: 'javascript:…'` (or `data:`/`vbscript:`) in a consumer's nav data became a live `<a href>`. All four now sanitize through the shared **`isSafeHref`** util: an unsafe scheme renders the label as a plain span (no anchor), and Header's structural brand link falls back to `'/'`. Internal/relative routes (`/path`, `#hash`, `?query`) are unaffected. Consolidates three sanitizers that had drifted (`isSafeUrl`, `isSafeHref`, InlineLink's private `sanitizeHref`) into a coherent pair: `isSafeHref` (relative-allowing, for anchor hrefs) is now **publicly exported** alongside `isSafeUrl` (absolute-only, for image/favicon srcs), with a new `extraSchemes` option (e.g. `tel`/`ftp`/`sms`). `InlineLink`'s private sanitizer now delegates to it with behavior unchanged.
+
 ## [0.38.1] - 2026-07-10
 
 ### Fixed

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -2,6 +2,16 @@
 
 Working-mode log (deviations from plan, late-discovered unknowns, conservative choices made on Dom's behalf). Feeds the next planning round.
 
+## 2026-07-11 — URL safety consolidation (v0.39.0 release train, Plan 1 of 5)
+
+- **This file is intentionally tracked/public (Dom's call, deviation from plan).** Plan 1's D7 protocol said to create `IMPLEMENTATION_NOTES.md` and `.gitignore` it. But #466 (DMNC-1373) had already committed it as a tracked file, so it's public on GitHub. Asked Dom → he chose to keep it a **public dev-log** rather than un-track or scrub history. So future notes here are public-by-design; keep them factual and non-sensitive.
+- **`main` advanced 3 commits during planning** — `origin/main` was at `70e64c1` (v0.38.1 fontless CSS, #466) while the plan was verified against the 0.37.x-era tree. Branched `fix/url-safety-consolidation` off the fresh `main`. Side effect: `isSafeHref` was *already* imported by the TimelineContainer `article`/`gallery` variants, and an `ArticleUnsafeHref` story + an `[Unreleased] → Added` line already existed — so this work only *exports* the util and applies it at the four nav boundaries.
+- **registry `ChangelogEntry.type` has no `'fixed'` (deviation from plan).** The plan said `type: 'fixed'`; the union is `'added' | 'changed' | 'deprecated' | 'removed'`. Used `'changed'` for all five entries — `'fixed'` would fail `tsc`/lint. (CHANGELOG.md keeps the Keep-a-Changelog `### Fixed` heading, which is correct there.)
+- **No `Nav` registry entry exists (conservative choice).** The plan listed Nav for a changelog line, but `registry.ts` has no `Nav:` key (only `DesktopNav`/`MobileNav` are the real exports and neither is registered). Rather than fabricate a full metadata entry (origin/consumers/since/platforms), added the 0.39.0 changelog line to the four registered components (Breadcrumb, Header, Footer, InlineLink) and noted Nav's guard inside Header's entry. Registering Nav is a separate follow-up.
+- **Header/Footer registry entries were one-liners without a `changelog` array** — expanded both to multi-line objects to carry the 0.39.0 entry (no other field changed).
+- **Todo Work Logs dated 2026-07-11 (today), not the plan's hardcoded 2026-07-10.** Todos 001/002/003 were already DONE in code (isSafeUrl + InlineExpand + `span[role=list]`); this PR only flips their frontmatter to `complete` and records the Breadcrumb/Nav/Footer/Header retrofit + consolidation.
+- **`isSafeUrl` left deliberately strict for favicons.** Did NOT unify InlineExpand's `isSafeUrl(source.favicon)` onto `isSafeHref` — favicons need absolute-URL semantics (relative = broken image; `data:` = the attack surface todo 002 targeted). Documented the division of labor in both utils' JSDoc.
+
 ## 2026-07-10 — DMNC-1373 (0.38.1 fontless dist CSS)
 
 - **Publish flow is release-triggered, not local (plan deviation).** `.github/workflows/publish.yml` publishes to npm via OIDC trusted publishing when a GitHub Release is published (local `npm publish` would bypass provenance and the stale-NPM_TOKEN history documented in that workflow). The DMNC-1373 checkpoint therefore gates on: merge PR → create GitHub Release `v0.38.1` → workflow publishes. Do NOT publish locally.

--- a/src/components/Breadcrumb/components/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb/components/Breadcrumb.test.tsx
@@ -210,4 +210,36 @@ describe('Breadcrumb', () => {
       expect(nav).toHaveClass('eidotter-breadcrumb');
     });
   });
+
+  describe('href safety', () => {
+    it('renders the label without an anchor when href uses an unsafe scheme', () => {
+      const trail = [{ href: 'javascript:alert(1)', label: 'Danger' }];
+      render(<Breadcrumb trail={trail} currentLabel="Details" showBackArrow={false} />);
+      expect(screen.getByText('Danger')).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Danger' })).not.toBeInTheDocument();
+      expect(screen.getByText('Danger').closest('a')).toBeNull();
+    });
+
+    it('renders a safe relative href as a normal link (regression guard)', () => {
+      const trail = [{ href: '/projects', label: 'Projects' }];
+      render(<Breadcrumb trail={trail} currentLabel="Details" showBackArrow={false} />);
+      const link = screen.getByRole('link', { name: 'Projects' });
+      expect(link).toHaveAttribute('href', '/projects');
+    });
+
+    it('drops the anchor for an unsafe href through a custom linkComponent', () => {
+      const CustomLink: React.FC<{ href: string; className?: string; children: React.ReactNode }> =
+        ({ href, className, children }) => (
+          <a href={href} className={className} data-custom="true">
+            {children}
+          </a>
+        );
+      const trail = [{ href: 'javascript:alert(1)', label: 'Danger' }];
+      render(
+        <Breadcrumb trail={trail} currentLabel="Details" linkComponent={CustomLink} showBackArrow={false} />,
+      );
+      expect(screen.getByText('Danger')).toBeInTheDocument();
+      expect(document.querySelectorAll('[data-custom="true"]').length).toBe(0);
+    });
+  });
 });

--- a/src/components/Breadcrumb/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/components/Breadcrumb.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Button as AriaButton } from 'react-aria-components';
 import { cn } from '../../../utils/cn';
+import { isSafeHref } from '../../../utils/isSafeHref';
 import './Breadcrumb.css';
 
 export interface BreadcrumbItem {
@@ -70,17 +71,21 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
       );
     }
 
-    if (item.href) {
+    // Guard author-supplied hrefs: unsafe schemes (javascript, data, vbscript, …)
+    // fall through to the non-link <span> branch below rather than rendering an anchor.
+    const safeHref = item.href && isSafeHref(item.href) ? item.href : undefined;
+
+    if (safeHref) {
       if (LinkComponent) {
         return (
-          <LinkComponent href={item.href} className={linkClasses}>
+          <LinkComponent href={safeHref} className={linkClasses}>
             {linkContent}
           </LinkComponent>
         );
       }
 
       return (
-        <a href={item.href} className={linkClasses}>
+        <a href={safeHref} className={linkClasses}>
           {linkContent}
         </a>
       );

--- a/src/components/Footer/components/Footer.test.tsx
+++ b/src/components/Footer/components/Footer.test.tsx
@@ -177,4 +177,46 @@ describe('Footer', () => {
       expect(link).not.toHaveAttribute('data-router-link');
     });
   });
+
+  describe('href safety', () => {
+    it('renders the label without an anchor when href uses an unsafe scheme', () => {
+      render(<Footer links={[{ label: 'Danger', href: 'javascript:alert(1)' }]} />);
+      expect(screen.getByText('Danger')).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Danger' })).not.toBeInTheDocument();
+      expect(screen.getByText('Danger').closest('a')).toBeNull();
+    });
+
+    it('renders a safe relative href as a normal link (regression guard)', () => {
+      render(<Footer links={[{ label: 'About', href: '/about' }]} />);
+      const link = screen.getByRole('link', { name: 'About' });
+      expect(link).toHaveAttribute('href', '/about');
+    });
+
+    it('blocks an unsafe external href (drops the target anchor)', () => {
+      render(
+        <Footer links={[{ label: 'Danger', href: 'javascript:alert(1)', external: true }]} />,
+      );
+      expect(screen.getByText('Danger').closest('a')).toBeNull();
+    });
+
+    it('drops the anchor for an unsafe href through a custom linkComponent', () => {
+      const FakeRouterLink: React.FC<{ href: string; className?: string; children: React.ReactNode }> = ({
+        href,
+        className,
+        children,
+      }) => (
+        <a data-router-link="true" href={href} className={className}>
+          {children}
+        </a>
+      );
+      render(
+        <Footer
+          linkComponent={FakeRouterLink}
+          links={[{ label: 'Danger', href: 'javascript:alert(1)' }]}
+        />,
+      );
+      expect(screen.getByText('Danger')).toBeInTheDocument();
+      expect(document.querySelector('[data-router-link]')).toBeNull();
+    });
+  });
 });

--- a/src/components/Footer/components/Footer.tsx
+++ b/src/components/Footer/components/Footer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { cn } from '../../../utils/cn';
+import { isSafeHref } from '../../../utils/isSafeHref';
 import './Footer.css';
 
 export interface FooterLink {
@@ -69,25 +70,31 @@ export const Footer: React.FC<FooterProps & React.HTMLAttributes<HTMLElement>> =
       {children && <div className="mb-3">{children}</div>}
       {resolvedLinks.length > 0 && (
         <nav className="flex justify-center items-center flex-wrap gap-2 mb-2" aria-label="Footer links">
-          {resolvedLinks.map((link, index) => (
-            <React.Fragment key={link.href}>
-              {index > 0 && <span className="text-dos-text-muted select-none eidotter-footer__dot" aria-hidden="true">·</span>}
-              {link.external ? (
-                <a
-                  className={linkClassName}
-                  href={link.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {link.label}
-                </a>
-              ) : (
-                <LinkTag className={linkClassName} href={link.href}>
-                  {link.label}
-                </LinkTag>
-              )}
-            </React.Fragment>
-          ))}
+          {resolvedLinks.map((link, index) => {
+            // Unsafe hrefs (javascript, data, vbscript, …) render the label without an anchor.
+            const safeHref = isSafeHref(link.href) ? link.href : undefined;
+            return (
+              <React.Fragment key={link.href}>
+                {index > 0 && <span className="text-dos-text-muted select-none eidotter-footer__dot" aria-hidden="true">·</span>}
+                {!safeHref ? (
+                  <span className={linkClassName}>{link.label}</span>
+                ) : link.external ? (
+                  <a
+                    className={linkClassName}
+                    href={safeHref}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {link.label}
+                  </a>
+                ) : (
+                  <LinkTag className={linkClassName} href={safeHref}>
+                    {link.label}
+                  </LinkTag>
+                )}
+              </React.Fragment>
+            );
+          })}
         </nav>
       )}
       {copyright && (

--- a/src/components/Header/components/Header.test.tsx
+++ b/src/components/Header/components/Header.test.tsx
@@ -124,4 +124,39 @@ describe('Header', () => {
     render(<Header brandName="SITE" items={items} />);
     expect(screen.getByLabelText('Open menu')).toBeInTheDocument();
   });
+
+  describe('brandHref safety', () => {
+    it('falls back to "/" when brandHref uses an unsafe scheme', () => {
+      render(<Header brandName="SITE" brandHref="javascript:alert(1)" items={items} />);
+      const link = screen.getByText('SITE').closest('a');
+      expect(link).toHaveAttribute('href', '/');
+    });
+
+    it('falls back to "/" through a custom linkComponent', () => {
+      const CustomLink = ({
+        href,
+        children,
+        ...props
+      }: {
+        href: string;
+        children: React.ReactNode;
+        className?: string;
+        onClick?: () => void;
+      }) => (
+        <span data-href={href} {...props}>
+          {children}
+        </span>
+      );
+      render(
+        <Header
+          brandName="SITE"
+          brandHref="javascript:alert(1)"
+          items={items}
+          linkComponent={CustomLink}
+        />,
+      );
+      const brandingLink = screen.getByText('SITE').closest('span');
+      expect(brandingLink).toHaveAttribute('data-href', '/');
+    });
+  });
 });

--- a/src/components/Header/components/Header.tsx
+++ b/src/components/Header/components/Header.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef } from 'react';
 import { cn } from '../../../utils/cn';
+import { isSafeHref } from '../../../utils/isSafeHref';
 import { DesktopNav, MobileNav } from '../../Nav';
 import type { NavItem, NavProps } from '../../Nav';
 import './Header.css';
@@ -43,6 +44,9 @@ export const Header = forwardRef<HTMLElement, HeaderProps>(({
   ...rest
 }, ref) => {
   const LinkTag = (linkComponent as React.ElementType | undefined) ?? 'a';
+  // The brand link is structural — an unsafe brandHref falls back to '/' rather
+  // than unmounting the branding anchor.
+  const safeBrandHref = isSafeHref(brandHref) ? brandHref : '/';
 
   return (
     <header
@@ -57,7 +61,7 @@ export const Header = forwardRef<HTMLElement, HeaderProps>(({
       {...rest}
     >
       <LinkTag
-        href={brandHref}
+        href={safeBrandHref}
         className={cn(
           'no-underline text-base font-bold tracking-wide',
           'eidotter-header__branding',

--- a/src/components/InlineLink/components/InlineLink.tsx
+++ b/src/components/InlineLink/components/InlineLink.tsx
@@ -1,19 +1,17 @@
 import React, { forwardRef } from 'react';
 import { cn } from '../../../utils/cn';
+import { isSafeHref } from '../../../utils/isSafeHref';
 import './InlineLink.css';
 
 // Relative paths, hash/query fragments, and standard nav schemes are allowed.
 // Everything else (javascript:, data:, vbscript:, unknown schemes) collapses
-// to a safe "#" sentinel.
+// to a safe "#" sentinel. Delegates to the shared isSafeHref util with
+// InlineLink's wider allowlist (tel/ftp/sms); behavior is unchanged — the empty
+// passthrough and "#" fallback are InlineLink-specific and preserved here.
 function sanitizeHref(href: string): string {
   const trimmed = href.trim();
   if (trimmed === '') return trimmed;
-  if (/^[#?/]/.test(trimmed)) return trimmed;
-  const schemeMatch = /^([a-z][a-z0-9+\-.]*):/i.exec(trimmed);
-  if (!schemeMatch) return trimmed;
-  const scheme = schemeMatch[1].toLowerCase();
-  const allowed = ['http', 'https', 'mailto', 'tel', 'ftp', 'sms'];
-  return allowed.includes(scheme) ? trimmed : '#';
+  return isSafeHref(trimmed, { extraSchemes: ['tel', 'ftp', 'sms'] }) ? trimmed : '#';
 }
 
 // Union-merge caller rel tokens with the required safety tokens so

--- a/src/components/Nav/components/Nav.test.tsx
+++ b/src/components/Nav/components/Nav.test.tsx
@@ -159,3 +159,36 @@ describe('Nav', () => {
     expect(container.querySelector('.eidotter-nav--desktop')).toBeInTheDocument();
   });
 });
+
+describe('href safety', () => {
+  const unsafeItems = [{ label: 'Danger', href: 'javascript:alert(1)' }];
+
+  it('DesktopNav renders an unsafe href as a plain span, not a link', () => {
+    render(<DesktopNav items={unsafeItems} />);
+    expect(screen.getByText('Danger')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Danger' })).not.toBeInTheDocument();
+    expect(screen.getByText('Danger').closest('a')).toBeNull();
+  });
+
+  it('DesktopNav renders a safe relative href as a link (regression guard)', () => {
+    render(<DesktopNav items={[{ label: 'Projects', href: '/projects' }]} />);
+    const link = screen.getByRole('link', { name: 'Projects' });
+    expect(link).toHaveAttribute('href', '/projects');
+  });
+
+  it('MobileNav renders an unsafe href as a plain span inside the panel', () => {
+    render(<MobileNav items={unsafeItems} />);
+    fireEvent.click(screen.getByLabelText('Open menu'));
+    expect(screen.getByText('Danger')).toBeInTheDocument();
+    expect(screen.getByText('Danger').closest('a')).toBeNull();
+  });
+
+  it('drops the anchor for an unsafe href through a custom linkComponent', () => {
+    const CustomLink = ({ href, children, ...props }: { href: string; children: React.ReactNode; className?: string }) => (
+      <span data-href={href} {...props}>{children}</span>
+    );
+    render(<DesktopNav items={unsafeItems} linkComponent={CustomLink} />);
+    expect(screen.getByText('Danger')).toBeInTheDocument();
+    expect(document.querySelector('[data-href]')).toBeNull();
+  });
+});

--- a/src/components/Nav/components/Nav.tsx
+++ b/src/components/Nav/components/Nav.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { cn } from '../../../utils/cn';
+import { isSafeHref } from '../../../utils/isSafeHref';
 import { Icon } from '../../Icon';
 import './Nav.css';
 
@@ -57,20 +58,30 @@ export const DesktopNav: React.FC<NavProps> = ({
       aria-label="Main navigation"
     >
       <ul className="eidotter-nav__desktop-list">
-        {items.map((item) => (
-          <li key={item.href} className="eidotter-nav__desktop-item">
-            <LinkTag
-              href={item.href}
-              className={cn(
-                'eidotter-nav__link',
-                activeHref === item.href && 'eidotter-nav__link--active',
+        {items.map((item) => {
+          // Unsafe hrefs (javascript, data, vbscript, …) render the label as a
+          // plain span instead of an anchor.
+          const safeHref = isSafeHref(item.href) ? item.href : undefined;
+          const linkClassName = cn(
+            'eidotter-nav__link',
+            activeHref === item.href && 'eidotter-nav__link--active',
+          );
+          return (
+            <li key={item.href} className="eidotter-nav__desktop-item">
+              {safeHref ? (
+                <LinkTag
+                  href={safeHref}
+                  className={linkClassName}
+                  aria-current={activeHref === item.href ? 'page' : undefined}
+                >
+                  {item.label}
+                </LinkTag>
+              ) : (
+                <span className={linkClassName}>{item.label}</span>
               )}
-              aria-current={activeHref === item.href ? 'page' : undefined}
-            >
-              {item.label}
-            </LinkTag>
-          </li>
-        ))}
+            </li>
+          );
+        })}
       </ul>
     </nav>
   );
@@ -183,21 +194,30 @@ export const MobileNav: React.FC<NavProps> = ({
         </div>
 
         <ul className="eidotter-nav__list">
-          {items.map((item) => (
-            <li key={item.href} className="eidotter-nav__item">
-              <LinkTag
-                href={item.href}
-                className={cn(
-                  'eidotter-nav__link',
-                  activeHref === item.href && 'eidotter-nav__link--active',
+          {items.map((item) => {
+            // Same guard as desktop — mobile panel is a second render path.
+            const safeHref = isSafeHref(item.href) ? item.href : undefined;
+            const linkClassName = cn(
+              'eidotter-nav__link',
+              activeHref === item.href && 'eidotter-nav__link--active',
+            );
+            return (
+              <li key={item.href} className="eidotter-nav__item">
+                {safeHref ? (
+                  <LinkTag
+                    href={safeHref}
+                    className={linkClassName}
+                    aria-current={activeHref === item.href ? 'page' : undefined}
+                    onClick={close}
+                  >
+                    {item.label}
+                  </LinkTag>
+                ) : (
+                  <span className={linkClassName}>{item.label}</span>
                 )}
-                aria-current={activeHref === item.href ? 'page' : undefined}
-                onClick={close}
-              >
-                {item.label}
-              </LinkTag>
-            </li>
-          ))}
+              </li>
+            );
+          })}
         </ul>
       </nav>
     </div>

--- a/src/components/registry.ts
+++ b/src/components/registry.ts
@@ -176,6 +176,7 @@ export const componentRegistry: Record<string, ComponentMeta> = {
       swiftui: { status: 'planned' },
     },
     changelog: [
+      { version: '0.39.0', type: 'changed', description: 'Sanitize href via shared isSafeHref — unsafe schemes (javascript:, data:, …) render the label without an anchor' },
       { version: '0.16.0', type: 'changed', description: 'Migrate to Tailwind-first (Wave 2 — Separator, Stat, Breadcrumb, Progress)' },
       { version: '0.9.0',  type: 'changed', description: 'Fix trail links invisible on dark backgrounds' },
       { version: '0.3.0',  type: 'added',   description: 'Initial Breadcrumb — trail array, currentLabel, separator, showBackArrow' },
@@ -663,8 +664,22 @@ export const componentRegistry: Record<string, ComponentMeta> = {
   ChatContainer: { origin: 'eidotter', consumers: [], originNote: 'Composes ChatHistory + ChatInput into a complete chat interface' },
 
   // Layout components
-  Header:        { origin: 'eidotter', consumers: [], originNote: 'Sticky site header composing branding link + Nav — retro/modern variants' },
-  Footer:        { origin: 'eidotter', consumers: [], originNote: 'DOS-themed footer with default legal links (Impressum + Datenschutz) for German compliance' },
+  Header: {
+    origin: 'eidotter',
+    consumers: [],
+    originNote: 'Sticky site header composing branding link + Nav — retro/modern variants',
+    changelog: [
+      { version: '0.39.0', type: 'changed', description: 'Sanitize brandHref via shared isSafeHref — unsafe schemes fall back to "/" (nav-item links guarded in Nav)' },
+    ],
+  },
+  Footer: {
+    origin: 'eidotter',
+    consumers: [],
+    originNote: 'DOS-themed footer with default legal links (Impressum + Datenschutz) for German compliance',
+    changelog: [
+      { version: '0.39.0', type: 'changed', description: 'Sanitize link hrefs via shared isSafeHref — unsafe schemes (javascript:, data:, …) render the label without an anchor' },
+    ],
+  },
 
   // Imported from April 2026 design handoff (v0.20.0)
   InlineLink: {
@@ -674,6 +689,7 @@ export const componentRegistry: Record<string, ComponentMeta> = {
     originNote: 'In-flow navigational anchor — dotted amber underline, phosphor-invert hover, trailing `▸` / `↗`. Distinct from InlineExpand (destination vs disclosure). Closes rizomorf parity gap #03.',
     platforms: { react: { path: 'src/components/InlineLink', status: 'canonical' } },
     changelog: [
+      { version: '0.39.0', type: 'changed', description: 'sanitizeHref now delegates to the shared isSafeHref util (extraSchemes tel/ftp/sms); behavior unchanged' },
       { version: '0.20.0', type: 'added', description: 'Initial InlineLink — internal + external variants, tabnabbing guard when consumer passes target="_blank"' },
     ],
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,8 @@ export { useTextScramble } from './hooks/useTextScramble';
 export type { UseTextScrambleOptions } from './hooks/useTextScramble';
 
 // Utilities
-export { isSafeUrl } from './utils';
+export { isSafeUrl, isSafeHref } from './utils';
+export type { SafeHrefOptions } from './utils';
 export { ZOOM_LEVELS } from './components/TimelineContainer';
 
 // Component metadata registry

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,4 @@
 export { isSafeUrl } from './isSafeUrl';
+export { isSafeHref } from './isSafeHref';
+export type { SafeHrefOptions } from './isSafeHref';
 export { prefersReducedMotion } from './prefersReducedMotion';

--- a/src/utils/isSafeHref.test.ts
+++ b/src/utils/isSafeHref.test.ts
@@ -79,6 +79,29 @@ describe('isSafeHref', () => {
     });
   });
 
+  describe('control-character scheme evasion (browsers strip tab/newline/CR)', () => {
+    it('blocks javascript: with an embedded tab', () => {
+      expect(isSafeHref('jav\tascript:alert(1)')).toBe(false);
+    });
+
+    it('blocks javascript: with an embedded newline', () => {
+      expect(isSafeHref('java\nscript:alert(1)')).toBe(false);
+    });
+
+    it('blocks javascript: with an embedded carriage return', () => {
+      expect(isSafeHref('java\rscript:alert(1)')).toBe(false);
+    });
+
+    it('blocks data: with an embedded tab', () => {
+      expect(isSafeHref('da\tta:text/html,alert(1)')).toBe(false);
+    });
+
+    it('does not over-block a relative path that happens to contain a tab', () => {
+      // After stripping control chars the string is still scheme-less → relative → safe.
+      expect(isSafeHref('/foo\tbar')).toBe(true);
+    });
+  });
+
   describe('extraSchemes option', () => {
     it('blocks tel: by default', () => {
       expect(isSafeHref('tel:+491234')).toBe(false);

--- a/src/utils/isSafeHref.test.ts
+++ b/src/utils/isSafeHref.test.ts
@@ -1,0 +1,109 @@
+import { isSafeHref } from './isSafeHref';
+
+describe('isSafeHref', () => {
+  describe('relative URLs (no scheme) are safe', () => {
+    it('allows absolute-path routes', () => {
+      expect(isSafeHref('/path')).toBe(true);
+    });
+
+    it('allows hash fragments', () => {
+      expect(isSafeHref('#hash')).toBe(true);
+    });
+
+    it('allows query strings', () => {
+      expect(isSafeHref('?query')).toBe(true);
+    });
+
+    it('allows relative ./ paths', () => {
+      expect(isSafeHref('./rel')).toBe(true);
+    });
+
+    it('allows bare filenames (no scheme, the dot is not a scheme separator)', () => {
+      expect(isSafeHref('page.html')).toBe(true);
+    });
+  });
+
+  describe('allowed schemes', () => {
+    it('allows http URLs', () => {
+      expect(isSafeHref('http://example.com')).toBe(true);
+    });
+
+    it('allows https URLs', () => {
+      expect(isSafeHref('https://example.com')).toBe(true);
+    });
+
+    it('allows mailto URLs', () => {
+      expect(isSafeHref('mailto:user@example.com')).toBe(true);
+    });
+  });
+
+  describe('blocked schemes', () => {
+    it('blocks javascript:', () => {
+      expect(isSafeHref('javascript:alert(1)')).toBe(false);
+    });
+
+    it('blocks data:', () => {
+      expect(isSafeHref('data:text/html,<script>alert(1)</script>')).toBe(false);
+    });
+
+    it('blocks vbscript:', () => {
+      expect(isSafeHref('vbscript:MsgBox("XSS")')).toBe(false);
+    });
+
+    it('blocks blob:', () => {
+      expect(isSafeHref('blob:https://example.com/uuid')).toBe(false);
+    });
+
+    it('blocks file:', () => {
+      expect(isSafeHref('file:///etc/passwd')).toBe(false);
+    });
+  });
+
+  describe('case-insensitivity and whitespace', () => {
+    it('blocks uppercase JAVASCRIPT:', () => {
+      expect(isSafeHref('JAVASCRIPT:alert(1)')).toBe(false);
+    });
+
+    it('blocks javascript: wrapped in leading/trailing whitespace', () => {
+      expect(isSafeHref('  \tjavascript:alert(1)\n  ')).toBe(false);
+    });
+  });
+
+  describe('empty input', () => {
+    it('rejects the empty string', () => {
+      expect(isSafeHref('')).toBe(false);
+    });
+
+    it('rejects a whitespace-only string', () => {
+      expect(isSafeHref('   \t\n')).toBe(false);
+    });
+  });
+
+  describe('extraSchemes option', () => {
+    it('blocks tel: by default', () => {
+      expect(isSafeHref('tel:+491234')).toBe(false);
+    });
+
+    it('allows tel: when passed via extraSchemes', () => {
+      expect(isSafeHref('tel:+491234', { extraSchemes: ['tel'] })).toBe(true);
+    });
+
+    it('matches extraSchemes case-insensitively', () => {
+      expect(isSafeHref('TEL:+491234', { extraSchemes: ['tel'] })).toBe(true);
+    });
+
+    it('still blocks schemes not in the extra list', () => {
+      expect(isSafeHref('javascript:alert(1)', { extraSchemes: ['tel', 'sms', 'ftp'] })).toBe(
+        false,
+      );
+    });
+
+    it('reproduces the InlineLink allowlist (tel/ftp/sms)', () => {
+      const opts = { extraSchemes: ['tel', 'ftp', 'sms'] };
+      expect(isSafeHref('tel:+491234', opts)).toBe(true);
+      expect(isSafeHref('ftp://host/file', opts)).toBe(true);
+      expect(isSafeHref('sms:+491234', opts)).toBe(true);
+      expect(isSafeHref('data:text/html,x', opts)).toBe(false);
+    });
+  });
+});

--- a/src/utils/isSafeHref.ts
+++ b/src/utils/isSafeHref.ts
@@ -35,12 +35,21 @@ export function isSafeHref(href: string, options?: SafeHrefOptions): boolean {
   const trimmed = href.trim();
   if (trimmed.length === 0) return false;
 
-  const schemeMatch = SCHEME_PATTERN.exec(trimmed);
+  // Browsers strip ASCII tab (U+0009), LF (U+000A) and CR (U+000D) while parsing
+  // a URL's scheme, so `jav\tascript:alert(1)` is executed as `javascript:`.
+  // Normalize the same way before scheme detection — otherwise the embedded
+  // control char breaks the scheme regex, the string looks scheme-less, and a
+  // dangerous URL is reported safe (OWASP XSS filter evasion: embedded
+  // tab/newline/carriage-return).
+  const normalized = trimmed.replace(/[\t\n\r]/g, '');
+  if (normalized.length === 0) return false;
+
+  const schemeMatch = SCHEME_PATTERN.exec(normalized);
   // Relative URLs (no scheme) — /path, #hash, ?query, ./rel, page.html — are safe.
   if (!schemeMatch) return true;
 
   // http/https/mailto are always allowed.
-  if (DEFAULT_SAFE_SCHEME_PATTERN.test(trimmed)) return true;
+  if (DEFAULT_SAFE_SCHEME_PATTERN.test(normalized)) return true;
 
   // Opt-in extra schemes (e.g. tel/sms/ftp) — matched case-insensitively.
   const extraSchemes = options?.extraSchemes;

--- a/src/utils/isSafeHref.ts
+++ b/src/utils/isSafeHref.ts
@@ -4,17 +4,50 @@
  * Allows: http://, https://, mailto:, and relative URLs (no scheme).
  * Blocks: javascript:, data:, vbscript:, file:, and other unsafe schemes.
  *
+ * Unlike `isSafeUrl` (which parses with `new URL()` and therefore rejects
+ * relative URLs), this validator treats scheme-less strings — `/path`,
+ * `#hash`, `?query`, `./rel`, `page.html` — as safe, so it is the correct
+ * guard for anchor hrefs that may be relative routes (Breadcrumb, Nav, Footer,
+ * Header, InlineLink). For absolute external URLs use `isSafeUrl`.
+ *
  * Used to guard `<a href={...}>` against author-supplied URLs (e.g. MDX or
- * JSON content). Returns the input unchanged when safe so callers can pass
- * it directly into href; returns false to signal the link should be dropped.
+ * JSON content). Returns a boolean; callers pass the original href through
+ * when true and render the label without an anchor (or a safe fallback) when
+ * false.
  */
-const SAFE_SCHEME_PATTERN = /^(?:https?:|mailto:)/i;
+export interface SafeHrefOptions {
+  /**
+   * Additional schemes to allow beyond the http/https/mailto default, e.g.
+   * `['tel', 'sms', 'ftp']`. Compared case-insensitively. Everything not in
+   * the default set or this list stays blocked.
+   */
+  extraSchemes?: string[];
+}
 
-export function isSafeHref(href: string): boolean {
+/** Schemes always considered safe, regardless of options. */
+const DEFAULT_SAFE_SCHEME_PATTERN = /^(?:https?:|mailto:)/i;
+
+/** Captures the leading scheme (the part before the first `:`), if any. */
+const SCHEME_PATTERN = /^([a-z][a-z0-9+\-.]*):/i;
+
+export function isSafeHref(href: string, options?: SafeHrefOptions): boolean {
   if (typeof href !== 'string') return false;
   const trimmed = href.trim();
   if (trimmed.length === 0) return false;
-  // Relative URLs (no scheme) are safe.
-  if (!/^[a-z][a-z0-9+\-.]*:/i.test(trimmed)) return true;
-  return SAFE_SCHEME_PATTERN.test(trimmed);
+
+  const schemeMatch = SCHEME_PATTERN.exec(trimmed);
+  // Relative URLs (no scheme) — /path, #hash, ?query, ./rel, page.html — are safe.
+  if (!schemeMatch) return true;
+
+  // http/https/mailto are always allowed.
+  if (DEFAULT_SAFE_SCHEME_PATTERN.test(trimmed)) return true;
+
+  // Opt-in extra schemes (e.g. tel/sms/ftp) — matched case-insensitively.
+  const extraSchemes = options?.extraSchemes;
+  if (extraSchemes && extraSchemes.length > 0) {
+    const scheme = schemeMatch[1].toLowerCase();
+    return extraSchemes.some(allowed => allowed.toLowerCase() === scheme);
+  }
+
+  return false;
 }

--- a/src/utils/isSafeUrl.ts
+++ b/src/utils/isSafeUrl.ts
@@ -2,6 +2,11 @@
  * Validates that a URL uses a safe protocol (http, https, or mailto).
  * Blocks javascript:, data:, vbscript:, blob:, and other dangerous protocols.
  *
+ * Parses with `new URL()`, so this is for **absolute external URLs** and
+ * **rejects relative URLs** (`/path`, `#hash`) — a relative favicon or image
+ * src is a broken resource, and `data:` URLs are the attack surface here. For
+ * anchor hrefs that may be relative routes, use `isSafeHref` instead.
+ *
  * @param url - URL string to validate
  * @returns true if the URL uses an allowed protocol
  */

--- a/todos/001-ready-p1-url-sanitization-utility.md
+++ b/todos/001-ready-p1-url-sanitization-utility.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: complete
 priority: p1
 issue_id: "001"
 tags: [code-review, security, xss, utility]
@@ -41,6 +41,7 @@ Create `src/utils/isSafeUrl.ts` with its own test file. Export from `src/utils/i
 
 | Date | Action | Learnings |
 |------|--------|-----------|
+| 2026-07-11 | Verified `isSafeUrl` + InlineExpand usage shipped; Breadcrumb/Nav/Footer/Header retrofit + sanitizer consolidation landed in `fix/url-safety-consolidation`. `isSafeHref` is now publicly exported and guards all four nav boundaries. | Three sanitizers had drifted (`isSafeUrl` absolute-only, `isSafeHref` relative-allowing, InlineLink's wider allowlist) — see the `isSafeHref`/`isSafeUrl` JSDoc for the division of labor. |
 
 ## Resources
 

--- a/todos/002-ready-p1-sanitize-favicon-urls.md
+++ b/todos/002-ready-p1-sanitize-favicon-urls.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: complete
 priority: p1
 issue_id: "002"
 tags: [code-review, security, xss]
@@ -38,3 +38,4 @@ The plan sanitizes `source.url` but not `source.favicon`, which is rendered into
 
 | Date | Action | Learnings |
 |------|--------|-----------|
+| 2026-07-11 | Verified `isSafeUrl(source.favicon)` guards favicon rendering in InlineExpand; kept deliberately strict (absolute-only, blocks relative + `data:`) rather than switching to `isSafeHref`. | Favicons need absolute-URL semantics (a relative favicon is a broken image; `data:` image URLs were the attack surface) — intentionally NOT unified onto `isSafeHref`. |

--- a/todos/003-ready-p1-span-ul-invalid-html.md
+++ b/todos/003-ready-p1-span-ul-invalid-html.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: complete
 priority: p1
 issue_id: "003"
 tags: [code-review, architecture, accessibility, html-validity]
@@ -42,3 +42,4 @@ Render sources as `<span>` elements with appropriate ARIA roles (`role="list"`, 
 
 | Date | Action | Learnings |
 |------|--------|-----------|
+| 2026-07-11 | Verified InlineExpand renders `span[role=list]` / `span[role=listitem]` (no `<ul>` inside `<span>`); no code change needed. Closed as part of the P1 URL-safety sweep. | Invalid HTML was already fixed in prior work — this pass only confirmed and recorded it. |


### PR DESCRIPTION
## Description

Consolidates the portfolio's three divergent URL sanitizers into a coherent, publicly exported pair, and applies href sanitization at every nav link-rendering boundary that previously rendered raw author-supplied hrefs.

**The gap:** `<Breadcrumb>`, `<Nav>`, `<Footer>`, and `<Header brandHref>` rendered consumer-supplied `href`s verbatim — an `href: 'javascript:…'` (or `data:` / `vbscript:`) in a consumer's nav data became a live `<a href>` (an XSS vector). `isSafeHref` already existed and guarded the TimelineContainer variants, but was **not exported** and **not applied** to the four nav components.

**The fix:**
- **Breadcrumb, Nav (desktop + mobile), Footer** — an unsafe scheme now renders the label as a plain `<span>` (no anchor). Relative/internal routes (`/path`, `#hash`, `?query`) are unaffected. Both the plain-`<a>` and custom `linkComponent`/`LinkTag` branches are guarded.
- **Header `brandHref`** — unsafe falls back to `'/'` (the brand link is structural, so it is never unmounted).
- **`isSafeHref`** gains a backward-compatible `extraSchemes` option (e.g. `tel`/`ftp`/`sms`) and is now **exported** from the public API alongside `isSafeUrl`, with JSDoc documenting the division of labor — `isSafeHref` is relative-allowing (for anchor hrefs), `isSafeUrl` is absolute-only (for image/favicon srcs, deliberately kept strict).
- **`InlineLink`**'s private `sanitizeHref` now delegates to the shared util (with its wider `tel/ftp/sms` allowlist); **behavior unchanged** — its existing tests pass untouched as the oracle.

## Related Issue

No dedicated Linear issue — this executes the open follow-up named in `todos/001` ("Breadcrumb retrofit in separate follow-up PR") and consolidates the sanitizer sprawl that grew since. Marks P1 **todos 001, 002, 003** complete.

Fixes: n/a (see todos 001–003)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's coding style (V.37 React Aria + Tailwind; TypeScript interfaces with JSDoc)
- [x] I have added tests that prove my fix works (new `isSafeHref.test.ts` + per-component unsafe-href + relative-regression tests, incl. custom `linkComponent` branches and Nav desktop + mobile)
- [x] All new and existing tests pass (`npm test -- --ci` → **1453 passed / 68 suites**; zero existing InlineLink/InlineExpand/TimelineContainer tests modified)
- [x] I have updated the documentation if needed (`CHANGELOG.md [Unreleased] → Fixed`; per-component `registry.ts` changelog entries)
- [ ] I have added a changeset — repo uses manual CHANGELOG, no changesets

## Component compliance (for any component change)

- [x] **Reuse** — reuses the existing shared `isSafeHref` util rather than re-implementing per component
- [x] **Tokens** — no colour/spacing changes; no hardcoded values introduced
- [x] **Keyboard** — unchanged; unsafe links become non-interactive spans (correct — a blocked destination should not be a focusable link)
- [x] **Focus** — unchanged
- [x] **ARIA** — `aria-current` still applied on safe links; no prohibited attributes added
- [x] **Reduced motion** — n/a (no animation change)
- [x] **High contrast** — n/a (no glow change)
- [x] **Responsive** — n/a (no layout change)
- [x] **Axe gate** — no new `a11y-known-failures.json` entries; behavior is markup-level

## Verification

```
npx jest src/utils                                   # isSafeHref (new) + isSafeUrl — green
npx jest Breadcrumb Nav Footer Header InlineLink \
         InlineExpand TimelineContainer              # green; no existing tests edited
npm run lint && npm run lint-tokens                  # clean
npm run build                                        # tsc + vite OK; dist types export isSafeHref/SafeHrefOptions
npm test -- --ci                                     # 1453 passed, coverage gate held
grep -rn "javascript:" src/components/{Breadcrumb,Nav,Footer,Header}   # test files only
```

## Additional Notes

- First plan in the **v0.39.0 release train** (Plan 1 of 5); ships to consumers when v0.39.0 is cut.
- `registry.ts` entries use `type: 'changed'` — the `ChangelogEntry` union has no `'fixed'` member. Nav has no standalone registry entry (only `DesktopNav`/`MobileNav` are exported), so its guard is noted under Header's entry rather than fabricating a new metadata entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJFiHsTRxy9n48vaSfmVd2
