### PR TITLE
chore(release): v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.0] - 2026-07-13
+
 ### Added
 - **Connector system — nav-as-course (DMNC-1388 / 1326 / 1325).** The Timeline-OS navigation model lands as reusable primitives:
   - **`Header` `context` prop (DMNC-1326).** An additive, optional second row below brand+nav: a measurable category badge row + an optional "← back" returnTo pill (same-tab via `linkComponent`, or `reuseTab` named-tab reuse via `window.open`). Emits the stable measurement contract `.eidotter-header__context` / `.eidotter-header__categories` / `.eidotter-header__category` + `li[data-category-key]`. Absent/empty `context` ⇒ DOM identical to before. Interactivity lives in an internal `'use client'` leaf so `Header` stays server-safe. New exported `isIconName()` guard renders unknown category icon strings label-only. Category + returnTo hrefs are sanitized via `isSafeHref`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eidotter",
-  "version": "0.38.1",
+  "version": "0.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eidotter",
-      "version": "0.38.1",
+      "version": "0.39.0",
       "license": "CC-BY-NC-4.0",
       "dependencies": {
         "pixelarticons": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eidotter",
-  "version": "0.38.1",
+  "version": "0.39.0",
   "type": "module",
   "description": "A DOS Themed Design System",
   "main": "./dist/index.umd.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,4 +170,4 @@ export type {
 // NOTE: keep in sync with package.json on release — this constant sat at
 // 0.30.0 through eight releases (caught in DMNC-1373); consumers must not
 // trust it as ground truth, `npm view eidotter version` is.
-export const version = '0.38.1';
+export const version = '0.39.0';


### PR DESCRIPTION
Release **v0.39.0**. Bumps `package.json` + the `version` export to 0.39.0 and finalizes the CHANGELOG `[0.39.0]` section.

**Ships:**
- Connector system — nav-as-course: `Header` `context` prop (DMNC-1326), `Mark` (DMNC-1325), `Connector` + `TimelineFeed` + `TimelinePage` (DMNC-1388) — merged in #476.
- Already-merged fixes now getting released: url-safety hardening (#470), provenance nav-bleed (#471).

**Validated:** `npm pack` 0.39.0 tarball smoke-tested in **rizomorf** (Next 15 RSC) — `next build` green, `/smoke-039` server route prerendered using the new RSC per-component subpaths + a client Connector, 0 TypeScript errors project-wide (clean 0.33→0.39 drop-in at the type level).

**On merge:** create GitHub Release `v0.39.0` → `publish.yml` publishes to npm via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJFiHsTRxy9n48vaSfmVd2