### PR TITLE
feat: deterministic Button component contract (code↔Figma differ) (DMNC-1459)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,7 @@ scripts/icons/.cache/
 !src/icons/components/dots-horizontal.tsx
 !src/icons/components/dots-vertical.tsx
 # >>> END CURATED ICONS <<<
+
+# Delegation plan files (local-only, never published — repo is public)
+PLAN-*.md
+IMPLEMENTATION_NOTES.md

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -19,3 +19,11 @@ The whole-section variant of provenance marking, activated by placing `data-ai-b
 ### AIText
 The ergonomic React shortcut for the provenance marker API. Renders a `<span data-provenance="ai-draft">` with a screen-reader-accessible "AI-assisted:" prefix and a default title attribute. Intended for marking a single phrase within otherwise-human prose in hand-authored MDX. For per-paragraph bulk marking, prefer the raw `data-provenance="ai-draft"` attribute directly on the prose element.
 *Avoid:* "AIText component" when referring to the attribute system generally — AIText is one consumer of the attribute API, not the API itself.
+
+---
+
+## Component Contracts
+
+### Component Contract
+A small machine-readable description of a component's variant surface — its variant axes, the legal values on each axis, and their defaults — extracted deterministically from two independent sides: the component's source code, and the design tool's snapshot of the same component. Neither side is the source of truth; both are treated as printouts that a mechanical differ arbitrates. A mismatch is an *error* only when the design side expects a value the code cannot render (the direction that breaks visual fidelity); everything else — extra code-side values such as deprecated aliases, differing defaults, an axis only one side models — is a *warning* for a human to triage. Contracts are regenerated rather than edited, and regeneration with unchanged inputs must produce byte-identical output; judgment (schema design, triaging a reported mismatch) stays with people, while extraction and comparison stay mechanical.
+*Avoid:* "spec" (too broad — overlaps with Storybook stories and Figma specs), "contract test" for the differ itself (the differ compares two contracts; contract tests are the CI wrapper around it).

--- a/figma-snapshots/contracts/Button.contract.json
+++ b/figma-snapshots/contracts/Button.contract.json
@@ -1,0 +1,77 @@
+{
+  "component": "Button",
+  "props": [
+    {
+      "default": "primary",
+      "name": "variant",
+      "required": true,
+      "type": "enum",
+      "values": [
+        "primary",
+        "secondary",
+        "tertiary",
+        "destructive",
+        "ghost",
+        "link"
+      ]
+    },
+    {
+      "default": "xs",
+      "name": "size",
+      "required": true,
+      "type": "enum",
+      "values": [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl"
+      ]
+    },
+    {
+      "default": "idle",
+      "name": "state",
+      "required": true,
+      "type": "enum",
+      "values": [
+        "idle",
+        "hover",
+        "active",
+        "disabled"
+      ]
+    }
+  ],
+  "source": "figma",
+  "variants": {
+    "size": {
+      "default": "xs",
+      "values": [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl"
+      ]
+    },
+    "state": {
+      "default": "idle",
+      "values": [
+        "idle",
+        "hover",
+        "active",
+        "disabled"
+      ]
+    },
+    "variant": {
+      "default": "primary",
+      "values": [
+        "primary",
+        "secondary",
+        "tertiary",
+        "destructive",
+        "ghost",
+        "link"
+      ]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,9 @@
         "tailwindcss": "^4.3.0",
         "tailwindcss-react-aria-components": "^2.0.1",
         "ts-jest": "^29.4.0",
+        "ts-morph": "^28.0.0",
         "ts-node": "^10.9.2",
+        "tsx": "^4.23.1",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.54.0",
         "vite": "^8.0.10"
@@ -4413,9 +4415,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4433,9 +4432,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4453,9 +4449,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4473,9 +4466,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4493,9 +4483,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4513,9 +4500,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5532,9 +5516,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5552,9 +5533,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5572,9 +5550,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5592,9 +5567,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5835,6 +5807,18 @@
       },
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.29.0.tgz",
+      "integrity": "sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^10.0.1",
+        "path-browserify": "^1.0.1",
+        "tinyglobby": "^0.2.14"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -7828,6 +7812,13 @@
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.3",
@@ -14751,6 +14742,13 @@
         "util": "^0.10.3"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -16973,6 +16971,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ts-morph": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-28.0.0.tgz",
+      "integrity": "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.29.0",
+        "code-block-writer": "^13.0.3"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -17047,6 +17056,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,10 @@
     "sync-figma-to-swift": "ts-node scripts/sync-figma-to-swift.ts",
     "fetch-figma-snapshot": "ts-node scripts/fetch-figma-snapshot.ts",
     "publish-figma-library": "ts-node scripts/publish-figma-library.ts",
-    "validate-tokens": "node scripts/validate-tokens.cjs"
+    "validate-tokens": "node scripts/validate-tokens.cjs",
+    "extract-code-contract": "tsx scripts/contracts/extract-code-contract.cli.ts",
+    "extract-figma-contract": "tsx scripts/contracts/extract-figma-contract.cli.ts",
+    "diff-contracts": "tsx scripts/contracts/diff-contracts.cli.ts"
   },
   "repository": {
     "type": "git",
@@ -178,7 +181,9 @@
     "tailwindcss": "^4.3.0",
     "tailwindcss-react-aria-components": "^2.0.1",
     "ts-jest": "^29.4.0",
+    "ts-morph": "^28.0.0",
     "ts-node": "^10.9.2",
+    "tsx": "^4.23.1",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.54.0",
     "vite": "^8.0.10"

--- a/scripts/contracts/diff-contracts.cli.ts
+++ b/scripts/contracts/diff-contracts.cli.ts
@@ -1,0 +1,29 @@
+/**
+ * CLI wrapper for diff-contracts.ts — invoked via `npm run diff-contracts` for
+ * verbose local debug output. See extract-code-contract.cli.ts's header
+ * comment for why this runs via `tsx`.
+ *
+ * Usage: npm run diff-contracts [ComponentName]  (defaults to Button)
+ */
+import { readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { diffContracts } from './diff-contracts';
+import type { ComponentContract } from './schema';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const component = process.argv[2] ?? 'Button';
+
+const code = JSON.parse(
+  readFileSync(resolve(ROOT, `src/components/${component}/${component}.contract.json`), 'utf-8'),
+) as ComponentContract;
+const figma = JSON.parse(
+  readFileSync(resolve(ROOT, `figma-snapshots/contracts/${component}.contract.json`), 'utf-8'),
+) as ComponentContract;
+
+const result = diffContracts(code, figma);
+console.log(`[diff-contracts] ${component}: ${result.pass ? 'PASS' : 'FAIL'}`);
+for (const v of result.violations) {
+  console.log(`  [${v.severity}] ${v.axis}: ${v.message}`);
+}
+if (!result.pass) process.exit(1);

--- a/scripts/contracts/diff-contracts.ts
+++ b/scripts/contracts/diff-contracts.ts
@@ -1,0 +1,114 @@
+/**
+ * diff-contracts — mechanical structural diff between a code contract and a
+ * Figma contract (pilot, DMNC-1459). This is the piece that replaces
+ * figma-audit's hand-built markdown comparison matrix with something that
+ * returns pass/fail — no agent, no judgment call, same input always
+ * produces the same output.
+ *
+ * Severity split (deliberate, to avoid the "rotted contract" trap — a check
+ * too noisy to trust gets ignored, which is worse than no check):
+ *   - error:   within an axis both sides recognize, Figma expects a value
+ *              the code cannot render. This is the one case that actually
+ *              breaks fidelity, so it's the only thing that fails CI.
+ *   - warning: code has MORE than Figma models (e.g. deprecated size
+ *              aliases `small`/`medium`/`large` alongside `sm`/`md`/`lg`),
+ *              a default-value mismatch, or an axis one side models and the
+ *              other doesn't (e.g. Figma's `state` interaction axis has no
+ *              code-side prop — it's expressed via CSS pseudo-classes and
+ *              the `disabled`/`loading` props instead, a legitimate
+ *              platform difference, not a bug — Curtis's "independent over
+ *              platform biased": Figma's model isn't automatically gospel).
+ *
+ * AI's role stops here: this file only reports what's true. A human (or an
+ * agent, per the source article's "authoring vs enforcement" split) decides
+ * what a violation *means* — adopt Figma, fix code, or document the
+ * divergence as intentional.
+ *
+ * Pure logic only — no file I/O, no CLI entrypoint. Imported directly by
+ * Button.contract.test.ts. Run via `npm run diff-contracts` for local debug
+ * output, which invokes the thin `diff-contracts.cli.cts` wrapper instead.
+ */
+
+import type { ComponentContract } from './schema';
+
+export type ViolationSeverity = 'error' | 'warning';
+
+export interface ContractViolation {
+  severity: ViolationSeverity;
+  axis: string;
+  message: string;
+}
+
+export interface DiffResult {
+  pass: boolean;
+  violations: ContractViolation[];
+}
+
+export function diffContracts(code: ComponentContract, figma: ComponentContract): DiffResult {
+  const violations: ContractViolation[] = [];
+  const codeAxes = new Set(Object.keys(code.variants));
+  const figmaAxes = new Set(Object.keys(figma.variants));
+
+  for (const axis of figmaAxes) {
+    const figmaAxisDef = figma.variants[axis];
+
+    if (!codeAxes.has(axis)) {
+      // Warning, not error: an axis Figma models but code doesn't declare as a
+      // variant (e.g. Figma's "state" interaction axis, expressed in code via
+      // CSS pseudo-classes and the disabled/loading props instead of a named
+      // variant prop) is a representational difference, not proof code can't
+      // render it. Whether to formalize it as a code prop or document the gap
+      // is a human judgment call — the differ's job stops at reporting it.
+      violations.push({
+        severity: 'warning',
+        axis,
+        message: `Figma defines variant axis "${axis}" with no code-side variant equivalent — verify code covers it some other way (prop, CSS state, etc).`,
+      });
+      continue;
+    }
+
+    const codeAxisDef = code.variants[axis];
+    const codeValueSet = new Set(codeAxisDef.values);
+    const missing = figmaAxisDef.values.filter((v) => !codeValueSet.has(v));
+    if (missing.length > 0) {
+      violations.push({
+        severity: 'error',
+        axis,
+        message: `Figma "${axis}" expects value(s) [${missing.join(', ')}] the code cannot render.`,
+      });
+    }
+
+    const figmaValueSet = new Set(figmaAxisDef.values);
+    const extra = codeAxisDef.values.filter((v) => !figmaValueSet.has(v));
+    if (extra.length > 0) {
+      violations.push({
+        severity: 'warning',
+        axis,
+        message: `Code "${axis}" defines extra value(s) [${extra.join(', ')}] Figma doesn't model.`,
+      });
+    }
+
+    if (figmaAxisDef.default && codeAxisDef.default && figmaAxisDef.default !== codeAxisDef.default) {
+      violations.push({
+        severity: 'warning',
+        axis,
+        message: `Default mismatch for "${axis}": Figma default is "${figmaAxisDef.default}", code default is "${codeAxisDef.default}".`,
+      });
+    }
+  }
+
+  for (const axis of codeAxes) {
+    if (!figmaAxes.has(axis)) {
+      violations.push({
+        severity: 'warning',
+        axis,
+        message: `Code defines variant axis "${axis}" with no Figma-side equivalent modeled.`,
+      });
+    }
+  }
+
+  return {
+    pass: !violations.some((v) => v.severity === 'error'),
+    violations,
+  };
+}

--- a/scripts/contracts/extract-code-contract.cli.ts
+++ b/scripts/contracts/extract-code-contract.cli.ts
@@ -1,0 +1,25 @@
+/**
+ * CLI wrapper for extract-code-contract.ts — invoked via `npm run extract-code-contract`.
+ *
+ * Run with `tsx`, not `ts-node`: ts-node 10.9.2's ESM loader doesn't resolve
+ * extensionless relative imports under this project's Node version (a known
+ * gap between ts-node's older loader-hook implementation and Node's current
+ * ESM loader API — see the pilot's plan doc, DMNC-1459, for the diagnosis).
+ * tsx is a modern, actively-maintained TS runner built for exactly this case.
+ * Scoped to these new pilot scripts only — the rest of the repo's existing
+ * ts-node usage is untouched.
+ */
+import { writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { extractCodeContract, PILOT_COMPONENTS } from './extract-code-contract';
+import { stableStringify } from './schema';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+for (const config of PILOT_COMPONENTS) {
+  const contract = extractCodeContract(config, ROOT);
+  const outputPath = resolve(ROOT, config.outputPath);
+  writeFileSync(outputPath, stableStringify(contract));
+  console.log(`[extract-code-contract] ${config.component}: ${config.outputPath}`);
+}

--- a/scripts/contracts/extract-code-contract.ts
+++ b/scripts/contracts/extract-code-contract.ts
@@ -1,0 +1,154 @@
+/**
+ * extract-code-contract — deterministic code-side component contract extractor (pilot, DMNC-1459).
+ *
+ * Walks a component's TS source with ts-morph (chosen over react-docgen-typescript,
+ * which has no clean path to reading the `variantClasses`/`sizeClasses` object-literal
+ * variant maps eidotter actually uses — it's built for prop tables, not variant→class
+ * maps) and produces a ComponentContract (scripts/contracts/schema.ts). No AI, no
+ * network — same input always produces the same output (Curtis's "determinism"
+ * principle; see Button.contract.test.ts for the byte-identical regeneration check).
+ *
+ * Pure logic only — no file I/O, no CLI entrypoint. Imported directly by
+ * Button.contract.test.ts. Run via `npm run extract-code-contract`, which
+ * invokes the thin `extract-code-contract.cli.cts` wrapper instead (kept
+ * separate because it needs CommonJS-style `__dirname`/CLI-argv handling
+ * that this ESM-importable module deliberately avoids).
+ */
+
+import { Node, Project, SyntaxKind } from 'ts-morph';
+import { resolve } from 'path';
+import type { ComponentContract, ContractProp, ContractPropType, ContractVariantAxis } from './schema';
+
+export interface ExtractCodeContractConfig {
+  component: string;
+  /** Path to the .tsx source, relative to repo root. */
+  sourcePath: string;
+  /** Path to write the contract JSON, relative to repo root (informational — the CLI wrapper does the writing). */
+  outputPath: string;
+  /** Object-literal variable name → variant axis name it maps to (e.g. variantClasses → variant). */
+  variantMapNames: Record<string, string>;
+}
+
+export const PILOT_COMPONENTS: ExtractCodeContractConfig[] = [
+  {
+    component: 'Button',
+    sourcePath: 'src/components/Button/components/Button.tsx',
+    outputPath: 'src/components/Button/Button.contract.json',
+    variantMapNames: { variantClasses: 'variant', sizeClasses: 'size' },
+  },
+];
+
+function classifyPropType(
+  typeNode: import('ts-morph').TypeNode | undefined,
+): { type: ContractPropType; values?: string[] } | null {
+  if (!typeNode) return null;
+
+  if (Node.isUnionTypeNode(typeNode)) {
+    const values: string[] = [];
+    for (const member of typeNode.getTypeNodes()) {
+      if (!Node.isLiteralTypeNode(member)) return null;
+      const literal = member.getLiteral();
+      if (!Node.isStringLiteral(literal)) return null;
+      values.push(literal.getLiteralValue());
+    }
+    return { type: 'enum', values };
+  }
+  if (typeNode.getKind() === SyntaxKind.BooleanKeyword) return { type: 'boolean' };
+  if (typeNode.getKind() === SyntaxKind.StringKeyword) return { type: 'string' };
+  return null;
+}
+
+function stripQuotes(name: string): string {
+  return name.replace(/^['"]|['"]$/g, '');
+}
+
+/** Reads default values from the component's destructured-props parameter (e.g. inside forwardRef). */
+function extractDestructuredDefaults(project: ReturnType<Project['getSourceFileOrThrow']>): Record<string, string | boolean> {
+  const defaults: Record<string, string | boolean> = {};
+  const objectPatterns = project
+    .getDescendantsOfKind(SyntaxKind.ArrowFunction)
+    .flatMap((fn) => fn.getParameters())
+    .map((param) => param.getNameNode())
+    .filter(Node.isObjectBindingPattern);
+
+  for (const pattern of objectPatterns) {
+    for (const element of pattern.getElements()) {
+      const init = element.getInitializer();
+      if (!init) continue;
+      const name = element.getName();
+      if (Node.isStringLiteral(init)) {
+        defaults[name] = init.getLiteralValue();
+      } else if (init.getKind() === SyntaxKind.TrueKeyword) {
+        defaults[name] = true;
+      } else if (init.getKind() === SyntaxKind.FalseKeyword) {
+        defaults[name] = false;
+      }
+    }
+  }
+  return defaults;
+}
+
+/** Reads a top-level `const NAME: Record<string, string> = {...}` object literal as a plain map. */
+function extractObjectLiteralMap(
+  sourceFile: ReturnType<Project['getSourceFileOrThrow']>,
+  variableName: string,
+): Record<string, string> | null {
+  const decl = sourceFile.getVariableDeclaration(variableName);
+  const init = decl?.getInitializer();
+  if (!init || !Node.isObjectLiteralExpression(init)) return null;
+
+  const map: Record<string, string> = {};
+  for (const prop of init.getProperties()) {
+    if (!Node.isPropertyAssignment(prop)) continue;
+    const valueNode = prop.getInitializer();
+    if (valueNode && Node.isStringLiteral(valueNode)) {
+      map[stripQuotes(prop.getName())] = valueNode.getLiteralValue();
+    }
+  }
+  return map;
+}
+
+/** `root` defaults to `process.cwd()` — both `npm run` and `jest` invoke from the repo root. */
+export function extractCodeContract(config: ExtractCodeContractConfig, root: string = process.cwd()): ComponentContract {
+  const project = new Project({
+    tsConfigFilePath: resolve(root, 'tsconfig.json'),
+    skipAddingFilesFromTsConfig: true,
+  });
+  const sourceFile = project.addSourceFileAtPath(resolve(root, config.sourcePath));
+
+  const propsInterface = sourceFile.getInterface(`${config.component}Props`);
+  const defaults = extractDestructuredDefaults(sourceFile);
+
+  const props: ContractProp[] = [];
+  if (propsInterface) {
+    for (const member of propsInterface.getProperties()) {
+      const classified = classifyPropType(member.getTypeNode());
+      if (!classified) continue; // functions, ReactNode, etc. — not part of the visual contract
+      const name = stripQuotes(member.getName());
+      const prop: ContractProp = {
+        name,
+        type: classified.type,
+        required: !member.hasQuestionToken(),
+      };
+      if (classified.values) prop.values = classified.values;
+      if (name in defaults) prop.default = defaults[name];
+      props.push(prop);
+    }
+  }
+
+  const variants: Record<string, ContractVariantAxis> = {};
+  for (const [mapName, axisName] of Object.entries(config.variantMapNames)) {
+    const classMap = extractObjectLiteralMap(sourceFile, mapName);
+    if (!classMap) continue;
+    const axis: ContractVariantAxis = { values: Object.keys(classMap), classMap };
+    if (axisName in defaults) axis.default = String(defaults[axisName]);
+    variants[axisName] = axis;
+  }
+
+  return {
+    component: config.component,
+    source: 'code',
+    props,
+    variants,
+  };
+}

--- a/scripts/contracts/extract-figma-contract.cli.ts
+++ b/scripts/contracts/extract-figma-contract.cli.ts
@@ -1,0 +1,21 @@
+/**
+ * CLI wrapper for extract-figma-contract.ts — invoked via `npm run extract-figma-contract`.
+ * See extract-code-contract.cli.ts's header comment for why this runs via `tsx`.
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { extractFigmaContract, PILOT_COMPONENTS } from './extract-figma-contract';
+import { stableStringify } from './schema';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const SNAPSHOT_PATH = resolve(ROOT, 'figma-snapshots/web-ds.json');
+
+const snapshot = JSON.parse(readFileSync(SNAPSHOT_PATH, 'utf-8'));
+for (const target of PILOT_COMPONENTS) {
+  const contract = extractFigmaContract(target, snapshot);
+  const outputPath = resolve(ROOT, target.outputPath);
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, stableStringify(contract));
+  console.log(`[extract-figma-contract] ${target.component}: ${target.outputPath}`);
+}

--- a/scripts/contracts/extract-figma-contract.ts
+++ b/scripts/contracts/extract-figma-contract.ts
@@ -1,0 +1,106 @@
+/**
+ * extract-figma-contract — deterministic Figma-side component contract extractor (pilot, DMNC-1459).
+ *
+ * Reads the already-committed `figma-snapshots/web-ds.json` (fetched via Figma's REST
+ * API by `fetch-figma-snapshot.ts` — no MCP bridge, no live agent session needed to run
+ * this) and normalizes a COMPONENT_SET's `componentPropertyDefinitions` into the shared
+ * ComponentContract shape (scripts/contracts/schema.ts).
+ *
+ * `componentPropertyDefinitions` is already an axis-level representation (e.g. Button's
+ * "variant" axis lists its 6 legal options once), not Figma's exploded per-instance
+ * cross-product (Button has 120 child instances = 6 variant × 5 size × 4 state). Reading
+ * the definitions instead of walking children is what keeps this normalized (Curtis's
+ * "favor normalized over redundant" — restating a decision 120 times is the trap this
+ * avoids for free).
+ *
+ * Figma's raw property `type` (VARIANT/BOOLEAN/TEXT/INSTANCE_SWAP) is translated into
+ * the shared, platform-neutral vocabulary rather than passed through raw (Curtis's
+ * "favor independent over platform biased").
+ *
+ * Pure logic only — no file I/O, no CLI entrypoint. Imported directly by
+ * Button.contract.test.ts. Run via `npm run extract-figma-contract`, which
+ * invokes the thin `extract-figma-contract.cli.cts` wrapper instead.
+ */
+
+import type { ComponentContract, ContractProp, ContractPropType, ContractVariantAxis } from './schema';
+
+export interface FigmaComponentPropertyDefinition {
+  type: 'VARIANT' | 'BOOLEAN' | 'TEXT' | 'INSTANCE_SWAP';
+  defaultValue: string | boolean;
+  variantOptions?: string[];
+}
+
+export interface FigmaNode {
+  id: string;
+  name: string;
+  type: string;
+  componentPropertyDefinitions?: Record<string, FigmaComponentPropertyDefinition>;
+  children?: FigmaNode[];
+}
+
+export interface FigmaExtractTarget {
+  component: string;
+  /** Name of the COMPONENT_SET node in the Figma document tree. */
+  figmaNodeName: string;
+  /** Path to write the contract JSON, relative to repo root (informational — the CLI wrapper does the writing). */
+  outputPath: string;
+}
+
+export const PILOT_COMPONENTS: FigmaExtractTarget[] = [
+  {
+    component: 'Button',
+    figmaNodeName: 'Button',
+    outputPath: 'figma-snapshots/contracts/Button.contract.json',
+  },
+];
+
+function findComponentSet(node: FigmaNode | undefined, name: string): FigmaNode | null {
+  if (!node) return null;
+  if (node.type === 'COMPONENT_SET' && node.name === name) return node;
+  for (const child of node.children ?? []) {
+    const found = findComponentSet(child, name);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Translates Figma's raw property type into the shared platform-neutral vocabulary. */
+function toContractPropType(figmaType: FigmaComponentPropertyDefinition['type']): ContractPropType {
+  if (figmaType === 'BOOLEAN') return 'boolean';
+  if (figmaType === 'VARIANT') return 'enum';
+  return 'string'; // TEXT, INSTANCE_SWAP — not visually a class-bearing variant axis
+}
+
+export function extractFigmaContract(target: FigmaExtractTarget, snapshot: unknown): ComponentContract {
+  const document = (snapshot as { document?: FigmaNode }).document;
+  const componentSet = findComponentSet(document, target.figmaNodeName);
+  if (!componentSet) {
+    throw new Error(`[extract-figma-contract] No COMPONENT_SET named "${target.figmaNodeName}" found in snapshot`);
+  }
+
+  const definitions = componentSet.componentPropertyDefinitions ?? {};
+  const props: ContractProp[] = [];
+  const variants: Record<string, ContractVariantAxis> = {};
+
+  for (const [name, def] of Object.entries(definitions)) {
+    const type = toContractPropType(def.type);
+    const prop: ContractProp = { name, type, required: true };
+    if (def.variantOptions) prop.values = def.variantOptions;
+    if (typeof def.defaultValue !== 'undefined') prop.default = def.defaultValue;
+    props.push(prop);
+
+    if (def.type === 'VARIANT' && def.variantOptions) {
+      variants[name] = {
+        values: def.variantOptions,
+        default: String(def.defaultValue),
+      };
+    }
+  }
+
+  return {
+    component: target.component,
+    source: 'figma',
+    props,
+    variants,
+  };
+}

--- a/scripts/contracts/schema.ts
+++ b/scripts/contracts/schema.ts
@@ -1,0 +1,69 @@
+/**
+ * Component contract schema — pilot (DMNC-1459).
+ *
+ * A minimal, well-typed, platform-neutral shape both a code-side extractor
+ * and a Figma-side extractor normalize into, so the two can be diffed
+ * mechanically instead of compared by hand. Scope is deliberately narrow:
+ * this models the "variant" surface (props whose values select a CSS-class
+ * or Figma-VARIANT-property option) — not every prop, not documentation
+ * blocks, not a11y. See plans/2026-07-31 pilot plan for the full rationale.
+ *
+ * Neither side is authoritative — both `extract-code-contract.ts` and
+ * `extract-figma-contract.ts` produce this same shape, and
+ * `diff-contracts.ts` arbitrates between them.
+ */
+
+export type ContractPropType = 'string' | 'boolean' | 'enum';
+
+export interface ContractProp {
+  name: string;
+  type: ContractPropType;
+  values?: string[];
+  default?: string | boolean;
+  required?: boolean;
+}
+
+export interface ContractVariantAxis {
+  /** Legal values for this axis, in source order. */
+  values: string[];
+  default?: string;
+  /**
+   * value → CSS class it maps to. Only the code-side extractor populates
+   * this (Figma has no CSS classes); present here so both sides share one
+   * type instead of forking into code-only/figma-only variants.
+   */
+  classMap?: Record<string, string>;
+}
+
+export interface ComponentContract {
+  component: string;
+  source: 'code' | 'figma';
+  /** Non-variant props, kept for audit context — not diffed (see diff-contracts.ts). */
+  props: ContractProp[];
+  /** Variant axes, keyed by prop/property name — the actual diff target. */
+  variants: Record<string, ContractVariantAxis>;
+}
+
+/**
+ * Deterministic JSON serialization (Curtis's "determinism" principle):
+ * sorted object keys at every level, stable array order (source order is
+ * already stable — arrays are never re-sorted), trailing newline. Two runs
+ * over unchanged source must produce a byte-identical file.
+ */
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(sortKeysDeep(value), null, 2) + '\n';
+}
+
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortKeysDeep);
+  }
+  if (value !== null && typeof value === 'object') {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      sorted[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+  return value;
+}

--- a/solutions/tooling-decisions/ts-node-esm-loader-node24-use-tsx.md
+++ b/solutions/tooling-decisions/ts-node-esm-loader-node24-use-tsx.md
@@ -1,0 +1,63 @@
+---
+title: Run TS scripts with relative imports via tsx — ts-node's ESM loader is broken on Node 24
+date: 2026-08-01
+category: tooling-decisions
+module: scripts
+problem_type: tooling_decision
+component: tooling
+severity: medium
+applies_when:
+  - "Adding an npm script that runs a TypeScript file under scripts/"
+  - "A ts-node script fails with ERR_MODULE_NOT_FOUND on a relative import that clearly exists"
+  - "Choosing between ts-node and tsx as the runner for a new CLI entrypoint"
+symptoms:
+  - "Cannot find module '/.../scripts/contracts/schema' imported from ... (ERR_MODULE_NOT_FOUND)"
+  - "npm run sync-to-figma dies before doing anything (import of '../src/components/registry')"
+root_cause: config_error
+resolution_type: tooling_addition
+tags: [ts-node, tsx, esm, node-24, module-resolution, npm-scripts]
+---
+
+# Run TS scripts with relative imports via tsx — ts-node's ESM loader is broken on Node 24
+
+## Context
+
+Because `package.json` has `"type": "module"`, ts-node 10.9.2 runs scripts through its ESM loader, whose hooks predate Node's current loader API. On this repo's Node (v24), that loader cannot resolve **extensionless relative `.ts` imports** — any script doing `import { x } from './other'` or `from '../src/components/registry'` dies with `ERR_MODULE_NOT_FOUND` before executing a line. Discovered while building the DMNC-1459 contract CLIs; it also explains why `npm run sync-to-figma` had been silently dead.
+
+Scripts that import **only node builtins / npm packages** (no relative TS imports) still work under ts-node — which is why `sync-figma-to-swift.ts` and `fetch-figma-snapshot.ts` never broke, and why the failure looked component-specific when it's actually import-shape-specific.
+
+## Guidance
+
+Any `scripts/**/*.ts` entrypoint that imports another local TS file runs via **tsx**, not ts-node (tsx is a devDep since PR #485):
+
+```json
+"extract-code-contract": "tsx scripts/contracts/extract-code-contract.cli.ts"
+```
+
+Keep shared logic extensionless (`import { x } from './schema'`) so Jest/ts-jest can import the same modules directly in tests. Split CLI wrappers (`*.cli.ts`, run by tsx) from pure logic modules (imported by tests) when a script needs both.
+
+Dead ends — do not retry these (all verified failing here):
+
+- **`.js`-suffixed relative imports** (`from './schema.js'`): fails — there is no emitted JS next to the source.
+- **`.ts`-suffixed imports** (`from './schema.ts'`): works under ts-node's loader but breaks ts-jest with TS5097 (`allowImportingTsExtensions` not enabled) — and enabling that flag ripples into the build tsconfigs.
+- **`.cts` CommonJS wrappers**: TS5095 — CommonJS module kind conflicts with the root tsconfig's `moduleResolution: "bundler"`.
+- **package.json `ts-node` config block** with `"experimentalSpecifierResolution": "node"` + `"esm": true`: silently ignored — the loader-hook mismatch means the option never takes effect on this Node.
+
+## Why This Matters
+
+The failure mode is silent at the repo level: CI never runs the affected scripts, so a dead script (like `sync-to-figma`) can sit broken for months looking like a working npm script. Knowing the rule ("relative TS import ⇒ tsx") turns an hour of loader archaeology into a one-line runner swap.
+
+## When to Apply
+
+- Writing any new `scripts/` entrypoint: default to `tsx` in the npm script.
+- Debugging `ERR_MODULE_NOT_FOUND` from a script whose import path looks correct: check the runner before checking the path.
+- Migrating existing ts-node scripts: only `sync-to-figma.ts` needs the swap for import reasons; `create-component.ts` additionally has a latent `require('readline')` that throws under ESM when reached (see PLAN-adoption-manifest.md, local).
+
+## Examples
+
+Working pattern from `scripts/contracts/` (PR #485): `extract-code-contract.ts` holds pure logic with extensionless imports (imported directly by `Button.contract.test.ts` under Jest); `extract-code-contract.cli.ts` is a thin wrapper doing file I/O, wired as `"extract-code-contract": "tsx scripts/contracts/extract-code-contract.cli.ts"`.
+
+## Related Issues
+
+- PR #485 (DMNC-1459) — introduced tsx + the split-wrapper pattern.
+- DMNC-1195 — will apply the runner swap to `sync-to-figma.ts` and fix `create-component.ts`.

--- a/src/components/Button/Button.contract.json
+++ b/src/components/Button/Button.contract.json
@@ -1,0 +1,125 @@
+{
+  "component": "Button",
+  "props": [
+    {
+      "default": "primary",
+      "name": "variant",
+      "required": false,
+      "type": "enum",
+      "values": [
+        "primary",
+        "secondary",
+        "tertiary",
+        "destructive",
+        "ghost",
+        "link"
+      ]
+    },
+    {
+      "default": "md",
+      "name": "size",
+      "required": false,
+      "type": "enum",
+      "values": [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+        "small",
+        "medium",
+        "large"
+      ]
+    },
+    {
+      "default": "button",
+      "name": "type",
+      "required": false,
+      "type": "enum",
+      "values": [
+        "button",
+        "submit",
+        "reset"
+      ]
+    },
+    {
+      "default": false,
+      "name": "disabled",
+      "required": false,
+      "type": "boolean"
+    },
+    {
+      "default": false,
+      "name": "loading",
+      "required": false,
+      "type": "boolean"
+    },
+    {
+      "name": "className",
+      "required": false,
+      "type": "string"
+    },
+    {
+      "name": "aria-label",
+      "required": false,
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "fullWidth",
+      "required": false,
+      "type": "boolean"
+    },
+    {
+      "default": false,
+      "name": "iconOnly",
+      "required": false,
+      "type": "boolean"
+    }
+  ],
+  "source": "code",
+  "variants": {
+    "size": {
+      "classMap": {
+        "large": "text-dos-text-lg px-4 py-2.5 min-h-10 gap-2",
+        "lg": "text-dos-text-lg px-4 py-2.5 min-h-10 gap-2",
+        "md": "text-dos-text-md px-3 py-2 min-h-8 gap-1.5",
+        "medium": "text-dos-text-md px-3 py-2 min-h-8 gap-1.5",
+        "sm": "text-dos-text-sm px-2.5 py-1 min-h-7 gap-1",
+        "small": "text-dos-text-sm px-2.5 py-1 min-h-7 gap-1",
+        "xl": "text-dos-text-xl px-5 py-3 min-h-11 gap-2",
+        "xs": "text-dos-text-xs px-2 py-1 min-h-6 gap-1"
+      },
+      "default": "md",
+      "values": [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+        "small",
+        "medium",
+        "large"
+      ]
+    },
+    "variant": {
+      "classMap": {
+        "destructive": "eidotter-btn--destructive",
+        "ghost": "eidotter-btn--ghost",
+        "link": "eidotter-btn--link",
+        "primary": "eidotter-btn--primary",
+        "secondary": "eidotter-btn--secondary",
+        "tertiary": "eidotter-btn--tertiary"
+      },
+      "default": "primary",
+      "values": [
+        "primary",
+        "secondary",
+        "tertiary",
+        "destructive",
+        "ghost",
+        "link"
+      ]
+    }
+  }
+}

--- a/src/components/Button/Button.contract.test.ts
+++ b/src/components/Button/Button.contract.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Contract tests for Button's code↔Figma component contract (pilot, DMNC-1459).
+ *
+ * This is the piece that rides the existing `npm test` CI gate in place of a
+ * new workflow step — no new CI YAML. Three properties are asserted:
+ *
+ * 1. Determinism (Curtis): regenerating the code contract twice with nothing
+ *    changed produces byte-identical output.
+ * 2. Freshness: the regenerated code/Figma contracts match the committed
+ *    `*.contract.json` files — catches "Button.tsx changed but nobody ran
+ *    `npm run extract-code-contract`" the same way `tailwind-preset.test.ts`
+ *    catches token-generator drift.
+ * 3. Parity: the committed contracts, diffed, have zero error-level
+ *    violations — this is the actual replacement for figma-audit's
+ *    hand-built markdown comparison matrix.
+ *
+ * The known warning-level findings are pinned so a *new* one is caught the
+ * moment it appears, instead of silently joining the noise.
+ */
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { extractCodeContract } from '../../../scripts/contracts/extract-code-contract';
+import { extractFigmaContract } from '../../../scripts/contracts/extract-figma-contract';
+import { diffContracts } from '../../../scripts/contracts/diff-contracts';
+import { stableStringify, type ComponentContract } from '../../../scripts/contracts/schema';
+
+const ROOT = resolve(__dirname, '../../..');
+
+const CODE_CONTRACT_CONFIG = {
+  component: 'Button',
+  sourcePath: 'src/components/Button/components/Button.tsx',
+  outputPath: 'src/components/Button/Button.contract.json',
+  variantMapNames: { variantClasses: 'variant', sizeClasses: 'size' },
+};
+
+const FIGMA_TARGET = {
+  component: 'Button',
+  figmaNodeName: 'Button',
+  outputPath: 'figma-snapshots/contracts/Button.contract.json',
+};
+
+function readJson(relativePath: string): unknown {
+  return JSON.parse(readFileSync(resolve(ROOT, relativePath), 'utf-8'));
+}
+
+function readText(relativePath: string): string {
+  return readFileSync(resolve(ROOT, relativePath), 'utf-8');
+}
+
+describe('Button code contract — determinism and freshness', () => {
+  it('regenerating twice with nothing changed produces byte-identical output', () => {
+    const first = stableStringify(extractCodeContract(CODE_CONTRACT_CONFIG));
+    const second = stableStringify(extractCodeContract(CODE_CONTRACT_CONFIG));
+    expect(second).toBe(first);
+  });
+
+  it('matches the committed Button.contract.json (run `npm run extract-code-contract` if this fails)', () => {
+    const regenerated = stableStringify(extractCodeContract(CODE_CONTRACT_CONFIG));
+    expect(regenerated).toBe(readText(CODE_CONTRACT_CONFIG.outputPath));
+  });
+});
+
+describe('Button Figma contract — freshness against the committed snapshot', () => {
+  it('matches the committed figma-snapshots/contracts/Button.contract.json (run `npm run extract-figma-contract` if this fails)', () => {
+    const snapshot = readJson('figma-snapshots/web-ds.json');
+    const regenerated = stableStringify(extractFigmaContract(FIGMA_TARGET, snapshot));
+    expect(regenerated).toBe(readText(FIGMA_TARGET.outputPath));
+  });
+});
+
+describe('Button contract diff — code↔Figma parity', () => {
+  const code = () => readJson(CODE_CONTRACT_CONFIG.outputPath) as ComponentContract;
+  const figma = () => readJson(FIGMA_TARGET.outputPath) as ComponentContract;
+
+  it('has zero error-level violations', () => {
+    const result = diffContracts(code(), figma());
+    if (!result.pass) {
+      const errors = result.violations
+        .filter((v) => v.severity === 'error')
+        .map((v) => `  [${v.axis}] ${v.message}`)
+        .join('\n');
+      throw new Error(`Button code↔Figma contract drift:\n${errors}`);
+    }
+    expect(result.pass).toBe(true);
+  });
+
+  // Pins the current, reviewed warnings so a *new* one fails the build
+  // instead of blending into the noise (the "rotted contract" trap).
+  it('has exactly the known, accepted warnings', () => {
+    const result = diffContracts(code(), figma());
+    const warnings = result.violations
+      .filter((v) => v.severity === 'warning')
+      .map((v) => `${v.axis}: ${v.message}`)
+      .sort();
+
+    expect(warnings).toEqual(
+      [
+        'size: Code "size" defines extra value(s) [small, medium, large] Figma doesn\'t model.',
+        'size: Default mismatch for "size": Figma default is "xs", code default is "md".',
+        'state: Figma defines variant axis "state" with no code-side variant equivalent — verify code covers it some other way (prop, CSS state, etc).',
+      ].sort(),
+    );
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,5 +7,5 @@
     "outDir": "./dist"
   },
   "include": ["src"],
-  "exclude": ["**/*.test.tsx", "**/*.stories.tsx", "src/stories", "src/icons"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.stories.tsx", "src/stories", "src/icons"]
 }


### PR DESCRIPTION
## Description

Pilot applying the "authoring vs enforcement" pattern from two articles ([TJ Pitre, southleft.substack.com](https://southleft.substack.com/p/use-ai-to-need-less-ai), [Nathan Curtis, nathanacurtis.substack.com](https://nathanacurtis.substack.com/p/component-contracts-and-schemas)) to eidotter: judgment-heavy work (authoring) happens once, recurring verification is handed to deterministic machinery instead of being re-derived by an agent every run.

**Gap this closes:** `.claude/skills/figma-audit/SKILL.md` is fully agentic and re-derived every invocation — live MCP query, hand-built markdown comparison matrix, judgment call, no automated diff. This adds a scripted alternative for one component (Button): a small JSON contract extracted deterministically from both sides, diffed mechanically.

**What's new:**
- `scripts/contracts/schema.ts` — minimal, well-typed contract schema + deterministic `stableStringify` (sorted keys, stable output)
- `extract-code-contract.ts` — ts-morph walk of `Button.tsx`'s prop types and `variantClasses`/`sizeClasses` maps → `src/components/Button/Button.contract.json`
- `extract-figma-contract.ts` — reads the already-committed `figma-snapshots/web-ds.json` (REST-sourced, no live MCP needed), normalizes Button's `componentPropertyDefinitions` (already axis-level — 6 variant × 5 size options, not the 120-instance cross-product) → `figma-snapshots/contracts/Button.contract.json`
- `diff-contracts.ts` — structural differ. `error` only when code truly cannot render a Figma-mandated value (the one thing that actually breaks fidelity); `warning` for everything else (deprecated size aliases, Figma/code default mismatches, an axis one side models and the other doesn't — e.g. Figma's `state` interaction axis has no code-side prop, expressed instead via CSS pseudo-classes + `disabled`/`loading`)
- `Button.contract.test.ts` — determinism (regenerate twice → byte-identical), freshness (regenerated contract matches committed JSON), and parity (zero error-level violations) checks. Rides the existing `npm test` CI gate — **no new workflow YAML**.

**Scope, deliberately narrow:** Button only, not a rollout to all 48 components. No documentation-schema buildout, no push-to-Figma, no live MCP in CI, no `registry.ts` auto-generation.

**Incidental fixes found along the way:**
- `tsx` added as a devDep to run the new CLI scripts — `ts-node` 10.9.2's ESM loader doesn't resolve extensionless relative imports under this repo's Node version (pre-existing gap that also silently breaks `sync-to-figma.ts`; left that alone, out of scope here).
- One-line `tsconfig.build.json` fix — `**/*.test.ts` was missing from `exclude` (only `**/*.test.tsx` was there). Latent gap; this pilot's test is the first `.test.ts` file to import outside `src/`, which is what surfaced it.

## Related Issue

DMNC-1459

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have added tests that prove my fix/feature works (`Button.contract.test.ts`, plus a manual drift injection verified the differ fails legibly)
- [x] All new and existing tests pass (`npm run test` — 75 suites / 1550 tests)
- [ ] Documentation — not updated; this is an internal tooling pilot, not a public API change. Worth a CLAUDE.md mention if/when a second component proves the pattern generalizes.
- [ ] Changeset — no public API change, skipped.

## Component compliance

N/A — no component UI/visual code changed. Button's actual rendering, props, and behavior are untouched; only new tooling that reads it.

## Additional Notes

Full analysis and pilot design: `/home/dmnc/.claude/plans/check-this-article-https-southleft-subst-cuddly-creek.md` (local plan doc, not committed). Verified locally:
- Real diff against committed Figma snapshot: PASS with 3 reviewed warnings
- Determinism: both extractors regenerate byte-identical output twice in a row
- Manual drift test: removed a variant class from `Button.tsx`, confirmed `[error]`-level failure with exit 1, reverted
- `npm run lint`, `npm run lint-tokens`, `node scripts/sync-client-directives.mjs --check`, `npm run build`, `node scripts/assert-rsc-safety.mjs`, full `npm test` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnSQi2U68pS2XFfTsnLfpy